### PR TITLE
Check the patch file is valid before applying patches in postinstall

### DIFF
--- a/scripts/apply_patches.sh
+++ b/scripts/apply_patches.sh
@@ -3,6 +3,8 @@
 # Script to apply the patches in patches directory, using patch-package.
 set -e
 
+node scripts/checkPatchFile.js
+
 for d in patches/*/ ; do
     echo "Patching $d..."
     yarn patch-package --patch-dir "$d"

--- a/scripts/checkPatchFile.js
+++ b/scripts/checkPatchFile.js
@@ -1,0 +1,27 @@
+function checkPatchFile(patchFile) {
+  console.log("Checking patch file is valid...");
+  const findFirstDuplicate = (arr) => {
+    let sorted_arr = arr.slice().sort();
+    for (let i = 0; i < sorted_arr.length - 1; i++) {
+      if (sorted_arr[i + 1] == sorted_arr[i]) {
+        return sorted_arr[i];
+      }
+    }
+    return;
+  }
+
+  let fileList = []
+  Object.values(patchFile).forEach(patchInfo => {
+    fileList = fileList.concat(patchInfo.files);
+  });
+  const dup = findFirstDuplicate(fileList);
+  if (dup) {
+    console.error("This file is used in two different patches:", dup);
+    console.error("The changes of the two packages will be mixed up. Don't do this.");
+    process.exit(1);
+  }
+  console.log("... patch file is valid.");
+};
+
+const patchFile = require('../patches/patches.json');
+checkPatchFile(patchFile);

--- a/scripts/makePatch.ts
+++ b/scripts/makePatch.ts
@@ -9,31 +9,8 @@ if (process.argv.length !== 3) {
   process.exit(1);
 }
 
-const checkPatchFile = (patchFile) => {
-  console.log("Checking patch file is valid...");
-  const findFirstDuplicate = (arr) => {
-    let sorted_arr = arr.slice().sort();
-    for (let i = 0; i < sorted_arr.length - 1; i++) {
-      if (sorted_arr[i + 1] == sorted_arr[i]) {
-        return sorted_arr[i];
-      }
-    }
-    return;
-  }
-
-  let fileList = []
-  Object.values(patchFile).forEach(patchInfo => {
-    fileList = fileList.concat(patchInfo.files);
-  });
-  const dup = findFirstDuplicate(fileList);
-  if (dup) {
-    console.error("This file is used in two different patches:", dup);
-    console.error("The changes of the two packages will be mixed up. Don't do this.");
-    process.exit(1);
-  }
-  console.log("... patch file is valid.");
-};
-checkPatchFile(patchFile);
+// Run patch file check.
+require('./checkPatchFile');
 
 const patchName = process.argv[2];
 const patchInfo = patchFile[patchName];


### PR DESCRIPTION
`yarn postinstall` applies the patches by running `apply_patches.sh`.
Add a step in apply_patches which checks that the patches.json file is valid.
This is to avoid a case where we have the same file in multiple patches. 