### PR TITLE
Fix space-panel color to be different from the button color, to be able to see the space buttons

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -76,7 +76,7 @@
                     "private-color": "#eb5757",
                     "external-color": "#f07a12",
                     "forum-color": "#27ae60",
-                    "sidebar-color": "#27303a",
+                    "sidebar-color": "#c0d8ef",
                     "roomlist-background-color": "#f3f8fd",
                     "roomlist-text-color": "#2e2f32",
                     "roomlist-text-secondary-color": "#61708b",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -70,7 +70,7 @@
                     "private-color": "#eb5757",
                     "external-color": "#f07a12",
                     "forum-color": "#27ae60",
-                    "sidebar-color": "#27303a",
+                    "sidebar-color": "#c0d8ef",
                     "roomlist-background-color": "#f3f8fd",
                     "roomlist-text-color": "#2e2f32",
                     "roomlist-text-secondary-color": "#61708b",

--- a/config.prod.json
+++ b/config.prod.json
@@ -154,7 +154,7 @@
                     "private-color": "#eb5757",
                     "external-color": "#f07a12",
                     "forum-color": "#27ae60",
-                    "sidebar-color": "#27303a",
+                    "sidebar-color": "#c0d8ef",
                     "roomlist-background-color": "#f3f8fd",
                     "roomlist-text-color": "#2e2f32",
                     "roomlist-text-secondary-color": "#61708b",

--- a/config.sample.json
+++ b/config.sample.json
@@ -62,7 +62,7 @@
                     "accent": "#162d58",
                     "primary-color": "#368bd6",
                     "warning-color": "#ff4b55",
-                    "sidebar-color": "#27303a",
+                    "sidebar-color": "#c0d8ef",
                     "roomlist-background-color": "#f3f8fd",
                     "roomlist-text-color": "#2e2f32",
                     "roomlist-text-secondary-color": "#61708b",


### PR DESCRIPTION
Before : can't see the buttons to add a space or view a sub space : 
![Screen Shot 2022-06-27 at 15 50 29](https://user-images.githubusercontent.com/911434/175957838-53e8dd34-6b4c-4349-b176-792db1e8ca8c.png)


After : see the buttons !
![Screen Shot 2022-06-27 at 15 50 20](https://user-images.githubusercontent.com/911434/175957855-d0be07ea-7cac-4bf1-af19-e9f33df4eff6.png)

