### PR TITLE
Fix createTchapRoom test to reflect code change

### DIFF
--- a/test/unit-tests/lib/createTchapRoom-test.ts
+++ b/test/unit-tests/lib/createTchapRoom-test.ts
@@ -20,7 +20,7 @@ describe("Create room options", () => {
             guestAccess: false,
             joinRule: "invite",
             encryption: true,
-            historyVisibility: "joined",
+            historyVisibility: "invited",
         };
         expect(roomCreateOptions("testName", TchapRoomType.Private)).toStrictEqual(privateRoomExpectedOpts);
         done();
@@ -80,7 +80,7 @@ describe("Create room options", () => {
             guestAccess: false,
             joinRule: "invite",
             encryption: true,
-            historyVisibility: "joined",
+            historyVisibility: "invited",
         };
         expect(roomCreateOptions("testName", TchapRoomType.External)).toStrictEqual(externalRoomExpectedOpts);
         done();


### PR DESCRIPTION
We forgot to update it. 

(Our test successfully caught a regression ! 😀 But the regression was caused by us ! 😭)

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

Add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is plus `X-Breaking-Change` if it's a breaking change.<!-- CHANGELOG_PREVIEW_END -->