### PR TITLE
Custom translations bug - PR for demonstrating the bug

### DIFF
--- a/scripts/copy-res.js
+++ b/scripts/copy-res.js
@@ -12,6 +12,7 @@ const loaderUtils = require("loader-utils");
 // control when new languages are available.
 const INCLUDE_LANGS = [
     {'value': 'en_EN', 'label': 'English'},
+    {'value': 'en_US', 'label': 'English (US)'},
     {'value': 'fr', 'label': 'Français'}
 ];
 

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -7,7 +7,9 @@
     "comments": "We use E-mail to login in Tchap. The Login code accepts both username and email. So the simplest change for us to force login by email is to just rename the Username field to Email."
   },
   "Welcome to Tchap": {
-    "en_EN": "Welcome to Tchap",
+    "en_EN": "Welcome to Tchap EN",
+    "en_US": "Welcome to Tchap US",
+    "en": "Welcome to Tchap no country",
     "fr": "Bienvenue sur Tchap"
   },
   "Examples:": {


### PR DESCRIPTION
Context : The "custom_translations_url" config var enables to specify a translation file that overwrites the translations in element.

Bug : For the languages "en_EN" and "en_US", the translations in the file are ignored, and the one for "en" is used instead. 

Example in this PR : the translation file contains : 
```
  "Welcome to Tchap": {
    "en_EN": "Welcome to Tchap EN",
    "en_US": "Welcome to Tchap US",
    "en": "Welcome to Tchap no country",
    "fr": "Bienvenue sur Tchap"
  },
```

Expected "Welcome to Tchap EN"
Obtained : 
![image](https://user-images.githubusercontent.com/911434/160377271-de103342-373a-485a-b79a-d30103aa77c2.png)

Expected "Welcome to Tchap US"
Obtained :
![image](https://user-images.githubusercontent.com/911434/160377211-c768de1a-31de-4bfc-b46c-e0dcd5e0ae72.png)

A review app is generated for this PR : https://tchap-web-staging-pr21.osc-secnum-fr1.scalingo.io/

(this is not blocking for us as we only use one type of english, so we can use the key "en" without problem)