### PR TITLE
Disable cross-signing in js-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "test:cypress:open": "cypress open",
     "coverage": "yarn test --coverage",
     "analyse:unused-exports": "node ./scripts/analyse_unused_exports.js",
-    "postinstall": "./scripts/apply_patches.sh"
+    "postinstall": "./scripts/apply_patches.sh",
+    "patch-package": "patch-package"
   },
   "dependencies": {
     "@matrix-org/olm": "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.12.tgz",

--- a/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
+++ b/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/matrix-js-sdk/src/client.ts b/node_modules/matrix-js-sdk/src/client.ts
+index d8fc75d..3010db8 100644
+--- a/node_modules/matrix-js-sdk/src/client.ts
++++ b/node_modules/matrix-js-sdk/src/client.ts
+@@ -6659,6 +6659,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
+         const response = await this.getVersions();
+         if (!response) return false;
+         const unstableFeatures = response["unstable_features"];
++
++        // :TCHAP: disable cross signing, by pretending the server doesn't support it.
++        unstableFeatures["org.matrix.e2e_cross_signing"] = false;
++        // end :TCHAP:
++
+         return unstableFeatures && !!unstableFeatures[feature];
+     }
+ 

--- a/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
+++ b/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
@@ -1,14 +1,15 @@
 diff --git a/node_modules/matrix-js-sdk/src/client.ts b/node_modules/matrix-js-sdk/src/client.ts
-index d8fc75d..3010db8 100644
+index d8fc75d..fa84f3c 100644
 --- a/node_modules/matrix-js-sdk/src/client.ts
 +++ b/node_modules/matrix-js-sdk/src/client.ts
-@@ -6659,6 +6659,11 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
+@@ -6659,6 +6659,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
          const response = await this.getVersions();
          if (!response) return false;
          const unstableFeatures = response["unstable_features"];
 +
 +        // :TCHAP: disable cross signing, by pretending the server doesn't support it.
 +        unstableFeatures["org.matrix.e2e_cross_signing"] = false;
++        console.error(':TCHAP: unstableFeatures', unstableFeatures);
 +        // end :TCHAP:
 +
          return unstableFeatures && !!unstableFeatures[feature];

--- a/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
+++ b/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
@@ -1,15 +1,17 @@
 diff --git a/node_modules/matrix-js-sdk/src/client.ts b/node_modules/matrix-js-sdk/src/client.ts
-index d8fc75d..fa84f3c 100644
+index d8fc75d..75cd64a 100644
 --- a/node_modules/matrix-js-sdk/src/client.ts
 +++ b/node_modules/matrix-js-sdk/src/client.ts
-@@ -6659,6 +6659,12 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
+@@ -6659,6 +6659,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
          const response = await this.getVersions();
          if (!response) return false;
          const unstableFeatures = response["unstable_features"];
 +
 +        // :TCHAP: disable cross signing, by pretending the server doesn't support it.
 +        unstableFeatures["org.matrix.e2e_cross_signing"] = false;
-+        console.error(':TCHAP: unstableFeatures', unstableFeatures);
++        if (feature === "org.matrix.e2e_cross_signing") {
++            console.error(':TCHAP: unstableFeatures', unstableFeatures);
++        }
 +        // end :TCHAP:
 +
          return unstableFeatures && !!unstableFeatures[feature];

--- a/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
+++ b/patches/disable-cross-signing/matrix-js-sdk+19.5.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-js-sdk/src/client.ts b/node_modules/matrix-js-sdk/src/client.ts
-index d8fc75d..75cd64a 100644
+index d8fc75d..6bc9a87 100644
 --- a/node_modules/matrix-js-sdk/src/client.ts
 +++ b/node_modules/matrix-js-sdk/src/client.ts
 @@ -6659,6 +6659,14 @@ export class MatrixClient extends TypedEventEmitter<EmittedEvents, ClientEventHa
@@ -10,7 +10,7 @@ index d8fc75d..75cd64a 100644
 +        // :TCHAP: disable cross signing, by pretending the server doesn't support it.
 +        unstableFeatures["org.matrix.e2e_cross_signing"] = false;
 +        if (feature === "org.matrix.e2e_cross_signing") {
-+            console.error(':TCHAP: unstableFeatures', unstableFeatures);
++            console.info(':TCHAP: doesServerSupportUnstableFeature org.matrix.e2e_cross_signing',unstableFeatures);
 +        }
 +        // end :TCHAP:
 +


### PR DESCRIPTION
By patching the client.ts in matrix-js-sdk

We need to patch in both places :
- [x] node_modules/matrix-js-sdk
<del> node_modules/matrix-react-sdk/node_modules/matrix-js-sdk</del> (dependencies are reused in both places, not necessary)