### PR TITLE
Make globe icon appears only on Forum

### DIFF
--- a/patches/patches.json
+++ b/patches/patches.json
@@ -1,4 +1,10 @@
 {
+  "show-icon-on-public-room": {
+    "package": "matrix-react-sdk",
+    "files": [
+      "src/components/views/avatars/DecoratedRoomAvatar.tsx"
+    ]
+  },
   "rename-exported-keys": {
     "package": "matrix-react-sdk",
     "files": [

--- a/patches/show-icon-on-public-room/matrix-react-sdk+3.58.0-rc.2.patch
+++ b/patches/show-icon-on-public-room/matrix-react-sdk+3.58.0-rc.2.patch
@@ -1,0 +1,24 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/avatars/DecoratedRoomAvatar.tsx b/node_modules/matrix-react-sdk/src/components/views/avatars/DecoratedRoomAvatar.tsx
+index 06ee20c..c0ef39a 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/avatars/DecoratedRoomAvatar.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/avatars/DecoratedRoomAvatar.tsx
+@@ -34,6 +34,7 @@ import TextWithTooltip from "../elements/TextWithTooltip";
+ import DMRoomMap from "../../../utils/DMRoomMap";
+ import { IOOBData } from "../../../stores/ThreepidInviteStore";
+ import TooltipTarget from "../elements/TooltipTarget";
++import TchapRoomUtils from "../../../../../../src/util/TchapRoomUtils";
+ 
+ interface IProps {
+     room: Room;
+@@ -173,7 +174,10 @@ export default class DecoratedRoomAvatar extends React.PureComponent<IProps, ISt
+             }
+         } else {
+             // Track publicity
+-            icon = this.isPublicRoom ? Icon.Globe : Icon.None;
++            //icon = this.isPublicRoom ? Icon.Globe : Icon.None;
++            //:tchap: use our definition of public room instead (= forum)
++            icon = TchapRoomUtils.isRoomOfTypeForum(this.props.room.roomId) ? Icon.Globe : Icon.None;
++            //end of :tchap:
+             if (!this.isWatchingTimeline) {
+                 this.props.room.on(RoomEvent.Timeline, this.onRoomTimeline);
+                 this.isWatchingTimeline = true;

--- a/src/@types/tchap.ts
+++ b/src/@types/tchap.ts
@@ -3,6 +3,7 @@ export enum TchapRoomType {
   Private = "private",
   External = "external",
   Forum = "forum",
+  Unknown = "unknown",
 }
 
 export enum TchapRoomAccessRule {

--- a/src/util/TchapRoomUtils.ts
+++ b/src/util/TchapRoomUtils.ts
@@ -24,6 +24,7 @@ export default class TchapRoomUtils {
         if (tchapRoomAccessRule === TchapRoomAccessRule.Unrestricted) {
             return TchapRoomType.External;
         }
+        return TchapRoomType.Unknown;
     }
 
     /**

--- a/src/util/TchapRoomUtils.ts
+++ b/src/util/TchapRoomUtils.ts
@@ -1,0 +1,56 @@
+
+/**
+ * Tchap Room utils.
+ */
+
+import { Room } from "matrix-js-sdk/src/matrix";
+import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
+
+import { TchapRoomAccessRule, TchapRoomAccessRulesEventId, TchapRoomType } from "../@types/tchap";
+
+export default class TchapRoomUtils {
+    //inspired by https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/main/java/fr/gouv/tchap/core/utils/RoomUtils.kt#L31
+    //direct type is not handled yet
+    static getTchapRoomType(isEncrypted: boolean, tchapRoomAccessRule?: string): TchapRoomType {
+        if (!isEncrypted) {
+            return TchapRoomType.Forum;
+        }
+        if (!tchapRoomAccessRule) {
+            return TchapRoomType.Unknown;
+        }
+        if (tchapRoomAccessRule === TchapRoomAccessRule.Restricted) {
+            return TchapRoomType.Private;
+        }
+        if (tchapRoomAccessRule === TchapRoomAccessRule.Unrestricted) {
+            return TchapRoomType.External;
+        }
+    }
+
+    /**
+     * Get Tchap Room Access Rule
+     * @param room
+     * @returns string that matches of one TchapRoomAccessRule //todo or null? or empty?
+     */
+    static getTchapRoomAccessRule(room: Room): string {
+        return room.currentState.getStateEvents(TchapRoomAccessRulesEventId, "")?.getContent().rule;
+    }
+
+    /**
+     * Is room encrypted? search in local storage or in server if needed
+     * @param roomId 
+     * @returns true if room is encrypted, false if not
+     */
+    static isRoomEncrypted(roomId: string): boolean {
+        return MatrixClientPeg.get().isRoomEncrypted(roomId);
+    }
+
+
+    /**
+     * Helper method
+     * @returns true of room is a Forum
+     */
+    static isRoomOfTypeForum(roomId: string): boolean {
+        const isRoomEncrypted: boolean = TchapRoomUtils.isRoomEncrypted(roomId);//is this ressource consuming?
+        return TchapRoomUtils.getTchapRoomType(isRoomEncrypted) === TchapRoomType.Forum;
+    }
+}

--- a/test/unit-tests/util/TchapRoomUtils-test.ts
+++ b/test/unit-tests/util/TchapRoomUtils-test.ts
@@ -1,0 +1,22 @@
+
+import { TchapRoomType } from '../../../src/@types/tchap';
+import TchapRoomUtils from '../../../src/util/TchapRoomUtils';
+
+
+describe("Provides utils method to get room type and state", () => {
+
+    beforeEach(() => {
+    });
+
+    it("returns room type depending on encryption and access rule", (done) => {
+        expect(TchapRoomUtils.getTchapRoomType(true, "restricted")).toStrictEqual(TchapRoomType.Private);
+        expect(TchapRoomUtils.getTchapRoomType(true, "unrestricted")).toStrictEqual(TchapRoomType.External);
+        expect(TchapRoomUtils.getTchapRoomType(false)).toStrictEqual(TchapRoomType.Forum);
+        expect(TchapRoomUtils.getTchapRoomType(true)).toStrictEqual(TchapRoomType.Unknown);
+        expect(TchapRoomUtils.getTchapRoomType(true, "any")).toStrictEqual(TchapRoomType.Unknown);
+        expect(TchapRoomUtils.getTchapRoomType(true, undefined)).toStrictEqual(TchapRoomType.Unknown);
+        done();
+    });
+
+    
+})


### PR DESCRIPTION
Right now, globe icon is shown on forum and private room regardless of encryption or not. 

Before : 
![Capture d’écran 2022-10-13 - v2](https://user-images.githubusercontent.com/4077729/195373309-94b2fbc6-9c2f-44b1-af8f-22d59d1a363c.png)


After,  globe is only shown on not encrypted room = FORUM on Tchap
![Capture d’écran 2022-10-13 à 10 46 29](https://user-images.githubusercontent.com/4077729/195548891-eed48162-c55a-4694-854a-3d2e3e0b2a9d.png)

