### PR TITLE
Implement registration

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -56,7 +56,7 @@
         "breadcrumbs": true,
         "UIFeature.voip": false,
         "UIFeature.shareSocial": false,
-        "UIFeature.registration": false,
+        "UIFeature.registration": true,
         "UIFeature.urlPreviews": false,
         "UIFeature.widgets": false,
         "UIFeature.shareQrCode": false,

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -46,7 +46,7 @@
         "breadcrumbs": true,
         "UIFeature.voip": false,
         "UIFeature.shareSocial": false,
-        "UIFeature.registration": false,
+        "UIFeature.registration": true,
         "UIFeature.urlPreviews": false,
         "UIFeature.widgets": false,
         "UIFeature.shareQrCode": false,

--- a/config.prod.json
+++ b/config.prod.json
@@ -154,7 +154,7 @@
         "breadcrumbs": true,
         "UIFeature.voip": false,
         "UIFeature.shareSocial": false,
-        "UIFeature.registration": false,
+        "UIFeature.registration": true,
         "UIFeature.urlPreviews": false,
         "UIFeature.widgets": false,
         "UIFeature.shareQrCode": false,

--- a/config.sample.json
+++ b/config.sample.json
@@ -55,7 +55,7 @@
         "breadcrumbs": true,
         "UIFeature.voip": false,
         "UIFeature.shareSocial": false,
-        "UIFeature.registration": false,
+        "UIFeature.registration": true,
         "UIFeature.urlPreviews": false,
         "UIFeature.widgets": false,
         "UIFeature.shareQrCode": false,

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -96,6 +96,13 @@
       "src/components/views/auth/PasswordLogin.tsx"
     ]
   },
