### PR TITLE
Fix/disable spaces, 2nd try

### DIFF
--- a/customisations.json
+++ b/customisations.json
@@ -2,5 +2,6 @@
   "src/@types/tchap.ts": "src/@types/tchap.ts",
   "src/components/views/dialogs/CreateRoomDialog.tsx": "src/components/views/dialogs/TchapCreateRoomDialog.tsx",
   "src/components/views/elements/TchapRoomTypeSelector.tsx": "src/components/views/elements/TchapRoomTypeSelector.tsx",
-  "src/components/views/dialogs/ServerPickerDialog.tsx": "src/components/views/dialogs/TchapServerPickerDialog.tsx"
+  "src/components/views/dialogs/ServerPickerDialog.tsx": "src/components/views/dialogs/TchapServerPickerDialog.tsx",
+  "src/customisations/ComponentVisibility.ts": "src/customisations/TchapComponentVisibility.ts"
 }

--- a/src/customisations/TchapComponentVisibility.ts
+++ b/src/customisations/TchapComponentVisibility.ts
@@ -4,7 +4,6 @@ Copyright 2022 - DINUM - MIT license
 File copied from ComponentVisibility.ts in matrix-react-sdk v3.46.0
 */
 
-
 // Dev note: this customisation point is heavily inspired by UIFeature flags, though
 // with an intention of being used for more complex switching on whether or not a feature
 // should be shown.
@@ -42,5 +41,5 @@ export interface IComponentVisibilityCustomisations {
 export const ComponentVisibilityCustomisations: IComponentVisibilityCustomisations = {
     // while we don't specify the functions here, their defaults are described
     // in their pseudo-implementations above.
-    shouldShowComponent
+    shouldShowComponent,
 };

--- a/src/customisations/TchapComponentVisibility.ts
+++ b/src/customisations/TchapComponentVisibility.ts
@@ -1,0 +1,46 @@
+/*
+Copyright 2022 - DINUM - MIT license
+
+File copied from ComponentVisibility.ts in matrix-react-sdk v3.46.0
+*/
+
+
+// Dev note: this customisation point is heavily inspired by UIFeature flags, though
+// with an intention of being used for more complex switching on whether or not a feature
+// should be shown.
+
+// Populate this class with the details of your customisations when copying it.
+
+import { UIComponent } from "matrix-react-sdk/src/settings/UIFeature";
+
+/**
+ * Determines whether or not the active MatrixClient user should be able to use
+ * the given UI component. If shown, the user might still not be able to use the
+ * component depending on their contextual permissions. For example, invite options
+ * might be shown to the user but they won't have permission to invite users to
+ * the current room: the button will appear disabled.
+ * @param {UIComponent} component The component to check visibility for.
+ * @returns {boolean} True (default) if the user is able to see the component, false
+ * otherwise.
+ */
+function shouldShowComponent(component: UIComponent): boolean {
+    if (component === UIComponent.CreateSpaces) {
+        return false;
+    }
+    return true; // default to visible
+}
+
+// This interface summarises all available customisation points and also marks
+// them all as optional. This allows customisers to only define and export the
+// customisations they need while still maintaining type safety.
+export interface IComponentVisibilityCustomisations {
+    shouldShowComponent?: typeof shouldShowComponent;
+}
+
+// A real customisation module will define and export one or more of the
+// customisation points that make up the interface above.
+export const ComponentVisibilityCustomisations: IComponentVisibilityCustomisations = {
+    // while we don't specify the functions here, their defaults are described
+    // in their pseudo-implementations above.
+    shouldShowComponent
+};


### PR DESCRIPTION
Hides the "+" button to create spaces in the sidebar:
Before :
![image](https://user-images.githubusercontent.com/911434/176676894-f7daaacd-a25c-4dd0-89bd-5d4b222397f0.png)
After :
![image](https://user-images.githubusercontent.com/911434/176677429-f10a19b0-5ee7-4cb2-aa84-739ae7696994.png)

Hides one of the buttons for creating sub-spaces : 
Before : 
![image](https://user-images.githubusercontent.com/911434/176678154-f5c4e559-eed9-4665-b6fd-f6b89314ceb9.png)
After : 
![image](https://user-images.githubusercontent.com/911434/176678282-c35fff4c-d561-4e79-9d0b-d3ed12f0b5a8.png)

But doesn't hide the second button for creating sub-spaces : when the space is open, in the space's sidebar, the button is still there.
(This is an element-web problem, will make a PR against element-web to suggest a fix)
![Screen Shot 2022-06-30 at 14 36 05](https://user-images.githubusercontent.com/911434/176678585-7b240e00-e40a-4e03-b87c-9a7784269d5a.png)



<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->