### PR TITLE
Label new issues with web label

### DIFF
--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -1,0 +1,20 @@
+# Change the label name in the job if needed.
+# If the label is already present, this job runs successfully and does nothing.
+name: Label new issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['web']
+            })


### PR DESCRIPTION
Action to label all new issues with the "web" label.
Tested in https://github.com/tchapgouv/action-test/blob/main/.github/workflows/label-new-issues.yml