### PR TITLE
Push all rageshakes though DINUM server

### DIFF
--- a/config.prod.json
+++ b/config.prod.json
@@ -100,7 +100,7 @@
     "disable_login_language_selector": false,
     "disable_3pid_login": false,
     "brand": "Tchap",
-    "bug_report_endpoint_url": "/bugreports/submit",
+    "bug_report_endpoint_url": "https://matrix.agent.dinum.tchap.gouv.fr/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "defaultCountryCode": "FR",
     "showLabsSettings": false,


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/213

In prod, hard-code the rageshake url to go through a given homeserver (DINUM because it is less loaded than others).

Later we can route to the user's homeserver.

Test by going to Settings > Help and About > Submit debug logs (you need to select an existing github issue for now) 
It should not display any errors, and you should see your report in support tickets.