+  "registration": {
+    "package": "matrix-react-sdk",
+    "files": [
+      "src/components/structures/auth/Registration.tsx",
+      "src/components/views/auth/RegistrationForm.tsx"
+    ]
+  },
   "password-policy": {
     "package": "matrix-react-sdk",
     "files": [

--- a/patches/registration/matrix-react-sdk+3.58.1.patch
+++ b/patches/registration/matrix-react-sdk+3.58.1.patch
@@ -1,0 +1,109 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
+index b577011..d778e6e 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
+@@ -38,8 +38,10 @@ import InteractiveAuth, { InteractiveAuthCallback } from "../InteractiveAuth";
+ import Spinner from "../../views/elements/Spinner";
+ import { AuthHeaderDisplay } from './header/AuthHeaderDisplay';
+ import { AuthHeaderProvider } from './header/AuthHeaderProvider';
++import { AuthHeaderModifier } from './header/AuthHeaderModifier'; // :TCHAP:
+ import SettingsStore from '../../../settings/SettingsStore';
+ import { ValidatedServerConfig } from '../../../utils/ValidatedServerConfig';
++import TchapUtils from '../../../../../../src/util/TchapUtils';
+ 
+ const debuglog = (...args: any[]) => {
+     if (SettingsStore.getValue("debug_registration")) {
+@@ -273,11 +275,22 @@ export default class Registration extends React.Component<IProps, IState> {
+     }
+ 
+     private onFormSubmit = async (formVals: Record<string, string>): Promise<void> => {
++        const server = await TchapUtils.fetchHomeserverForEmail(formVals.email);
++        const validatedServerConfig = TchapUtils.makeValidatedServerConfig(server);
++        // Note : onServerConfigChange triggers a state change at the matrixChat level. All the children are rerendered.
++        this.props.onServerConfigChange(validatedServerConfig);
++
+         this.setState({
+             errorText: "",
+             busy: true,
+             formVals,
+             doingUIAuth: true,
++            // :TCHAP: pass a new temporary client so that InteractiveAuth is set up with the right serverconfig.
++            matrixClient: createClient({
++                baseUrl: validatedServerConfig.hsUrl,
++                idBaseUrl: validatedServerConfig.isUrl,
++            }),
++            // end :TCHAP:
+         });
+     };
+ 
+@@ -286,7 +299,10 @@ export default class Registration extends React.Component<IProps, IState> {
+             emailAddress,
+             clientSecret,
+             sendAttempt,
+-            this.props.makeRegistrationUrl({
++            // :TCHAP: replace with custom registrationUrl, see TchapUtils.makeTchapRegistrationUrl for info.
++            // this.props.makeRegistrationUrl({
++            TchapUtils.makeTchapRegistrationUrl({
++            // end :TCHAP:
+                 client_secret: clientSecret,
+                 hs_url: this.state.matrixClient.getHomeserverUrl(),
+                 is_url: this.state.matrixClient.getIdentityServerUrl(),
+@@ -491,7 +507,7 @@ export default class Registration extends React.Component<IProps, IState> {
+                 sessionId={this.props.sessionId}
+                 clientSecret={this.props.clientSecret}
+                 emailSid={this.props.idSid}
+-                poll={true}
++                poll={/*true :TCHAP: polling results in M_THREEPID_IN_USE when account is created. Until we solve it, we disable polling. */ false}
+             />;
+         } else if (!this.state.matrixClient && !this.state.busy) {
+             return null;
+@@ -651,6 +667,12 @@ export default class Registration extends React.Component<IProps, IState> {
+                         { errorText }
+                         { serverDeadSection }
+                     </AuthHeaderDisplay>
++                    { /* :TCHAP: remove the serverpicker, using AuthHeaderModifier. Inspired by InteractiveAuthEntryComponents. */}
++                    <AuthHeaderModifier
++                        title={_t('Create account') /* we actually don't want to set this. */}
++                        hideServerPicker={true}
++                    />
++                    { /* end :TCHAP: */}
+                     { this.renderRegisterComponent() }
+                 </div>
+                 <div className="mx_Register_footerActions">
+diff --git a/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx b/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
+index d1f7c9a..36d09b5 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
+@@ -262,7 +262,7 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+     };
+ 
+     private validateEmailRules = withValidation({
+-        description: () => _t("Use an email address to recover your account"),
++        // :TCHAP: this is confusing because email=username in the Tchap case. // description: () => _t("Use an email address to recover your account"),
+         hideDescriptionIfValid: true,
+         rules: [
+             {
+@@ -270,7 +270,10 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+                 test(this: RegistrationForm, { value, allowEmpty }) {
+                     return allowEmpty || !this.authStepIsRequired('m.login.email.identity') || !!value;
+                 },
+-                invalid: () => _t("Enter email address (required on this homeserver)"),
++                // :TCHAP: don't mention homeserver, Tchap hides the concept from users.
++                //invalid: () => _t("Enter email address (required on this homeserver)"),
++                invalid: () => _t("Enter email address"),
++                // end :TCHAP:
+             },
+             {
+                 key: "email",
+@@ -546,9 +549,11 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+         return (
+             <div>
+                 <form onSubmit={this.onSubmit}>
++                    { /* :TCHAP: remove username field, the server will generate it from email.
+                     <div className="mx_AuthBody_fieldRow">
+                         { this.renderUsername() }
+                     </div>
++                    end :TCHAP: */}
+                     <div className="mx_AuthBody_fieldRow">
+                         { this.renderPassword() }
+                         { this.renderPasswordConfirm() }

--- a/patches/registration/matrix-react-sdk+3.58.1.patch
+++ b/patches/registration/matrix-react-sdk+3.58.1.patch
@@ -71,7 +71,7 @@ index b577011..d778e6e 100644
                  </div>
                  <div className="mx_Register_footerActions">
 diff --git a/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx b/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
-index d1f7c9a..36d09b5 100644
+index d1f7c9a..4591d9d 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
 @@ -262,7 +262,7 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
@@ -95,7 +95,7 @@ index d1f7c9a..36d09b5 100644
              },
              {
                  key: "email",
-@@ -546,9 +549,11 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+@@ -546,18 +549,22 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
          return (
              <div>
                  <form onSubmit={this.onSubmit}>
@@ -103,7 +103,23 @@ index d1f7c9a..36d09b5 100644
                      <div className="mx_AuthBody_fieldRow">
                          { this.renderUsername() }
                      </div>
+-                    <div className="mx_AuthBody_fieldRow">
+-                        { this.renderPassword() }
+-                        { this.renderPasswordConfirm() }
+-                    </div>
 +                    end :TCHAP: */}
++                    { /** :TCHAP: switch fields : email first, password under */}
                      <div className="mx_AuthBody_fieldRow">
-                         { this.renderPassword() }
-                         { this.renderPasswordConfirm() }
+                         { this.renderEmail() }
+                         { this.renderPhoneNumber() }
+                     </div>
+-                    { emailHelperText }
++                    <div className="mx_AuthBody_fieldRow">
++                        { this.renderPassword() }
++                        { this.renderPasswordConfirm() }
++                    </div>
++                    { /* end :TCHAP: */}
++                    { /** :TCHAP: remove helper text, adds confusion since email=username in tchap. // emailHelperText */ }
+                     { registerButton }
+                 </form>
+             </div>

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -148,7 +148,7 @@
   },
   "a minimum of %(number)s characters": {
     "en": "a minimum of %(number)s characters",
-    "fr": "8 caractères au minimum"
+    "fr": "%(number)s caractères au minimum"
   },
   "a number": {
     "en": "a number",

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -59,6 +59,11 @@ export default class TchapUtils {
         return homeServerList[Math.floor(Math.random() * homeServerList.length)];
     };
 
+    /**
+     * Find the homeserver corresponding to the given email.
+     * @param email Note : if email is invalid, this function still works and returns the externs server. (todo : fix)
+     * @returns
+     */
     static fetchHomeserverForEmail = async (email: string): Promise<void | {base_url: string, server_name: string}> => {
         const randomHomeServer = this.randomHomeServer();
         const infoUrl = "/_matrix/identity/api/v1/info?medium=email&address=";
@@ -83,6 +88,12 @@ export default class TchapUtils {
             });
     };
 
+    /**
+     * Make a ValidatedServerConfig from the server urls.
+     * Todo : merge this function with fetchHomeserverForEmail, they are always used together anyway.
+     * @param
+     * @returns
+     */
     static makeValidatedServerConfig = (serverConfig): ValidatedServerConfig => {
         const discoveryResult = {
             "m.homeserver": {

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -122,14 +122,4 @@ export default class TchapUtils {
         const cli = MatrixClientPeg.get();
         return cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing");
     }
-
-    /**
-     * Generate username from email, to make the matrixId with.
-     * Example : for matrixId @rick.sanchez-crazy.gouv.fr:agent.ssi.tchap.gouv.fr, the username is rick.sanchez-crazy.gouv.fr
-     * @param email example : rick.sanchez@crazy.gouv.fr. Email can be invalid at this point.
-     */
-    static makeUsername = (email: string) => {
-        // todo : should this be more complicated ? Go check in v2 code.
-        return email.replace("@", "-");
-    };
 }

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -122,4 +122,14 @@ export default class TchapUtils {
         const cli = MatrixClientPeg.get();
         return cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing");
     }
+
+    /**
+     * Generate username from email, to make the matrixId with.
+     * Example : for matrixId @rick.sanchez-crazy.gouv.fr:agent.ssi.tchap.gouv.fr, the username is rick.sanchez-crazy.gouv.fr
+     * @param email example : rick.sanchez@crazy.gouv.fr. Email can be invalid at this point.
+     */
+    static makeUsername = (email: string) => {
+        // todo : should this be more complicated ? Go check in v2 code.
+        return email.replace("@", "-");
+    };
 }

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -122,4 +122,27 @@ export default class TchapUtils {
         const cli = MatrixClientPeg.get();
         return cli.doesServerSupportUnstableFeature("org.matrix.e2e_cross_signing");
     }
+
+    /**
+     * @returns string The url to pass in next_link during registration. Compared to element-web, the hostname
+     * is the homeserver instead of the tchap-web server. This changes the flow to avoid the redirection to
+     * tchap-web, because tchap-web gets a "M_THREEPID_IN_USE" error from backend which is confusing.
+     * We should fix this bug and remove this custom function.
+     */
+    static makeTchapRegistrationUrl(
+        params: {client_secret: string, hs_url: string, is_url: string, session_id: string}): string {
+        let url: string = params.hs_url + window.location.pathname + '#/register';
+
+        const keys = Object.keys(params);
+        for (let i = 0; i < keys.length; ++i) {
+            if (i === 0) {
+                url += '?';
+            } else {
+                url += '&';
+            }
+            const k = keys[i];
+            url += k + '=' + encodeURIComponent(params[k]);
+        }
+        return url;
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/275

The full flow in element-web is a bit better than the flow in v2 : when the user clicks the link in email, they are redirected to the login page.

However, this implementation is reverting back to the v2 implementation, where the clicked link displays a confirmation page served by the backend, and then the user has to go back to login by hand.

This is because of a bug : after the redirect, element-web gets the status of the account creation by doing a `POST /register`. But in the Tchap case this request returns an error, `M_THREEPID_IN_USE: email is already in use`, even though the account is successfully created. https://github.com/tchapgouv/tchap-web-v4/issues/280
So we work around this problem for the moment by removing the redirect, and thus we are back to the v2 flow for now.

Review notes : 
 - For easier reviewing of the patch, you can look at the PR on react-sdk instead : https://github.com/tchapgouv/matrix-react-sdk-fork/pull/2/files
 - the review app is on the prod backend. Mainlined backends fail : https://github.com/tchapgouv/tchap-web-v4/issues/281
