### PR TITLE
88 add expiration account panel

### DIFF
--- a/patches/activate-expired-account-panel/matrix-js-sdk+21.0.0.patch
+++ b/patches/activate-expired-account-panel/matrix-js-sdk+21.0.0.patch
@@ -1,42 +1,53 @@
 diff --git a/node_modules/matrix-js-sdk/src/http-api/fetch.ts b/node_modules/matrix-js-sdk/src/http-api/fetch.ts
-index 4fecaae..40624fe 100644
+index 4fecaae..1ba0830 100644
 --- a/node_modules/matrix-js-sdk/src/http-api/fetch.ts
 +++ b/node_modules/matrix-js-sdk/src/http-api/fetch.ts
-@@ -164,6 +164,8 @@ export class FetchHttpApi<O extends IHttpOpts> {
-                 this.eventEmitter.emit(HttpApiEvent.SessionLoggedOut, err);
+@@ -165,6 +165,12 @@ export class FetchHttpApi<O extends IHttpOpts> {
              } else if (err.errcode == 'M_CONSENT_NOT_GIVEN') {
                  this.eventEmitter.emit(HttpApiEvent.NoConsent, err.message, err.data.consent_uri);
-+            }else if (err.errcode == 'ORG_MATRIX_EXPIRED_ACCOUNT') {
-+                this.eventEmitter.emit(HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT, err);
              }
++            //:tchap: this error is sent by the synapse module (synapse-email-account-validity)[https://github.com/matrix-org/synapse-email-account-validity] 
++            // when user account has expired
++            else if (err.errcode == 'ORG_MATRIX_EXPIRED_ACCOUNT') {
++                this.eventEmitter.emit(HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT, err);
++            }
++            //:tchap end
          });
  
+         // return the original promise, otherwise tests break due to it having to
 diff --git a/node_modules/matrix-js-sdk/src/http-api/interface.ts b/node_modules/matrix-js-sdk/src/http-api/interface.ts
-index c798bec..aa74be8 100644
+index c798bec..9ff3836 100644
 --- a/node_modules/matrix-js-sdk/src/http-api/interface.ts
 +++ b/node_modules/matrix-js-sdk/src/http-api/interface.ts
