### PR TITLE
Order rooms by activity by default

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -64,6 +64,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "MessageComposerInput.showPollsButton": false,
+        "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
         "custom_themes": [

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -54,6 +54,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "MessageComposerInput.showPollsButton": false,
+        "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
         "custom_themes": [

--- a/config.prod.json
+++ b/config.prod.json
@@ -162,6 +162,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "MessageComposerInput.showPollsButton": false,
+        "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
         "custom_themes": [

--- a/config.sample.json
+++ b/config.sample.json
@@ -63,6 +63,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "MessageComposerInput.showPollsButton": false,
+        "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "custom_themes": [
             {


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/214

Before : rooms and favorites sorted by alphabetical order by default : 
<img width="575" alt="Screen Shot 2022-10-20 at 9 23 47 AM" src="https://user-images.githubusercontent.com/911434/196884842-bcb87e1f-7e9a-40a4-aa90-b37832bbb1e1.png">

After : rooms and favorites sorted by activity by default. 
<img width="285" alt="Screen Shot 2022-10-20 at 9 27 48 AM" src="https://user-images.githubusercontent.com/911434/196884856-b2da3e46-343a-491a-818a-67ea2dc4587d.png">

Note : 
 - if the user changes the setting in the menu by hand, their preference is saved. Which is good.
 - DMs are already sorted by activity by default.
 - There is a checkbox for "Unread first" (RoomList.orderByImportance), which I didn't use by default because it's too complicated. It sorts by unread first AND by the other sorting criteria, so you can have unread first AND alphabetical. Too nerdy for a default.