### PR TITLE
E2e : clean up login

### DIFF
--- a/cypress/e2e/create-room/create-room.spec.ts
+++ b/cypress/e2e/create-room/create-room.spec.ts
@@ -33,13 +33,10 @@ function openCreateDMDialog(): Chainable<JQuery<HTMLElement>> {
 }
 
 describe("Create Room", () => {
-    const homeserverUrl = Cypress.env('E2E_TEST_USER_HOMESERVER_URL');
-    const email = Cypress.env('E2E_TEST_USER_EMAIL');
-    const password = Cypress.env('E2E_TEST_USER_PASSWORD');
     const homeserverShortname = Cypress.env('E2E_TEST_USER_HOMESERVER_SHORT');
 
     beforeEach(() => {
-        cy.loginUser(homeserverUrl, email, password);
+        cy.loginUser();
     });
 
     afterEach(() => {

--- a/cypress/support/loginToRemoteHomeserver.ts
+++ b/cypress/support/loginToRemoteHomeserver.ts
@@ -35,14 +35,12 @@ declare global {
              * @param homeserverUrl the homeserver to connect to over http
              * @param email the email of an existing user in this homeserver
              * @param password the password of an existing user in this homeserver
-             * @param prelaunchFn optional function to run before the app is visited
              * @return UserCredentials for the logged in user.
              */
             loginUser(
                 homeserverUrl: string,
                 email: string,
                 password: string,
-                prelaunchFn?: () => void,
             ): Chainable<UserCredentials>;
         }
     }
@@ -52,7 +50,6 @@ Cypress.Commands.add("loginUser", (
     homeserverUrl: string,
     email: string,
     password: string,
-    prelaunchFn?: () => void,
 ): Chainable<UserCredentials> => {
     // todo this might cause surprises. Move it to somewhere else ?
     // XXX: work around Cypress not clearing IDB between tests
@@ -97,8 +94,6 @@ Cypress.Commands.add("loginUser", (
             // Ensure the language is set to a consistent value
             win.localStorage.setItem("mx_local_settings", '{"language":"fr"}');
         });
-
-        prelaunchFn?.(); // todo cy.wrap this or something, otherwise it will run synchronously
 
         return cy.visit("/").then(() => {
             // wait for the app to load

--- a/cypress/support/loginToRemoteHomeserver.ts
+++ b/cypress/support/loginToRemoteHomeserver.ts
@@ -32,25 +32,29 @@ declare global {
         interface Chainable {
             /**
              * Instantiates an Element session with the given user.
-             * @param homeserverUrl the homeserver to connect to over http
-             * @param email the email of an existing user in this homeserver
-             * @param password the password of an existing user in this homeserver
+             * @param homeserverUrl Optional. The homeserver to connect to over http
+             * @param email Optional. The email of an existing user in this homeserver
+             * @param password Optional. The password of an existing user in this homeserver
              * @return UserCredentials for the logged in user.
              */
             loginUser(
-                homeserverUrl: string,
-                email: string,
-                password: string,
+                homeserverUrl?: string,
+                email?: string,
+                password?: string,
             ): Chainable<UserCredentials>;
         }
     }
 }
 
 Cypress.Commands.add("loginUser", (
-    homeserverUrl: string,
-    email: string,
-    password: string,
+    homeserverUrl?: string,
+    email?: string,
+    password?: string,
 ): Chainable<UserCredentials> => {
+    homeserverUrl = homeserverUrl ?? Cypress.env('E2E_TEST_USER_HOMESERVER_URL');
+    email = email ?? Cypress.env('E2E_TEST_USER_EMAIL');
+    password = password ?? Cypress.env('E2E_TEST_USER_PASSWORD');
+
     // XXX: work around Cypress not clearing IDB between tests
     // Otherwise Cypress clears all localstorage and cookies between tests.
     // https://github.com/cypress-io/cypress/issues/1208

--- a/cypress/support/loginToRemoteHomeserver.ts
+++ b/cypress/support/loginToRemoteHomeserver.ts
@@ -51,8 +51,9 @@ Cypress.Commands.add("loginUser", (
     email: string,
     password: string,
 ): Chainable<UserCredentials> => {
-    // todo this might cause surprises. Move it to somewhere else ?
     // XXX: work around Cypress not clearing IDB between tests
+    // Otherwise Cypress clears all localstorage and cookies between tests.
+    // https://github.com/cypress-io/cypress/issues/1208
     cy.window({ log: false }).then(win => {
         win.indexedDB.databases().then(databases => {
             databases.forEach(database => {

--- a/cypress/support/loginToRemoteHomeserver.ts
+++ b/cypress/support/loginToRemoteHomeserver.ts
@@ -98,7 +98,7 @@ Cypress.Commands.add("loginUser", (
 
         return cy.visit("/").then(() => {
             // wait for the app to load
-            cy.get(".mx_MatrixChat", { timeout: 15000 });
+            return cy.get(".mx_MatrixChat", { timeout: 15000 });
         }).then(() => ({
             password,
             accessToken: response.body.access_token,

--- a/cypress/support/loginToRemoteHomeserver.ts
+++ b/cypress/support/loginToRemoteHomeserver.ts
@@ -54,6 +54,7 @@ Cypress.Commands.add("loginUser", (
     password: string,
     prelaunchFn?: () => void,
 ): Chainable<UserCredentials> => {
+    // todo this might cause surprises. Move it to somewhere else ?
     // XXX: work around Cypress not clearing IDB between tests
     cy.window({ log: false }).then(win => {
         win.indexedDB.databases().then(databases => {
@@ -97,11 +98,11 @@ Cypress.Commands.add("loginUser", (
             win.localStorage.setItem("mx_local_settings", '{"language":"fr"}');
         });
 
-        prelaunchFn?.();
+        prelaunchFn?.(); // todo cy.wrap this or something, otherwise it will run synchronously
 
         return cy.visit("/").then(() => {
             // wait for the app to load
-            return cy.get(".mx_MatrixChat", { timeout: 15000 });
+            cy.get(".mx_MatrixChat", { timeout: 15000 });
         }).then(() => ({
             password,
             accessToken: response.body.access_token,


### PR DESCRIPTION
Especially, remove the prelaunchFn, because it is never used (in element's code either), and I suspect the way it's called doesn't respect cypress magic order. I don't want any surprises with things executing out of order.
We can always bring it back if we need it.