-@@ -58,11 +58,13 @@ export interface IContentUri {
+@@ -58,11 +58,18 @@ export interface IContentUri {
  export enum HttpApiEvent {
      SessionLoggedOut = "Session.logged_out",
      NoConsent = "no_consent",
++    //:tchap: this error is sent by the synapse module (synapse-email-account-validity)[https://github.com/matrix-org/synapse-email-account-validity] 
++    //when user account has expired
 +    ORG_MATRIX_EXPIRED_ACCOUNT = "ORG_MATRIX_EXPIRED_ACCOUNT",
++    //:tchap end
  }
  
  export type HttpApiEventHandlerMap = {
      [HttpApiEvent.SessionLoggedOut]: (err: MatrixError) => void;
      [HttpApiEvent.NoConsent]: (message: string, consentUri: string) => void;
++    //:tchap: this error is sent by the synapse module (synapse-email-account-validity)[https://github.com/matrix-org/synapse-email-account-validity] 
++    //when user account has expired
 +    [HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT]: (err: MatrixError) => void;
  };
  
  export interface UploadProgress {
 diff --git a/node_modules/matrix-js-sdk/src/sync.ts b/node_modules/matrix-js-sdk/src/sync.ts
-index c8f2545..d8997f6 100644
+index c8f2545..aad8831 100644
 --- a/node_modules/matrix-js-sdk/src/sync.ts
 +++ b/node_modules/matrix-js-sdk/src/sync.ts
-@@ -541,6 +541,12 @@ export class SyncApi {
+@@ -541,6 +541,14 @@ export class SyncApi {
              this.updateSyncState(SyncState.Error, { error });
              return true;
          }
++        //:tchap: this error is sent by (synapse-email-account-validity)[https://github.com/matrix-org/synapse-email-account-validity] 
++        // when user account has expired. client must be stopped and sync aborted when the user account is not valid anymore
 +        if (error.errcode === "ORG_MATRIX_EXPIRED_ACCOUNT") {
 +            // The account is expired
 +            this.stop();

--- a/patches/activate-expired-account-panel/matrix-js-sdk+21.0.0.patch
+++ b/patches/activate-expired-account-panel/matrix-js-sdk+21.0.0.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/matrix-js-sdk/src/http-api/fetch.ts b/node_modules/matrix-js-sdk/src/http-api/fetch.ts
+index 4fecaae..40624fe 100644
+--- a/node_modules/matrix-js-sdk/src/http-api/fetch.ts
++++ b/node_modules/matrix-js-sdk/src/http-api/fetch.ts
+@@ -164,6 +164,8 @@ export class FetchHttpApi<O extends IHttpOpts> {
+                 this.eventEmitter.emit(HttpApiEvent.SessionLoggedOut, err);
+             } else if (err.errcode == 'M_CONSENT_NOT_GIVEN') {
+                 this.eventEmitter.emit(HttpApiEvent.NoConsent, err.message, err.data.consent_uri);
++            }else if (err.errcode == 'ORG_MATRIX_EXPIRED_ACCOUNT') {
++                this.eventEmitter.emit(HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT, err);
+             }
+         });
+ 
+diff --git a/node_modules/matrix-js-sdk/src/http-api/interface.ts b/node_modules/matrix-js-sdk/src/http-api/interface.ts
+index c798bec..aa74be8 100644
+--- a/node_modules/matrix-js-sdk/src/http-api/interface.ts
++++ b/node_modules/matrix-js-sdk/src/http-api/interface.ts
+@@ -58,11 +58,13 @@ export interface IContentUri {
+ export enum HttpApiEvent {
+     SessionLoggedOut = "Session.logged_out",
+     NoConsent = "no_consent",
++    ORG_MATRIX_EXPIRED_ACCOUNT = "ORG_MATRIX_EXPIRED_ACCOUNT",
+ }
+ 
+ export type HttpApiEventHandlerMap = {
+     [HttpApiEvent.SessionLoggedOut]: (err: MatrixError) => void;
+     [HttpApiEvent.NoConsent]: (message: string, consentUri: string) => void;
++    [HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT]: (err: MatrixError) => void;
+ };
+ 
+ export interface UploadProgress {
+diff --git a/node_modules/matrix-js-sdk/src/sync.ts b/node_modules/matrix-js-sdk/src/sync.ts
+index c8f2545..d8997f6 100644
+--- a/node_modules/matrix-js-sdk/src/sync.ts
++++ b/node_modules/matrix-js-sdk/src/sync.ts
+@@ -541,6 +541,12 @@ export class SyncApi {
+             this.updateSyncState(SyncState.Error, { error });
+             return true;
+         }
++        if (error.errcode === "ORG_MATRIX_EXPIRED_ACCOUNT") {
++            // The account is expired
++            this.stop();
++            this.updateSyncState(SyncState.Error, { error });
++            return true;
++        }
+         return false;
+     }
+ 

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -130,5 +130,13 @@
     "files": [
       "src/components/views/rooms/MessageComposer.tsx"
     ]
+  },
+  "activate-expired-account-panel": {
+    "package": "matrix-js-sdk",
+    "files": [
+      "src/http-api/interface.ts",
+      "src/http-api/fetch.ts",
+      "src/sync.ts"
+    ]
   }
 }

--- a/src/app/initTchap.ts
+++ b/src/app/initTchap.ts
@@ -5,7 +5,7 @@ import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
 import TchapVersionManagement from "../util/TchapVersionManagement";
 import TchapUserSettings from "../util/TchapUserSettings";
 import TchapUIFeature from "../util/TchapUIFeature";
-import ExpiredAccountListener from "../lib/ExpiredAccountListener";
+import ExpiredAccountHandler from "../lib/ExpiredAccountHandler";
 /**
  * Determine weither the app needs a clearCacheAndReload after loading. We do it when upgrading from v2 to v4, to avoid weird keys bugs.
  * @returns Promise(true) if a refresh is needed, Promise(false) in other cases
@@ -89,5 +89,5 @@ export function saveAppVersionInLocalStorage() {
 }
 
 export function registerExpiredAccountListener() {
-    ExpiredAccountListener.register();
+    ExpiredAccountHandler.register();
 }

--- a/src/app/initTchap.ts
+++ b/src/app/initTchap.ts
@@ -5,7 +5,7 @@ import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
 import TchapVersionManagement from "../util/TchapVersionManagement";
 import TchapUserSettings from "../util/TchapUserSettings";
 import TchapUIFeature from "../util/TchapUIFeature";
-
+import ExpiredAccountListener from "../lib/ExpiredAccountListener";
 /**
  * Determine weither the app needs a clearCacheAndReload after loading. We do it when upgrading from v2 to v4, to avoid weird keys bugs.
  * @returns Promise(true) if a refresh is needed, Promise(false) in other cases
@@ -86,4 +86,8 @@ export function saveAppVersionInLocalStorage() {
     //:tchap: keep initialising so that we can show any possible error with as many features (theme, i18n) as possible
     TchapVersionManagement.saveAppVersion(PlatformPeg.get());
     //end
+}
+
+export function registerExpiredAccountListener() {
+    ExpiredAccountListener.register();
 }

--- a/src/components/views/dialogs/ExpiredAccountDialog.tsx
+++ b/src/components/views/dialogs/ExpiredAccountDialog.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { _t } from 'matrix-react-sdk/src/languageHandler';
+import BaseDialog from 'matrix-react-sdk/src/components/views/dialogs/BaseDialog';
+import DialogButtons from 'matrix-react-sdk/src/components/views/elements/DialogButtons';
+
+interface IProps {
+    focus: boolean;
+    onFinished();
+    onRequestNewEmail();
+}
+
+interface IState {
+    description: string;
+}
+
+export default class ExpiredAccountDialog extends React.Component<IProps, IState> {
+    constructor(props) {
+        super(props);
+
+        //const displayName = 'ExpiredAccountDialog';
+        this.state = {
+            description: _t('The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.'),
+        };
+    }
+
+    private onOk = async () => {
+        this.props.onFinished();
+    };
+
+    private onResendEmail = () => {
+        this.setState({
+            description: _t('An email has been sent to you. Click on the link it contains, click below.'),
+        });
+        this.props.onRequestNewEmail();
+    };
+
+    /**
+        <a href="#" className="tc_ExpiredAccountDialog_link" onClick={this.props.onLogout}>
+            { _t('Logout') }
+        </a>
+     This code add a Logout button to the Expired Account Modal.
+     Keep it here in case of need.
+     */
+
+    render() {
+        return (
+            <BaseDialog className="mx_QuestionDialog"
+                onFinished={this.props.onFinished}
+                title={_t('The validity period of your account has expired')}
+                contentId='mx_Dialog_content'
+                hasCancel={false}
+            >
+                <div className="mx_Dialog_content" id='mx_Dialog_content'>
+                    <div>
+                        <p> { this.state.description }
+                        </p>
+                    </div>
+                </div>
+                <DialogButtons primaryButton={_t('I renewed the validity of my account')}
+                    primaryButtonClass={null}
+                    cancelButton={null}
+                    hasCancel={false}
+                    onPrimaryButtonClick={this.onOk}
+                    focus={this.props.focus}
+                    onCancel={null}
+                >
+                    <button onClick={this.onResendEmail}>
+                        { _t('Request a renewal email') }
+                    </button>
+                </DialogButtons>
+            </BaseDialog>
+        );
+    }
+}

--- a/src/components/views/dialogs/ExpiredAccountDialog.tsx
+++ b/src/components/views/dialogs/ExpiredAccountDialog.tsx
@@ -5,13 +5,22 @@ import DialogButtons from 'matrix-react-sdk/src/components/views/elements/Dialog
 
 interface IProps {
     onFinished();
-    onRequestNewEmail();
+    onRequestNewEmail(): Promise<any>;
+    emailDelay?: number; //delay betwenn 2 emails in seconds, by default 30
 }
 
 interface IState {
-    description: string;
+    emailDelay: number;//delay betwenn 2 emails in seconds, by default 30
+    isAccountExpired: boolean; //todo: not used yet
+    newEmailSentTimestamp: number;//timestamp
+    newEmailState: EmailState;
 }
 
+enum EmailState {
+    MUST_WAIT,
+    SUCCESS,
+    FAILURE
+}
 /**
  * Expired Account is displayed when the user account is expired. It can not be cancel until the account is renewed.
  * This panel is exclusively opened by the listener ExpiredAccountHandler
@@ -21,25 +30,71 @@ interface IState {
 export default class ExpiredAccountDialog extends React.Component<IProps, IState> {
     constructor(props) {
         super(props);
-
         this.state = {
-            // eslint-disable-next-line max-len
-            description: _t('The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.'),
+            isAccountExpired: false,
+            newEmailSentTimestamp: 0,
+            emailDelay: this.props.emailDelay || 30, //seconds
+            newEmailState: undefined,
         };
+    }
+
+    //check if an email can be sent of must wait a bit
+    private mustWait() {
+        return this.state.newEmailSentTimestamp != 0
+            && (Date.now() - this.state.newEmailSentTimestamp < this.state.emailDelay*1000);
     }
 
     private onOk = async () => {
         this.props.onFinished();
     };
 
-    private onResendEmail = () => {
-        this.props.onRequestNewEmail();
-        this.setState({
-            description: _t('An email has been sent to you. Click on the link it contains, click below.'),
+    private onRequestEmail = () => {
+        //check if user must wait before sending a new email
+        if (this.mustWait()) {
+            return this.setState({
+                newEmailState: EmailState.MUST_WAIT,
+            });
+        }
+
+        this.props.onRequestNewEmail().then((success) => {
+            if (!success) {
+                this.setState({
+                    newEmailState: EmailState.FAILURE,
+                });
+            } else {
+                //sucess, save timestamp
+                this.setState({
+                    newEmailSentTimestamp: Date.now(),
+                    newEmailState: EmailState.SUCCESS,
+                });
+            }
         });
     };
 
     render() {
+        let alertMessage = null;
+        switch (this.state.newEmailState) {
+            case EmailState.MUST_WAIT:
+                //don't know which class should decorate this message, it is not really an error
+                //its goal is to avoid users to click twice or more on the button and spam themselves
+                alertMessage = <p className="">{ _t(
+                    "Wait for at least %(wait)s seconds between two emails", { wait: this.state.emailDelay },
+                ) }</p>;
+                break;
+            case EmailState.FAILURE:
+                alertMessage = <p className="text-error">{ _t(
+                    "The email was not sent sucessfully, please retry in a moment",
+                ) }</p>;
+                break;
+            case EmailState.SUCCESS:
+                alertMessage = <p className="text-success">{ _t(
+                    "A new email has been sent",
+                ) }</p>;
+                break;
+            default:
+                break;
+        }
+
         return (
             <BaseDialog className="mx_QuestionDialog"
                 onFinished={this.props.onFinished}
@@ -47,9 +102,10 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
                 contentId='mx_Dialog_content'
                 hasCancel={false} //panel does not offer a "close" button
             >
+                { alertMessage }
                 <div className="mx_Dialog_content" id='mx_Dialog_content'>
                     <div>
-                        <p> { this.state.description }
+                        <p> { _t('An email has been sent to you. Click on the link it contains, click below.') }
                         </p>
                     </div>
                 </div>
@@ -60,7 +116,7 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
                     onPrimaryButtonClick={this.onOk}
                     onCancel={null}
                 >
-                    <button onClick={this.onResendEmail}>
+                    <button onClick={this.onRequestEmail}>
                         { _t('Request a renewal email') }
                     </button>
                 </DialogButtons>

--- a/src/components/views/dialogs/ExpiredAccountDialog.tsx
+++ b/src/components/views/dialogs/ExpiredAccountDialog.tsx
@@ -14,7 +14,7 @@ interface IState {
 
 /**
  * Expired Account is displayed when the user account is expired. It can not be cancel until the account is renewed.
- * This panel is exclusively opened by the listener ExpiredAccountListener
+ * This panel is exclusively opened by the listener ExpiredAccountHandler
 * This component is required when activating the plugin synapse-email-account-validity on the server side:  https://github.com/matrix-org/synapse-email-account-validity
 
  */

--- a/src/components/views/dialogs/ExpiredAccountDialog.tsx
+++ b/src/components/views/dialogs/ExpiredAccountDialog.tsx
@@ -4,7 +4,6 @@ import BaseDialog from 'matrix-react-sdk/src/components/views/dialogs/BaseDialog
 import DialogButtons from 'matrix-react-sdk/src/components/views/elements/DialogButtons';
 
 interface IProps {
-    focus: boolean;
     onFinished();
     onRequestNewEmail();
 }
@@ -13,12 +12,18 @@ interface IState {
     description: string;
 }
 
+/**
+ * Expired Account is displayed when the user account is expired. It can not be cancel until the account is renewed.
+ * This panel is exclusively opened by the listener ExpiredAccountListener
+* This component is required when activating the plugin synapse-email-account-validity on the server side:  https://github.com/matrix-org/synapse-email-account-validity
+
+ */
 export default class ExpiredAccountDialog extends React.Component<IProps, IState> {
     constructor(props) {
         super(props);
 
-        //const displayName = 'ExpiredAccountDialog';
         this.state = {
+            // eslint-disable-next-line max-len
             description: _t('The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.'),
         };
     }
@@ -28,19 +33,11 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
     };
 
     private onResendEmail = () => {
+        this.props.onRequestNewEmail();
         this.setState({
             description: _t('An email has been sent to you. Click on the link it contains, click below.'),
         });
-        this.props.onRequestNewEmail();
     };
-
-    /**
-        <a href="#" className="tc_ExpiredAccountDialog_link" onClick={this.props.onLogout}>
-            { _t('Logout') }
-        </a>
-     This code add a Logout button to the Expired Account Modal.
-     Keep it here in case of need.
-     */
 
     render() {
         return (
@@ -48,7 +45,7 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
                 onFinished={this.props.onFinished}
                 title={_t('The validity period of your account has expired')}
                 contentId='mx_Dialog_content'
-                hasCancel={false}
+                hasCancel={false} //panel does not offer a "close" button
             >
                 <div className="mx_Dialog_content" id='mx_Dialog_content'>
                     <div>
@@ -61,7 +58,6 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
                     cancelButton={null}
                     hasCancel={false}
                     onPrimaryButtonClick={this.onOk}
-                    focus={this.props.focus}
                     onCancel={null}
                 >
                     <button onClick={this.onResendEmail}>

--- a/src/components/views/dialogs/ExpiredAccountDialog.tsx
+++ b/src/components/views/dialogs/ExpiredAccountDialog.tsx
@@ -59,10 +59,6 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
                 ProcessState: ProcessState.ACCOUNT_STILL_EXPIRED,
             });
         } else {
-            //call the onFinished method with a delay of 5 seconds
-            /* setTimeout(() => {
-                this.props.onFinished();
-            }, 5000); */
             this.setState({
                 ProcessState: ProcessState.ACCOUNT_RENEWED,
             });
@@ -77,18 +73,12 @@ export default class ExpiredAccountDialog extends React.Component<IProps, IState
             });
         }
 
