### PR TITLE
Fix/layered build dir structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@ electron/pub
 /matrix-react-sdk
 /matrix-js-sdk
 /matrix-analytics-events
+# yarn links dependencies generated with /scripts/layered.with.version.sh
+/yarn-linked-dependencies
 
 
 # Auto-generated file

--- a/scripts/layered.with.version.sh
+++ b/scripts/layered.with.version.sh
@@ -29,7 +29,7 @@ echo "Using MATRIX_REACT_SDK_VERSION $MATRIX_REACT_SDK_VERSION"
 # This is because the normal location of dependencies is in tchap-web-v4/node_modules, so ../.. is expected
 # to take us to tchap-web-v4. Make it work the same way.
 mkdir -p yarn-linked-dependencies
-cp yarn-linked-dependencies
+cd yarn-linked-dependencies
 
 # Set up the js-sdk first
 ./scripts/fetchdep.with.version.sh matrix-org matrix-js-sdk $MATRIX_JS_SDK_VERSION

--- a/scripts/layered.with.version.sh
+++ b/scripts/layered.with.version.sh
@@ -25,6 +25,11 @@ export MATRIX_REACT_SDK_VERSION=v$(awk -F \" '/"matrix-react-sdk": ".+"/ { print
 echo "Using MATRIX_JS_SDK_VERSION $MATRIX_JS_SDK_VERSION"
 echo "Using MATRIX_REACT_SDK_VERSION $MATRIX_REACT_SDK_VERSION"
 
+# :TCHAP: Create an additional directory to add one layer of depth, otherwise some imports will fail.
+# This is because the normal location of dependencies is in tchap-web-v4/node_modules, so ../.. is expected
+# to take us to tchap-web-v4. Make it work the same way.
+pushd linked-dependencies
+
 # Set up the js-sdk first
 ./scripts/fetchdep.with.version.sh matrix-org matrix-js-sdk $MATRIX_JS_SDK_VERSION
 pushd matrix-js-sdk
@@ -56,5 +61,8 @@ popd
 # Link the layers into element-web
 yarn link matrix-js-sdk
 yarn link matrix-react-sdk
+
+# :TCHAP: we are now in linked-dependencies, go back out to tchap-web-v4 dir
+popd
 
 yarn install --pure-lockfile

--- a/scripts/layered.with.version.sh
+++ b/scripts/layered.with.version.sh
@@ -32,7 +32,7 @@ mkdir -p yarn-linked-dependencies
 cd yarn-linked-dependencies
 
 # Set up the js-sdk first
-./scripts/fetchdep.with.version.sh matrix-org matrix-js-sdk $MATRIX_JS_SDK_VERSION
+../scripts/fetchdep.with.version.sh matrix-org matrix-js-sdk $MATRIX_JS_SDK_VERSION
 pushd matrix-js-sdk
 yarn unlink # :TCHAP: for local build, undo previous links if present.
 yarn link
@@ -50,7 +50,7 @@ popd
 #popd
 
 # Now set up the react-sdk
-./scripts/fetchdep.with.version.sh matrix-org matrix-react-sdk $MATRIX_REACT_SDK_VERSION
+../scripts/fetchdep.with.version.sh matrix-org matrix-react-sdk $MATRIX_REACT_SDK_VERSION
 pushd matrix-react-sdk
 yarn unlink # :TCHAP: for local build, undo previous links if present.
 yarn link
@@ -59,11 +59,11 @@ yarn link matrix-js-sdk
 yarn install --pure-lockfile
 popd
 
+# :TCHAP: we are now in linked-dependencies, go back out to tchap-web-v4 dir
+cd ..
+
 # Link the layers into element-web
 yarn link matrix-js-sdk
 yarn link matrix-react-sdk
-
-# :TCHAP: we are now in linked-dependencies, go back out to tchap-web-v4 dir
-cd ..
 
 yarn install --pure-lockfile

--- a/scripts/layered.with.version.sh
+++ b/scripts/layered.with.version.sh
@@ -28,7 +28,8 @@ echo "Using MATRIX_REACT_SDK_VERSION $MATRIX_REACT_SDK_VERSION"
 # :TCHAP: Create an additional directory to add one layer of depth, otherwise some imports will fail.
 # This is because the normal location of dependencies is in tchap-web-v4/node_modules, so ../.. is expected
 # to take us to tchap-web-v4. Make it work the same way.
-pushd linked-dependencies
+mkdir -p yarn-linked-dependencies
+cp yarn-linked-dependencies
 
 # Set up the js-sdk first
 ./scripts/fetchdep.with.version.sh matrix-org matrix-js-sdk $MATRIX_JS_SDK_VERSION
@@ -63,6 +64,6 @@ yarn link matrix-js-sdk
 yarn link matrix-react-sdk
 
 # :TCHAP: we are now in linked-dependencies, go back out to tchap-web-v4 dir
-popd
+cd ..
 
 yarn install --pure-lockfile


### PR DESCRIPTION
scripts/layered.with.version.sh runs but the yarn start is then broken. 
This is because the matrix-*-sdk are importing tchap-web-v4 files, and expecting to find them at ../.. (which works when deps are in node_modules dir). 
Adjust the dir structure for this to work.