### PR TITLE
Update forgotten fields in preprod config

### DIFF
--- a/config.preprod.json
+++ b/config.preprod.json
@@ -38,7 +38,9 @@
     "uisi_autorageshake_app": "element-auto-uisi",
     "defaultCountryCode": "FR",
     "showLabsSettings": false,
-    "features": { },
+    "features": {
+        "feature_thread": true
+    },
     "default_federate": true,
     "default_theme": "custom-Tchap",
     "roomDirectory": {
@@ -55,6 +57,7 @@
         "breadcrumbs": true,
         "UIFeature.voip": false,
         "UIFeature.shareSocial": false,
+        "UIFeature.registration": false,
         "layout": "bubble",
         "custom_themes": [
             {


### PR DESCRIPTION
We made changes in prod config that we forgot to add in preprod config.

For the future, to avoid this situation, it would be best to extract the common fields in the same file, and just apply the changes for each env. https://github.com/tchapgouv/tchap-web-v4/issues/44