### PR TITLE
Abort apply_patches.sh when a patch fails

### DIFF
--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -5,6 +5,6 @@ set -e
 
 for d in patches/*/ ; do
     echo "Patching $d..."
-    yarn patch-package --patch-dir "$d"
+    yarn patch-package --patch-dir "$d" --error-on-fail
     echo "...$d done."
 done


### PR DESCRIPTION
Before : 
When one of the patches failed to be applied, the script continued anyway.
```
patch-package finished with 1 error(s).
✨  Done in 0.70s.
```

After :
When one of the patches fails to be applied, `yarn postinstall` aborts with exit code 1. The next patches are not installed. (hopefully any CI jobs will crash at that point as well, not tested)

```
patch-package finished with 1 error(s).
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```