### PR TITLE
Linter fix : deprecation warning for enzyme

### DIFF
--- a/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars deprecate/import
+// eslint-disable-next-line deprecate/import
 import { mount, ReactWrapper } from 'enzyme';
 import { act } from 'react-dom/test-utils';
 import toJson from 'enzyme-to-json';


### PR DESCRIPTION
We still use enzyme for tests for now, even though element-web has deprecated it. Future tests will move away from it.
So remove the deprecation warning for now.