### PR TITLE
Set VERSION in scalingo builds

### DIFF
--- a/scripts/package-scalingo-prod.sh
+++ b/scripts/package-scalingo-prod.sh
@@ -7,6 +7,9 @@ set -e
 version=`node -e 'console.log(require("./package.json").version)'`
 today=$(date +%Y%m%d)
 
+export VERSION=$version
+echo "VERSION is set to $VERSION"
+
 if [[ -n "$CONFIG" ]]; then
   echo "CONFIG=$CONFIG"
   cp "config.$CONFIG.json" config.json
@@ -36,6 +39,3 @@ rm -r tchap-$version
 
 echo
 echo "Packaged tchap-$version-$CONFIG"
-
-scalingo --app $APP env-set VERSION=$version
-echo "VERSION is set to $VERSION"

--- a/scripts/package-scalingo-prod.sh
+++ b/scripts/package-scalingo-prod.sh
@@ -37,5 +37,5 @@ rm -r tchap-$version
 echo
 echo "Packaged tchap-$version-$CONFIG"
 
-export VERSION=$version
+scalingo --app $APP env-set VERSION=$version
 echo "VERSION is set to $VERSION"

--- a/scripts/package-scalingo-prod.sh
+++ b/scripts/package-scalingo-prod.sh
@@ -36,3 +36,6 @@ rm -r tchap-$version
 
 echo
 echo "Packaged tchap-$version-$CONFIG"
+
+export VERSION=$version
+echo "VERSION is set to $VERSION"


### PR DESCRIPTION
Fix https://github.com/tchapgouv/tchap-web-v4/issues/66

Sets the VERSION env var in the scalingo packaging script. The env var doesn't appear in the "Environment" tab in the scalingo dashboard, but it is set.

Console logs now say `startUpdater, current version is 1.10.14` (instead of `!!UNSET!!`) and the update dialog stops appearing for nothing.


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->