### PR TITLE
Hide room aliases

### DIFF
--- a/patches/hide-room-alias-settings/matrix-react-sdk+3.54.0.patch
+++ b/patches/hide-room-alias-settings/matrix-react-sdk+3.54.0.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
+index e531f0c..67dea9c 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/room/GeneralRoomSettingsTab.tsx
+@@ -87,6 +87,7 @@ export default class GeneralRoomSettingsTab extends React.Component<IProps, ISta
+                     <RoomProfileSettings roomId={this.props.roomId} />
+                 </div>
+ 
++                { /* :TCHAP: no aliases for rooms
+                 <div className="mx_SettingsTab_heading">{ _t("Room Addresses") }</div>
+                 <AliasSettings
+                     roomId={this.props.roomId}
+@@ -94,6 +95,7 @@ export default class GeneralRoomSettingsTab extends React.Component<IProps, ISta
+                     canSetAliases={canSetAliases}
+                     canonicalAliasEvent={canonicalAliasEv}
+                 />
++                end :TCHAP: */}
+                 <div className="mx_SettingsTab_heading">{ _t("Other") }</div>
+                 { urlPreviewSettings }
+                 { leaveSection }


### PR DESCRIPTION
In room settings, hide the section for "Adresses du salon" ("adresses publiées" and "adresses locales").
For DMs, private rooms, and public rooms.