### PR TITLE
Change visibility of history to invited users by default

### DIFF
--- a/src/lib/createTchapRoom.ts
+++ b/src/lib/createTchapRoom.ts
@@ -47,7 +47,7 @@ export default function roomCreateOptions(
             createRoomOpts.preset = Preset.PrivateChat;
             opts.joinRule = JoinRule.Invite;
             opts.encryption = true;
-            opts.historyVisibility = HistoryVisibility.Joined;
+            opts.historyVisibility = HistoryVisibility.Invited;
             break;
         }
         case TchapRoomType.External: {
@@ -57,7 +57,7 @@ export default function roomCreateOptions(
             createRoomOpts.preset = Preset.PrivateChat;
             opts.joinRule = JoinRule.Invite;
             opts.encryption = true;
-            opts.historyVisibility = HistoryVisibility.Joined;
+            opts.historyVisibility = HistoryVisibility.Invited;
             break;
         }
     }


### PR DESCRIPTION
# Before 
When I create a new room, visibility of messages is when the user join

# After 
When I create a new room, visibility of messages is when the user is invited to the room
(This is the default on Tchap)

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->