### PR TITLE
Scalingo builds, without building SDKs

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,0 +1,2 @@
+https://github.com/Scalingo/nodejs-buildpack.git
+https://github.com/Scalingo/nginx-buildpack.git

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -1,0 +1,78 @@
+{
+    "default_server_config": {
+        "m.homeserver": {
+            "base_url": "https://matrix.i.tchap.gouv.fr",
+            "server_name": "Internes - Preprod"
+        },
+        "m.identity_server": {
+            "base_url": "https://matrix.i.tchap.gouv.fr"
+        }
+    },
+    "homeserver_list": [
+        {
+            "base_url": "https://matrix.i.tchap.gouv.fr",
+            "server_name": "Internes - preprod",
+            "email_examples": "hakim@beta.gouv.fr, alice@interieur.gouv.fr, ..."
+        },
+        {
+            "base_url": "https://matrix.e.tchap.gouv.fr",
+            "server_name": "Externes - preprod",
+            "email_examples": "nina@soprasteria.com, paul@athos.fr, ..."
+        }
+    ],
+    "disable_custom_urls": false,
+    "disable_guests": true,
+    "disable_login_language_selector": false,
+    "disable_3pid_login": true,
+    "brand": "Tchap",
+    "integrations_ui_url": "https://scalar.vector.im/",
+    "integrations_rest_url": "https://scalar.vector.im/api",
+    "integrations_widgets_urls": [
+        "https://scalar.vector.im/_matrix/integrations/v1",
+        "https://scalar.vector.im/api",
+        "https://scalar-staging.vector.im/_matrix/integrations/v1",
+        "https://scalar-staging.vector.im/api",
+        "https://scalar-staging.riot.im/scalar/api"
+    ],
+    "bug_report_endpoint_url": "https://element.io/bugreports/submit",
+    "uisi_autorageshake_app": "element-auto-uisi",
+    "defaultCountryCode": "FR",
+    "showLabsSettings": false,
+    "features": { },
+    "default_federate": true,
+    "default_theme": "custom-Tchap",
+    "roomDirectory": {
+        "servers": [
+            "i.tchap.gouv.fr"
+        ]
+    },
+    "enable_presence_by_hs_url": {
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
+    },
+    "settingDefaults": {
+        "breadcrumbs": true,
+        "UIFeature.voip": false,
+        "UIFeature.shareSocial": false,
+        "custom_themes": [
+            {
+                "name": "Tchap",
+                "is_dark": false,
+                "colors": {
+                    "accent": "#162d58"
+                }
+            }
+        ]
+    },
+    "branding": {
+        "authHeaderLogoUrl": "themes/tchap/img/logos/tchap-logo.svg",
+        "authFooterLinks": []
+    },
+    "jitsi": {
+        "preferredDomain": "meet.element.io"
+    },
+    "desktopBuilds": {
+        "available": false
+    },
+    "map_style_url": "https://api.maptiler.com/maps/streets/style.json?key=fU3vlMsMn4Jb6dnEIFsx"
+}

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -1,0 +1,6 @@
+   
+root /app/dist;
+
+location / {
+   index index.html;
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "build:bundle": "webpack --progress --bail --mode production",
     "build:bundle-stats": "webpack --progress --bail --mode production --json > webpack-stats.json",
     "dist": "scripts/package.sh",
+    "scalingo-postbuild": "scripts/package-scalingo-prod.sh",
     "start": "concurrently --kill-others-on-fail --prefix \"{time} [{name}]\" -n reskindex,reskindex-react,res,element-js \"yarn reskindex:watch\" \"yarn reskindex:watch-react\" \"yarn start:res\" \"yarn start:js\"",
     "start:https": "concurrently --kill-others-on-fail --prefix \"{time} [{name}]\" -n reskindex,reskindex-react,res,element-js \"yarn reskindex:watch\" \"yarn reskindex:watch-react\" \"yarn start:res\" \"yarn start:js --https\"",
     "start:res": "yarn build:jitsi && node scripts/copy-res.js -w",

--- a/scripts/package-scalingo-prod.sh
+++ b/scripts/package-scalingo-prod.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Tchap: File copied from scripts/package.json.
+
+set -e
+
+version=`node -e 'console.log(require("./package.json").version)'`
+today=$(date +%Y%m%d)
+
+if [[ -n "$CONFIG" ]]; then
+  echo "CONFIG=$CONFIG"
+  cp "config.$CONFIG.json" config.json
+  echo "Using config.$CONFIG.json"
+else
+  echo "No config specified, using config.json."
+fi
+
+yarn clean
+yarn build
+
+mkdir -p dist
+cp -r webapp tchap-$version
+
+# if $version looks like semver with leading v, strip it before writing to file
+if [[ ${version} =~ ^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+(-.+)?$ ]]; then
+    echo ${version:1} > tchap-$version/version
+else
+    echo ${version} > tchap-$version/version
+fi
+
+# Copy the files in /dist, ready to be served.
+cp -r tchap-$version/* dist/
+# Also make a tar file. Useful for releases.
+tar chvzf tchap-$version-$CONFIG-$today.tar.gz dist
+rm -r tchap-$version
+
+echo
+echo "Packaged tchap-$version-$CONFIG"


### PR DESCRIPTION
Copy the same builds as v2, except we can now use the standard `build` command from package.json.

This build uses matrix-react-sdk and matrix-js-sdk packaged versions, that you get from npm, so it doesn't build them. It probably won't work if you specify versions from github branches, because they are not packaged (you would need to build them before using them, like we did in v2)


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->