### PR TITLE
Forget password : user friendly version

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,28 @@
+Commands to make the patches
+--
+
+Keep track of the commands used to make the patches, to make sure we keep the same files in them.
+Todo : automate the making and updating of patches
+
+### better-help-settings
+yarn patch-package --patch-dir patches/better-help-settings --include src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx  matrix-react-sdk
+
+### better-help-settings-2
+
+### disable-access-options
+
+### disable-cross-signing
+
+### forgot-password
+yarn patch-package --patch-dir patches/forgot-password --include src/components/structures/auth/ForgotPassword.tsx  matrix-react-sdk
+
+### hide-cross-signing-actions
+
+### hide-room-alias-settings
+
+### hide-secure-storage
+
+### hide-secure-storage-2
+
+### login
+yarn patch-package --patch-dir patches/login --include src/components/.*/auth/.*Login.*  matrix-react-sdk

--- a/patches/forgot-password/matrix-react-sdk+3.54.0.patch
+++ b/patches/forgot-password/matrix-react-sdk+3.54.0.patch
@@ -1,12 +1,12 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
-index 83a8e3e..06cdc47 100644
+index 83a8e3e..7ce6037 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 @@ -40,6 +40,7 @@ import PassphraseConfirmField from "../../views/auth/PassphraseConfirmField";
  import AccessibleButton from '../../views/elements/AccessibleButton';
  import StyledCheckbox from '../../views/elements/StyledCheckbox';
  import { ValidatedServerConfig } from '../../../utils/ValidatedServerConfig';
