### PR TITLE
rename exported keys file

### DIFF
--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,4 +1,10 @@
 {
+  "rename-exported-keys": {
+    "package": "matrix-react-sdk",
+    "files": [
+      "src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx"
+    ]
+  },
   "better-help-settings": {
     "package": "matrix-react-sdk",
     "files": [

--- a/patches/rename-exported-keys/matrix-react-sdk+3.58.0-rc.2.patch
+++ b/patches/rename-exported-keys/matrix-react-sdk+3.58.0-rc.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx b/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
+index 2f2bc36..63bc57f 100644
+--- a/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
++++ b/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx
+@@ -86,7 +86,7 @@ export default class ExportE2eKeysDialog extends React.Component<IProps, IState>
+             const blob = new Blob([f], {
+                 type: 'text/plain;charset=us-ascii',
+             });
+-            FileSaver.saveAs(blob, 'element-keys.txt');
++            FileSaver.saveAs(blob, 'tchap-keys.txt');
+             this.props.onFinished(true);
+         }).catch((e) => {
+             logger.error("Error exporting e2e keys:", e);


### PR DESCRIPTION
Before :
exported key files is element-keys.txt

After the file has the same name as Tchap V2 so the documentation is up to date: 
file is tchap-keys.txt
