### PR TITLE
Extend cypress timeout in CI

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -40,6 +40,8 @@ jobs:
           start: yarn start
           #start: npx serve -p 8080 webapp # If you have downloaded a build artifact, it will be in webapp dir.
           wait-on: 'http://localhost:8080'
+          # wait for 3min, the build is long
+          wait-on-timeout: 180
           # record: true # todo record to dashboard, see action's doc
           command: 'yarn test:cypress'
         env:


### PR DESCRIPTION
Extend timeout because half the time, when cypress ci fails it's because it timed out while waiting for yarn start.
Set to 180s instead of 90s.

Result : From the cypress job log :
<img width="587" alt="image" src="https://user-images.githubusercontent.com/911434/196744341-de81e510-3019-4f3d-a227-309b8aea7549.png">