-+import SdkConfig from '../../../SdkConfig'; // :TCHAP: added for homeserver list
++import TchapUtils from '../../../../../../src/util/TchapUtils';
  
  enum Phase {
      // Show the forgot password inputs
@@ -25,63 +25,7 @@ index 83a8e3e..06cdc47 100644
          this.reset.resetPassword(email, password, logoutDevices).then(() => {
              this.setState({
                  phase: Phase.EmailSent,
-@@ -187,18 +189,80 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
-         }
-     };
- 
-+    // todo place this code in common somewhere.
-+    tchap_fetchHomeserverForEmail = async (email) => {
-+        const homeServerList = SdkConfig.get()['homeserver_list'];
-+
-+        const findHomeServerNameFromUrl = (url) => {
-+            const homeserver = homeServerList.find(homeServer => homeServer.base_url === url);
-+            return homeserver.server_name;
-+        };
-+
-+        const randomHomeServer = homeServerList[ Math.floor(Math.random() * homeServerList.length) ];
-+        const infoUrl = "/_matrix/identity/api/v1/info?medium=email&address=";
-+        return fetch(randomHomeServer.base_url + infoUrl + email)
-+            .then((response) => {
-+                if (!response.ok) {
-+                  throw new Error('Could not find homeserver for this email');
-+                }
-+                return response.json();
-+            })
-+            .then(response => {
-+                // Never returns error : anything that doesn't match a homeserver (even invalid email) returns "externe".
-+                const serverUrl = "https://matrix." + response.hs;
-+                return {
-+                    base_url: serverUrl,
-+                    server_name: findHomeServerNameFromUrl(serverUrl),
-+                };
-+            })
-+            .catch((error) => {
-+                console.error('Could not find homeserver for this email', error);
-+                return;
-+            });
-+    };
-+
-+    tchap_makeValidatedServerConfig = (serverConfig) => {
-+        const discoveryResult = {
-+            "m.homeserver": {
-+                state: "SUCCESS",
-+                error: null,
-+                base_url: serverConfig.base_url,
-+                server_name: serverConfig.server_name,
-+            },
-+            "m.identity_server": {
-+                state: "SUCCESS",
-+                error: null,
-+                base_url: serverConfig.base_url, // On Tchap our Identity server urls and home server urls are the same
-+                server_name: serverConfig.server_name,
-+            },
-+        };
-+        const validatedServerConf = AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(
-+            discoveryResult['m.homeserver'].server_name, discoveryResult);
-+        return validatedServerConf;
-+    };
-+
-     private onSubmitForm = async (ev: React.FormEvent): Promise<void> => {
+@@ -191,14 +193,24 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
          ev.preventDefault();
          if (this.state.currentHttpRequest) return;
  
@@ -96,17 +40,17 @@ index 83a8e3e..06cdc47 100644
          }
  
 +        /* :TCHAP: fetch homeserver corresponding to email */
-+        const serverResult = await this.tchap_fetchHomeserverForEmail(this.state.email);
++        const serverResult = await TchapUtils.fetchHomeserverForEmail(this.state.email);
 +        if (!serverResult) {
 +            // todo display error, set Phase probably
 +            return
 +        }
-+        const serverConfig = this.tchap_makeValidatedServerConfig(serverResult);
++        const serverConfig = TchapUtils.makeValidatedServerConfig(serverResult);
 +
          if (this.state.logoutDevices) {
              const { finished } = Modal.createDialog<[boolean]>(QuestionDialog, {
                  title: _t('Warning!'),
-@@ -227,7 +291,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+@@ -227,7 +239,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
              if (!confirmed) return;
          }
  
@@ -115,7 +59,7 @@ index 83a8e3e..06cdc47 100644
      };
  
      private async verifyFieldsBeforeSubmit() {
-@@ -313,10 +377,12 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+@@ -313,10 +325,12 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
          return <div>
              { errorText }
              { serverDeadSection }

--- a/patches/forgot-password/matrix-react-sdk+3.54.0.patch
+++ b/patches/forgot-password/matrix-react-sdk+3.54.0.patch
@@ -1,0 +1,130 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
+index 83a8e3e..06cdc47 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
+@@ -40,6 +40,7 @@ import PassphraseConfirmField from "../../views/auth/PassphraseConfirmField";
+ import AccessibleButton from '../../views/elements/AccessibleButton';
+ import StyledCheckbox from '../../views/elements/StyledCheckbox';
+ import { ValidatedServerConfig } from '../../../utils/ValidatedServerConfig';
++import SdkConfig from '../../../SdkConfig'; // :TCHAP: added for homeserver list
+ 
+ enum Phase {
+     // Show the forgot password inputs
+@@ -154,11 +155,12 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+         });
+     }
+ 
+-    public submitPasswordReset(email: string, password: string, logoutDevices = true): void {
++    // :TCHAP: use serverConfig passed as argument, instead of this.props.serverConfig
++    public submitPasswordReset(serverConfig: ValidatedServerConfig, email: string, password: string, logoutDevices = true): void {
+         this.setState({
+             phase: Phase.SendingEmail,
+         });
+-        this.reset = new PasswordReset(this.props.serverConfig.hsUrl, this.props.serverConfig.isUrl);
++        this.reset = new PasswordReset(serverConfig.hsUrl, serverConfig.isUrl);
+         this.reset.resetPassword(email, password, logoutDevices).then(() => {
+             this.setState({
+                 phase: Phase.EmailSent,
+@@ -187,18 +189,80 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+         }
+     };
+ 
++    // todo place this code in common somewhere.
++    tchap_fetchHomeserverForEmail = async (email) => {
++        const homeServerList = SdkConfig.get()['homeserver_list'];
++
++        const findHomeServerNameFromUrl = (url) => {
++            const homeserver = homeServerList.find(homeServer => homeServer.base_url === url);
++            return homeserver.server_name;
++        };
++
++        const randomHomeServer = homeServerList[ Math.floor(Math.random() * homeServerList.length) ];
++        const infoUrl = "/_matrix/identity/api/v1/info?medium=email&address=";
++        return fetch(randomHomeServer.base_url + infoUrl + email)
++            .then((response) => {
++                if (!response.ok) {
++                  throw new Error('Could not find homeserver for this email');
++                }
++                return response.json();
++            })
++            .then(response => {
++                // Never returns error : anything that doesn't match a homeserver (even invalid email) returns "externe".
++                const serverUrl = "https://matrix." + response.hs;
++                return {
++                    base_url: serverUrl,
++                    server_name: findHomeServerNameFromUrl(serverUrl),
++                };
++            })
++            .catch((error) => {
++                console.error('Could not find homeserver for this email', error);
++                return;
++            });
++    };
++
++    tchap_makeValidatedServerConfig = (serverConfig) => {
++        const discoveryResult = {
++            "m.homeserver": {
++                state: "SUCCESS",
++                error: null,
++                base_url: serverConfig.base_url,
++                server_name: serverConfig.server_name,
++            },
++            "m.identity_server": {
++                state: "SUCCESS",
++                error: null,
++                base_url: serverConfig.base_url, // On Tchap our Identity server urls and home server urls are the same
++                server_name: serverConfig.server_name,
++            },
++        };
++        const validatedServerConf = AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(
++            discoveryResult['m.homeserver'].server_name, discoveryResult);
++        return validatedServerConf;
++    };
++
+     private onSubmitForm = async (ev: React.FormEvent): Promise<void> => {
+         ev.preventDefault();
+         if (this.state.currentHttpRequest) return;
+ 
++        /* :TCHAP: remove liveliness check, we don't know which server to use yet.
+         // refresh the server errors, just in case the server came back online
+         await this.handleHttpRequest(this.checkServerLiveliness(this.props.serverConfig));
++        end :TCHAP: */
+ 
+         const allFieldsValid = await this.verifyFieldsBeforeSubmit();
+         if (!allFieldsValid) {
+             return;
+         }
+ 
++        /* :TCHAP: fetch homeserver corresponding to email */
++        const serverResult = await this.tchap_fetchHomeserverForEmail(this.state.email);
++        if (!serverResult) {
++            // todo display error, set Phase probably
++            return
++        }
++        const serverConfig = this.tchap_makeValidatedServerConfig(serverResult);
++
+         if (this.state.logoutDevices) {
+             const { finished } = Modal.createDialog<[boolean]>(QuestionDialog, {
+                 title: _t('Warning!'),
+@@ -227,7 +291,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+             if (!confirmed) return;
+         }
+ 
+-        this.submitPasswordReset(this.state.email, this.state.password, this.state.logoutDevices);
++        this.submitPasswordReset(serverConfig, this.state.email, this.state.password, this.state.logoutDevices);
+     };
+ 
+     private async verifyFieldsBeforeSubmit() {
+@@ -313,10 +377,12 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+         return <div>
+             { errorText }
+             { serverDeadSection }
++            { /* :TCHAP: remove server picker, we don't allow user to chose, server is assigned to each email.
+             <ServerPicker
+                 serverConfig={this.props.serverConfig}
+                 onServerConfigChange={this.props.onServerConfigChange}
+             />
++            */ }
+             <form onSubmit={this.onSubmitForm}>
+                 <div className="mx_AuthBody_fieldRow">
+                     <EmailField

--- a/patches/forgot-password/matrix-react-sdk+3.54.0.patch
+++ b/patches/forgot-password/matrix-react-sdk+3.54.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
-index 83a8e3e..7ce6037 100644
+index 83a8e3e..6e93b85 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 @@ -40,6 +40,7 @@ import PassphraseConfirmField from "../../views/auth/PassphraseConfirmField";
@@ -25,7 +25,7 @@ index 83a8e3e..7ce6037 100644
          this.reset.resetPassword(email, password, logoutDevices).then(() => {
              this.setState({
                  phase: Phase.EmailSent,
-@@ -191,14 +193,24 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+@@ -191,14 +193,27 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
          ev.preventDefault();
          if (this.state.currentHttpRequest) return;
  
@@ -42,15 +42,18 @@ index 83a8e3e..7ce6037 100644
 +        /* :TCHAP: fetch homeserver corresponding to email */
 +        const serverResult = await TchapUtils.fetchHomeserverForEmail(this.state.email);
 +        if (!serverResult) {
-+            // todo display error, set Phase probably
-+            return
++            this.setState({
++                phase: Phase.Forgot,
++                errorText: _t('Server unavailable, overloaded, or something else went wrong.'), // reuse existing string
++            });
++            return;
 +        }
 +        const serverConfig = TchapUtils.makeValidatedServerConfig(serverResult);
 +
          if (this.state.logoutDevices) {
              const { finished } = Modal.createDialog<[boolean]>(QuestionDialog, {
                  title: _t('Warning!'),
-@@ -227,7 +239,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+@@ -227,7 +242,7 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
              if (!confirmed) return;
          }
  
@@ -59,7 +62,7 @@ index 83a8e3e..7ce6037 100644
      };
  
      private async verifyFieldsBeforeSubmit() {
-@@ -313,10 +325,12 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
+@@ -313,10 +328,12 @@ export default class ForgotPassword extends React.Component<IProps, IState> {
          return <div>
              { errorText }
              { serverDeadSection }

--- a/patches/login/matrix-react-sdk+3.54.0.patch
+++ b/patches/login/matrix-react-sdk+3.54.0.patch
@@ -1,65 +1,26 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
-index c00aa90..e4df01b 100644
+index c00aa90..39232b3 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
-@@ -165,7 +165,64 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -38,6 +38,7 @@ import AuthBody from "../../views/auth/AuthBody";
+ import AuthHeader from "../../views/auth/AuthHeader";
+ import AccessibleButton from '../../views/elements/AccessibleButton';
+ import { ValidatedServerConfig } from '../../../utils/ValidatedServerConfig';
++import TchapUtils from '../../../../../../src/util/TchapUtils'; // :TCHAP:
+ 
+ // These are used in several places, and come from the js-sdk's autodiscovery
+ // stuff. We define them here so that they'll be picked up by i18n.
+@@ -165,7 +166,17 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
  
      isBusy = () => this.state.busy || this.props.busy;
  
-+    tchap_fetchHomeserverForEmail = async (email) => {
-+        const homeServerList = SdkConfig.get()['homeserver_list'];
-+
-+        const findHomeServerNameFromUrl = (url) => {
-+            const homeserver = homeServerList.find(homeServer => homeServer.base_url === url);
-+            return homeserver.server_name;
-+        };
-+
-+        const randomHomeServer = homeServerList[ Math.floor(Math.random() * homeServerList.length) ];
-+        const infoUrl = "/_matrix/identity/api/v1/info?medium=email&address=";
-+        return fetch(randomHomeServer.base_url + infoUrl + email)
-+            .then((response) => {
-+                if (!response.ok) {
-+                  throw new Error('Could not find homeserver for this email');
-+                }
-+                return response.json();
-+            })
-+            .then(response => {
-+                // Never returns error : anything that doesn't match a homeserver (even invalid email) returns "externe".
-+                const serverUrl = "https://matrix." + response.hs;
-+                return {
-+                    base_url: serverUrl,
-+                    server_name: findHomeServerNameFromUrl(serverUrl),
-+                };
-+            })
-+            .catch((error) => {
-+                console.error('Could not find homeserver for this email', error);
-+                return;
-+            });
-+    };
-+
-+    tchap_setServerInMemory = (serverConfig) => {
-+        // Make a ValidatedServerConfig, from a fake discovery result.
-+        const discoveryResult = {
-+            "m.homeserver": {
-+                state: "SUCCESS",
-+                error: null,
-+                base_url: serverConfig.base_url,
-+                server_name: serverConfig.server_name,
-+            },
-+            "m.identity_server": {
-+                state: "SUCCESS",
-+                error: null,
-+                base_url: serverConfig.base_url, // On Tchap our Identity server urls and home server urls are the same
-+                server_name: serverConfig.server_name,
-+            },
-+        };
-+        const validatedServerConf = AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(
-+            discoveryResult['m.homeserver'].server_name, discoveryResult);
++    tchap_setServerInMemory = async (serverConfig) => {
++        const validatedServerConf = TchapUtils.makeValidatedServerConfig(serverConfig);
 +
 +        // Simulate the end of the serverPicker component flow.
 +        this.props.onServerConfigChange(validatedServerConf);
 +
-+        this.initLoginLogic(validatedServerConf);
++        await this.initLoginLogic(validatedServerConf);
 +    };
 +
      onPasswordLogin = async (username, phoneCountry, phoneNumber, password) => {
@@ -67,7 +28,7 @@ index c00aa90..e4df01b 100644
          if (!this.state.serverIsAlive) {
              this.setState({ busy: true });
              // Do a quick liveliness check on the URLs
-@@ -190,7 +247,7 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -190,7 +201,7 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
              if (!aliveAgain) {
                  return;
              }
@@ -76,12 +37,12 @@ index c00aa90..e4df01b 100644
  
          this.setState({
              busy: true,
-@@ -199,6 +256,22 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -199,6 +210,22 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
              loginIncorrect: false,
          });
  
 +        /* :TCHAP: fetch homeserver corresponding to email */
-+        const serverResult = await this.tchap_fetchHomeserverForEmail(username);
++        const serverResult = await TchapUtils.fetchHomeserverForEmail(username);
 +
 +        if (!serverResult) {
 +            this.setState({
@@ -93,13 +54,25 @@ index c00aa90..e4df01b 100644
 +            return;
 +        }
 +
-+        this.tchap_setServerInMemory(serverResult);
++        await this.tchap_setServerInMemory(serverResult);
 +        /** end :TCHAP: */
 +
          this.loginLogic.loginViaPassword(
              username, phoneCountry, phoneNumber, password,
          ).then((data) => {
-@@ -606,10 +679,12 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -261,6 +288,11 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+                 } else {
+                     errorText = _t('Incorrect username and/or password.');
+                 }
++            // :TCHAP: display proper message for TOO_MANY_REQUESTS
++            } else if (error.httpStatus === 429) {
++                console.log('fff error', error, error.httpStatus, error.errcode);
++                errorText = _t("You have made to many requests and have been blocked. Try again later.");
++            // end :TCHAP:
+             } else {
+                 // other errors, not specific to doing a password login
+                 errorText = this.errorTextFromError(error);
+@@ -606,10 +638,12 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
                      </h1>
                      { errorTextSection }
                      { serverDeadSection }

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -56,7 +56,7 @@ export default class TchapUtils {
             return homeserver.server_name;
         };
 
-        const randomHomeServer = homeServerList[ Math.floor(Math.random() * homeServerList.length)];
+        const randomHomeServer = homeServerList[Math.floor(Math.random() * homeServerList.length)];
         const infoUrl = "/_matrix/identity/api/v1/info?medium=email&address=";
         return fetch(randomHomeServer.base_url + infoUrl + email)
             .then((response) => {


### PR DESCRIPTION
 - Similar to login : after the form is filled, add a step to fetch the homeserver corresponding to the email entered in the form. 
 - I moved the functions in common between Login and ForgotPassword to TchapUtils. 
 - started a README to keep track of the patches, and the command to create them. We have to watch out that the right changes are in the right patches... This should be automated more, it's fragile.

Before:
<img width="708" alt="image" src="https://user-images.githubusercontent.com/3725676/192816501-e700521e-596b-44f5-81a5-314d58e2291f.png">

After:
<img width="699" alt="image" src="https://user-images.githubusercontent.com/3725676/192815914-f3ae2a5a-2207-4002-9565-539f4ea6caf8.png">