+        //send the new email requested
         this.props.onRequestNewEmail().then((success) => {
-            if (!success) {
-                this.setState({
-                    ProcessState: ProcessState.EMAIL_FAILURE,
-                });
-            } else {
-                //sucess, save timestamp
-                this.setState({
-                    newEmailSentTimestamp: Date.now(),
-                    ProcessState: ProcessState.EMAIL_SUCCESS,
-                });
-            }
+            this.setState({
+                newEmailSentTimestamp: success? Date.now() : this.state.newEmailSentTimestamp,
+                ProcessState: success? ProcessState.EMAIL_SUCCESS : ProcessState.EMAIL_FAILURE,
+            });
         });
     };
 

--- a/src/components/views/dialogs/ExpiredAccountDialog.tsx
+++ b/src/components/views/dialogs/ExpiredAccountDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import { _t } from 'matrix-react-sdk/src/languageHandler';
 import BaseDialog from 'matrix-react-sdk/src/components/views/dialogs/BaseDialog';

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -232,10 +232,10 @@
   },
   "The app will reload now": {
     "en": "You can refresh the page to continue your conversations",
-    "fr": "Vous pouvez dorénavant rafraichir la page pour continuer vos conversations"
+    "fr": "Vous pouvez dorénavant rafraîchir la page pour continuer vos conversations"
   },
   "Reload the app": {
     "en": "Reload page",
-    "fr": "Rafraichir la page"
+    "fr": "Rafraîchir la page"
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -193,5 +193,25 @@
   "Save my keys": {
     "en": "Save my keys",
     "fr": "Sauvegarder mes clés"
+  },
+  "The validity period of your account has expired": {
+    "en": "The validity period of your account has expired",
+    "fr": "La durée de validité de votre compte a expiré"
+  },
+  "The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.": {
+    "en": "The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.",
+    "fr": "La durée de validité de votre compte a expiré. Un email vous a été envoyé pour la renouveler. Une fois que vous aurez suivi le lien qu’il contient, cliquez ci-dessous."
+  },
+  "An email has been sent to you. Click on the link it contains, click below.": {
+    "en":  "An email has been sent to you. Once you’ve followed the link it contains, click below.",
+    "fr": "Un e-mail vous a été envoyé. Une fois que vous aurez suivi le lien qu'il contient, cliquez ci-dessous."
+  },
+  "I renewed the validity of my account": {
+    "en":  "I renewed the validity of my account",
+    "fr": "J’ai renouvelé mon compte"
+  },
+  "Request a renewal email": {
+    "en":  "Request a renewal email",
+    "fr": "Demander l’envoi d’un nouvel email"
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -199,11 +199,11 @@
     "fr": "Votre compte Tchap a expiré"
   },
   "An email has been sent to you. Click on the link it contains, click below.": {
-    "en": "An email has been sent to you. Once you’ve followed the link it contains, click below.",
-    "fr": "Un email vous a été envoyé pour renouveler votre compte. Une fois que vous aurez suivi le lien qu'il contient, cliquez ci-dessous."
+    "en": "An email has been sent to you. Its title is : \"Renew your Tchap account\" Once you’ve followed the link it contains, click on the button \"I renewed my account\".",
+    "fr": "Un email vous a été envoyé pour renouveler votre compte. Il est intitulé : \"Renouvelez votre compte Tchap\". Une fois que vous aurez suivi le lien qu'il contient, cliquez sur le bouton \"J’ai renouvelé mon compte\"."
   },
   "I renewed the validity of my account": {
-    "en": "I renewed the validity of my account",
+    "en": "I renewed my account",
     "fr": "J’ai renouvelé mon compte"
   },
   "Request a renewal email": {
@@ -212,7 +212,7 @@
   },
   "A new email has been sent": {
     "en": "A new email has been sent",
-    "fr": "Un nouvel email vous a été adressé"
+    "fr": "Un nouvel email de renouvellement vous a été adressé"
   },
   "Wait for at least %(wait)s seconds between two emails": {
     "en": "Wait for at least %(wait)s seconds between two emails",
@@ -220,6 +220,22 @@
   },
   "The email was not sent sucessfully, please retry in a moment": {
     "en": "The email was not sent sucessfully, please retry",
-    "fr": "L'email n'a pas pu être envoyé, veuillez réessayer"
+    "fr": "L'email de renouvellement n'a pas pu être envoyé, veuillez réessayer"
+  },
+  "Your account is still expired, please follow the link in the email you have received to renew it": {
+    "en": "Your account is still expired, please follow the link in the email you should have received to renew it",
+    "fr": "Votre compte est toujours expiré, merci de cliquer sur le lien reçu dans le mail de renouvellement"
+  },
+  "Congratulations, your account has been renewed": {
+    "en": "Congratulations, your account has been renewed",
+    "fr": "Félicitations, votre compte a été renouvelé"
+  },
+  "The app will reload now": {
+    "en": "You can refresh the page to continue your conversations",
+    "fr": "Vous pouvez dorénavant rafraichir la page pour continuer vos conversations"
+  },
+  "Reload the app": {
+    "en": "Reload page",
+    "fr": "Rafraichir la page"
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -195,23 +195,31 @@
     "fr": "Sauvegarder mes clés"
   },
   "The validity period of your account has expired": {
-    "en": "The validity period of your account has expired",
-    "fr": "La durée de validité de votre compte a expiré"
-  },
-  "The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.": {
-    "en": "The validity period of your account has expired. An email has been sent to you in order to renew it. Once you’ve followed the link it contains, click below.",
-    "fr": "La durée de validité de votre compte a expiré. Un email vous a été envoyé pour la renouveler. Une fois que vous aurez suivi le lien qu’il contient, cliquez ci-dessous."
+    "en": "Your Tchap account has expired",
+    "fr": "Votre compte Tchap a expiré"
   },
   "An email has been sent to you. Click on the link it contains, click below.": {
-    "en":  "An email has been sent to you. Once you’ve followed the link it contains, click below.",
-    "fr": "Un e-mail vous a été envoyé. Une fois que vous aurez suivi le lien qu'il contient, cliquez ci-dessous."
+    "en": "An email has been sent to you. Once you’ve followed the link it contains, click below.",
+    "fr": "Un email vous a été envoyé pour renouveler votre compte. Une fois que vous aurez suivi le lien qu'il contient, cliquez ci-dessous."
   },
   "I renewed the validity of my account": {
-    "en":  "I renewed the validity of my account",
+    "en": "I renewed the validity of my account",
     "fr": "J’ai renouvelé mon compte"
   },
   "Request a renewal email": {
-    "en":  "Request a renewal email",
+    "en": "Request a renewal email",
     "fr": "Demander l’envoi d’un nouvel email"
+  },
+  "A new email has been sent": {
+    "en": "A new email has been sent",
+    "fr": "Un nouvel email vous a été adressé"
+  },
+  "Wait for at least %(wait)s seconds between two emails": {
+    "en": "Wait for at least %(wait)s seconds between two emails",
+    "fr": "Attendez au moins %(wait)s secondes entre l'envoi de deux emails"
+  },
+  "The email was not sent sucessfully, please retry in a moment": {
+    "en": "The email was not sent sucessfully, please retry",
+    "fr": "L'email n'a pas pu être envoyé, veuillez réessayer"
   }
 }

