### PR TITLE
In logout dialog, hide secure storage option

### DIFF
--- a/patches/hide-secure-storage-2/matrix-react-sdk+3.54.0.patch
+++ b/patches/hide-secure-storage-2/matrix-react-sdk+3.54.0.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/LogoutDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/LogoutDialog.tsx
+index cea5d31..8ed11bd 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/dialogs/LogoutDialog.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/LogoutDialog.tsx
+@@ -157,6 +157,7 @@ export default class LogoutDialog extends React.Component<IProps, IState> {
+                     <div className="mx_Dialog_content" id='mx_Dialog_content'>
+                         { description }
+                     </div>
++                    { /** :TCHAP: do not suggest key backup. Suggest exporting keys as primary method.
+                     <DialogButtons primaryButton={setupButtonCaption}
+                         hasCancel={false}
+                         onPrimaryButtonClick={this.onSetRecoveryMethodClick}
+@@ -172,6 +173,17 @@ export default class LogoutDialog extends React.Component<IProps, IState> {
+                             { _t("Manually export keys") }
+                         </button></p>
+                     </details>
++                    */ }
++                    <DialogButtons primaryButton={_t("Manually export keys")}
++                        hasCancel={false}
++                        onPrimaryButtonClick={this.onExportE2eKeysClicked}
++                        focus={true}
++                    >
++                        <button onClick={this.onLogoutConfirm}>
++                            { _t("I don't want my encrypted messages") }
++                        </button>
++                    </DialogButtons>
++                    { /** end :TCHAP: */ }
+                 </div>;
+             }
+             // Not quite a standard question dialog as the primary button cancels


### PR DESCRIPTION
I wanted to put it in the same patch as hide-secure-storage, to have everything together, but I couldn't find a regex to select the right files for patch-package. So I decided to keep it simple and make a separate patch with similar name.

Not tested yet. I have to figure out how to make this dialog appear.
On a "clean" account without cross-signing, it doesn't appear, whether you have multiple sessions or single session.