### PR TITLE
Tchap login, first version

### DIFF
--- a/config.sample.json
+++ b/config.sample.json
@@ -11,7 +11,7 @@
     "disable_custom_urls": false,
     "disable_guests": false,
     "disable_login_language_selector": false,
-    "disable_3pid_login": false,
+    "disable_3pid_login": true,
     "brand": "Element",
     "integrations_ui_url": "https://scalar.vector.im/",
     "integrations_rest_url": "https://scalar.vector.im/api",

--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -11,51 +11,8 @@ const loaderUtils = require("loader-utils");
 // This could readily be automated, but it's nice to explicitly
 // control when new languages are available.
 const INCLUDE_LANGS = [
-    {'value': 'bg', 'label': 'Български'},
-    {'value': 'ca', 'label': 'Català'},
-    {'value': 'cs', 'label': 'čeština'},
-    {'value': 'da', 'label': 'Dansk'},
-    {'value': 'de_DE', 'label': 'Deutsch'},
-    {'value': 'el', 'label': 'Ελληνικά'},
     {'value': 'en_EN', 'label': 'English'},
-    {'value': 'en_US', 'label': 'English (US)'},
-    {'value': 'eo', 'label': 'Esperanto'},
-    {'value': 'es', 'label': 'Español'},
-    {'value': 'et', 'label': 'Eesti'},
-    {'value': 'eu', 'label': 'Euskara'},
-    {'value': 'fi', 'label': 'Suomi'},
-    {'value': 'fr', 'label': 'Français'},
-    {'value': 'gl', 'label': 'Galego'},
-    {'value': 'he', 'label': 'עברית'},
-    {'value': 'hi', 'label': 'हिन्दी'},
-    {'value': 'hu', 'label': 'Magyar'},
-    {'value': 'id', 'label': 'Bahasa Indonesia'},
-    {'value': 'is', 'label': 'íslenska'},
-    {'value': 'it', 'label': 'Italiano'},
-    {'value': 'ja', 'label': '日本語'},
-    {'value': 'kab', 'label': 'Taqbaylit'},
-    {'value': 'ko', 'label': '한국어'},
-    {'value': 'lt', 'label': 'Lietuvių'},
-    {'value': 'lv', 'label': 'Latviešu'},
-    {'value': 'nb_NO', 'label': 'Norwegian Bokmål'},
-    {'value': 'nl', 'label': 'Nederlands'},
-    {'value': 'nn', 'label': 'Norsk Nynorsk'},
-    {'value': 'pl', 'label': 'Polski'},
-    {'value': 'pt', 'label': 'Português'},
-    {'value': 'pt_BR', 'label': 'Português do Brasil'},
-    {'value': 'ru', 'label': 'Русский'},
-    {'value': 'sk', 'label': 'Slovenčina'},
-    {'value': 'sq', 'label': 'Shqip'},
-    {'value': 'sr', 'label': 'српски'},
-    {'value': 'sv', 'label': 'Svenska'},
-    {'value': 'te', 'label': 'తెలుగు'},
-    {'value': 'th', 'label': 'ไทย'},
-    {'value': 'tr', 'label': 'Türkçe'},
-    {'value': 'uk', 'label': 'українська мова'},
-    {'value': 'vi', 'label': 'Tiếng Việt'},
-    {'value': 'vls', 'label': 'West-Vlaams'},
-    {'value': 'zh_Hans', 'label': '简体中文'}, // simplified chinese
-    {'value': 'zh_Hant', 'label': '繁體中文'}, // traditional chinese
+    {'value': 'fr', 'label': 'Français'}
 ];
 
 // cpx includes globbed parts of the filename in the destination, but excludes

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -29,5 +29,7 @@
     "Decentralised, encrypted chat &amp; collaboration powered by [matrix]": "Decentralised, encrypted chat &amp; collaboration powered by [matrix]",
     "Sign In": "Sign In",
     "Create Account": "Create Account",
-    "Explore rooms": "Explore rooms"
+    "Explore rooms": "Explore rooms",
+    "Username": "Email",
+    "Username_comments": "We use Email to login in Tchap. The Login code accepts both username and email. So the simplest change for us to force login by email is to just rename the Username field to Email."
 }

--- a/src/i18n/strings/fr.json
+++ b/src/i18n/strings/fr.json
@@ -3,7 +3,7 @@
     "powered by Matrix": "propulsé par Matrix",
     "Unknown device": "Appareil inconnu",
     "You need to be using HTTPS to place a screen-sharing call.": "Vous devez utiliser HTTPS pour effectuer un appel avec partage d’écran.",
-    "Welcome to Element": "Bienvenue sur Element",
+    "Welcome to Element": "Bienvenue sur Element AAAAA",
     "Decentralised, encrypted chat &amp; collaboration powered by [matrix]": "Messagerie et collaboration décentralisées et chiffrées, propulsées par [matrix]",
     "Sign In": "Se connecter",
     "Create Account": "Créer un compte",
@@ -36,5 +36,7 @@
     "Use %(brand)s on mobile": "Utiliser %(brand)s sur téléphone",
     "Switch to space by number": "Afficher un espace par son numéro",
     "Next recently visited room or community": "Prochain salon ou communauté récemment visité",
-    "Previous recently visited room or community": "Salon ou communauté précédemment visité"
+    "Previous recently visited room or community": "Salon ou communauté précédemment visité",
+    "Username": "E-mail",
+    "Username_comments": "We use E-mail to login in Tchap. The Login code accepts both username and email. So the simplest change for us to force login by email is to just rename the Username field to Email."
 }

--- a/src/i18n/strings/fr.json
+++ b/src/i18n/strings/fr.json
@@ -3,7 +3,7 @@
     "powered by Matrix": "propulsé par Matrix",
     "Unknown device": "Appareil inconnu",
     "You need to be using HTTPS to place a screen-sharing call.": "Vous devez utiliser HTTPS pour effectuer un appel avec partage d’écran.",
-    "Welcome to Element": "Bienvenue sur Element AAAAA",
+    "Welcome to Element": "Bienvenue sur Element",
     "Decentralised, encrypted chat &amp; collaboration powered by [matrix]": "Messagerie et collaboration décentralisées et chiffrées, propulsées par [matrix]",
     "Sign In": "Se connecter",
     "Create Account": "Créer un compte",


### PR DESCRIPTION
https://github.com/tchapgouv/matrix-react-sdk-v4/issues/11

Login by email only.

We reuse the standard login, which is smart enough to detect if the user enters an email or a matrixid (by [checking for "@" and setting login type to `m.id.thirdparty`](https://github.com/matrix-org/matrix-react-sdk/blob/2802d39bc9da8454f54fb44e65558727938e3e72/src/Login.ts#L150)), and we change the label to "email" for the users to understand. 

This PR removes all languages except french and english, to guarantee that "Username" is properly translated to "Email" for Tchap.

Out of scope : 
 - Choosing the homeserver 
 - registration (new accounts)

French :
![image](https://user-images.githubusercontent.com/911434/159489347-8b4c83f5-4569-4a5e-a72a-eb2f73985b74.png)

English : 
![image](https://user-images.githubusercontent.com/911434/159489497-647dd145-21cf-4524-88e9-25968aee79ba.png)



<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes: 

Changelog entries will also appear in element-desktop. For PRs that *only* affect the desktop version:
Notes: none
element-desktop notes: <notes>
-->


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->