--- a/src/lib/ExpiredAccountHandler.ts
+++ b/src/lib/ExpiredAccountHandler.ts
@@ -13,7 +13,7 @@ import TchapUtils from "../util/TchapUtils"; "matrix-react-sdk/src/dispatcher/di
  * This component is required when activating the plugin synapse-email-account-validity on the server side:  https://github.com/matrix-org/synapse-email-account-validity
  * The class is instantiated in the default export, thus it is created only once at the first import.
  */
-class ExpiredAccountListener {
+class ExpiredAccountHandler {
     private boundOnExpiredAccountEvent: any;//the listener function;
     private dispatcher: MatrixDispatcher;
     private isPanelOpen: boolean;
@@ -76,4 +76,4 @@ class ExpiredAccountListener {
     }
 }
 
-export default new ExpiredAccountListener();
+export default new ExpiredAccountHandler();

--- a/src/lib/ExpiredAccountHandler.ts
+++ b/src/lib/ExpiredAccountHandler.ts
@@ -7,7 +7,7 @@ import Modal from "matrix-react-sdk/src/Modal";
 import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
 
 import ExpiredAccountDialog from "../components/views/dialogs/ExpiredAccountDialog";
-import TchapUtils from "../util/TchapUtils"; "matrix-react-sdk/src/dispatcher/dispatcher";
+import TchapUtils from "../util/TchapUtils";
 
 /*
  * Listens for HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT events and opens the panel ExpiredAccountDialog.

--- a/src/lib/ExpiredAccountListener.ts
+++ b/src/lib/ExpiredAccountListener.ts
@@ -10,8 +10,9 @@ import ExpiredAccountDialog from "../components/views/dialogs/ExpiredAccountDial
 import TchapUtils from "../util/TchapUtils"; "matrix-react-sdk/src/dispatcher/dispatcher";
 
 /*
- * Listens for HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT events in which case, it opens the panel ExpiredAccountDialog.
- * The class is instantiated in the default export, thus it is a singleton object
+ * Listens for HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT events and opens the panel ExpiredAccountDialog.
+ * This component is required when activating the plugin synapse-email-account-validity on the server side:  https://github.com/matrix-org/synapse-email-account-validity
+ * The class is instantiated in the default export, thus it is created only once at the first import.
  */
 class ExpiredAccountListener {
     private boundOnExpiredAccountEvent: any;//the listener function;

--- a/src/lib/ExpiredAccountListener.ts
+++ b/src/lib/ExpiredAccountListener.ts
@@ -1,7 +1,6 @@
 import { HttpApiEvent } from "matrix-js-sdk/src/matrix";
 import { defaultDispatcher, MatrixDispatcher } from "matrix-react-sdk/src/dispatcher/dispatcher";
 import { ActionPayload } from "matrix-react-sdk/src/dispatcher/payloads";
-import { stopMatrixClient } from "matrix-react-sdk/src/Lifecycle";
 import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
 import Modal from "matrix-react-sdk/src/Modal";
 import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
@@ -17,7 +16,6 @@ import TchapUtils from "../util/TchapUtils"; "matrix-react-sdk/src/dispatcher/di
 class ExpiredAccountListener {
     private boundOnExpiredAccountEvent: any;//the listener function;
     private dispatcher: MatrixDispatcher;
-    private newEmailRequested: boolean;
     private isPanelOpen: boolean;
     private isAccountExpired: boolean;
 
@@ -26,7 +24,6 @@ class ExpiredAccountListener {
         this.dispatcher = defaultDispatcher;
         this.isPanelOpen = false;
         this.isAccountExpired = false;
-        this.newEmailRequested = false;
     }
 
     /**
@@ -54,22 +51,15 @@ class ExpiredAccountListener {
             return;
         }
 
-        //stop the client to disable sync
-        stopMatrixClient(false);
         //should we sent the email directly? Normally they should have received already an email 7 days earlier
-        TchapUtils.requestNewExpiredAccountEmail()
-            .then((emailRequested) => {
-                this.newEmailRequested = emailRequested;
-                this.isPanelOpen = true;
-                this.showExpirationPanel();
-            });
+        this.isPanelOpen = true;
+        this.showExpirationPanel();
     }
 
     private async showExpirationPanel() {
         Modal.createDialog(ExpiredAccountDialog, {
-            newEmailRequested: this.newEmailRequested,
+            newEmailRequested: false,
             onRequestNewEmail: () => {
-                this.newEmailRequested = true;
                 TchapUtils.requestNewExpiredAccountEmail();
             },
             //check that the account is not expired when finishing

--- a/src/lib/ExpiredAccountListener.ts
+++ b/src/lib/ExpiredAccountListener.ts
@@ -1,0 +1,85 @@
+import { HttpApiEvent } from "matrix-js-sdk/src/matrix";
+import { defaultDispatcher, MatrixDispatcher } from "matrix-react-sdk/src/dispatcher/dispatcher";
+import { ActionPayload } from "matrix-react-sdk/src/dispatcher/payloads";
+import { stopMatrixClient } from "matrix-react-sdk/src/Lifecycle";
+import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
+import Modal from "matrix-react-sdk/src/Modal";
+import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
+
+import ExpiredAccountDialog from "../components/views/dialogs/ExpiredAccountDialog";
+import TchapUtils from "../util/TchapUtils"; "matrix-react-sdk/src/dispatcher/dispatcher";
+
+class ExpiredAccountListener {
+    private newEmailRequested: boolean;
+    private isExpiredPanelOpen: boolean;
+    private boundOnSyncStateChange: any;
+    private dispatcher: MatrixDispatcher;
+    private isAccountExpired: boolean;
+
+    constructor() {
+        this.isExpiredPanelOpen = false;
+        this.dispatcher = defaultDispatcher;
+        this.isAccountExpired = true;
+    }
+
+    //register the listener after the Matrix Client has been initialized but before it is started
+    public register() {
+        const expiredRegistrationId = this.dispatcher.register(
+            (payload: ActionPayload) => {
+                if (payload.action === "will_start_client") {
+                    console.log(":tchap: register a listener for HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT events");
+                    const cli = MatrixClientPeg.get();
+                    this.boundOnSyncStateChange = this.boundOnSyncStateChange || this.onAccountExpiredError.bind(this);
+                    cli.on(HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT, this.boundOnSyncStateChange);
+                    //unregister callback once the work is done
+                    this.dispatcher.unregister(expiredRegistrationId);
+                }
+            },
+        );
+    }
+
+    public async showExpirationPanel() {
+        Modal.createDialog(ExpiredAccountDialog, {
+            newEmailRequested: this.newEmailRequested,
+            onRequestNewEmail: () => {
+                this.newEmailRequested = true;
+                TchapUtils.requestNewExpiredAccountEmail();
+            },
+            //check that the account is not expired when finishing
+            onFinished: async () => {
+                this.isExpiredPanelOpen = false;
+                PlatformPeg.get().reload();
+            },
+        }, null, false, true, {
+            //close panel only if account is not expired
+            onBeforeClose: async () => {
+                this.isAccountExpired = await TchapUtils.isAccountExpired();
+                return Promise.resolve(!this.isAccountExpired);
+            } });
+    }
+
+    /**
+     * React on Sync State Changed
+     * @param state
+     * @param prevState
+     * @param data
+     */
+    private onAccountExpiredError() {
+        //const cli = MatrixClientPeg.get();
+        //cli.stopClient();
+        MatrixClientPeg.get().stopClient();
+        if (!this.isExpiredPanelOpen) {
+            stopMatrixClient(false);
+            TchapUtils.requestNewExpiredAccountEmail()
+                .then((emailRequested) => {
+                    this.newEmailRequested = emailRequested;
+                    //this.isAccountExpired = await TchapUtils.isAccountExpired();
+                    //MatrixClientPeg.get().store.deleteAllData().done(); why was this done ?
+                    this.isExpiredPanelOpen = true;
+                    this.showExpirationPanel();
+                });
+        }
+    }
+}
+
+export default new ExpiredAccountListener();

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -174,7 +174,8 @@ export default class TchapUtils {
     }
 
     /**
-     * Request a new validation email for expired account.
+     * Request a new validity email for a user account (expired or not).
+    * @returns true if the mail was sent succesfully, false otherwise
      */
     static async requestNewExpiredAccountEmail(): Promise<boolean> {
         console.log(":tchap: Requesting an email to renew to account");
@@ -199,7 +200,9 @@ export default class TchapUtils {
     }
 
     /**
-     * Get the expiration information for an account
+     * Verify if the account is expired.
+     * It executes an API call and check that it receives a ORG_MATRIX_EXPIRED_ACCOUNT
+     * The API invoked is getProfileInfo()
      * @param matrixId the account matrix Id
      * @returns true if account is expired, false otherwise
      */
@@ -207,9 +210,6 @@ export default class TchapUtils {
         if (!matrixId) {
             matrixId = MatrixClientPeg.getCredentials().userId;
         }
-        /* const homeserverUrl = MatrixClientPeg.get().getHomeserverUrl();
-        const accessToken = MatrixClientPeg.get().getAccessToken();
- */
         try {
             await MatrixClientPeg.get().getProfileInfo(matrixId);
         } catch (err) {
@@ -218,22 +218,5 @@ export default class TchapUtils {
             }
         }
         return false;
-
-        //const url = `${homeserverUrl}/_matrix/client/unstable/account_validity/send_mail`;
-        const url = `${homeserverUrl}${TchapApi.expiredInfoUrl(matrixId)}`;
-        const options = {
-            method: 'GET',
-            headers: {
-                Authorization: `Bearer ${accessToken}`,
-            },
-        };
-
-        return fetch(url, options).then((response) => {
-            console.log(":tchap: email isAccountExpired sent", response);
-            return response.json().then((json) => json["org.matrix.expired"]);
-        }).catch((err) => {
-            console.error(":tchap: email isAccountExpired error", err);
-            return false;
-        });
     }
 }

--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -24,7 +24,7 @@ import { logger } from "matrix-js-sdk/src/logger";
 import { parseQsFromFragment } from "./url_utils";
 import './modernizr';
 // eslint-disable-next-line max-len
-import { queueClearCacheAndReload, queueOverideUserSettings, needsRefreshForVersion4, saveAppVersionInLocalStorage } from "../app/initTchap";
+import { queueClearCacheAndReload, queueOverideUserSettings, needsRefreshForVersion4, saveAppVersionInLocalStorage, registerExpiredAccountListener } from "../app/initTchap";
 
 // Require common CSS here; this will make webpack process it into bundle.css.
 // Our own CSS (which is themed) is imported via separate webpack entry points
@@ -239,6 +239,8 @@ async function start() {
         if (needRefreshForV4) {
             queueClearCacheAndReload();
         }
+
+        registerExpiredAccountListener();
         //end of :tchap:
 
         // Finally, load the app. All of the other react-sdk imports are in this file which causes the skinner to


### PR DESCRIPTION
- Users will receive an email when the panel opens ( //should we sent the email directly? Normally they should have received already an email 7 days earlier)
- they can close the dialog only if the account is enable again

----
While trying to login :




----
While in the app : 



Idea to improve UX : the panel refreshes automatically when it detects that the account is enable (by polling)

On dev server, neither the email nor the landing page are tchapitized : 
![Capture d’écran 2022-11-15 à 16 18 17](https://user-images.githubusercontent.com/4077729/201956363-2e2221ad-8af7-409f-8482-d5201b8ec7f7.png)


