### PR TITLE
mainlining fix : do not send username in registration

### DIFF
--- a/patches/patches.json
+++ b/patches/patches.json
@@ -100,7 +100,7 @@
       "src/components/views/auth/PasswordLogin.tsx"
     ]
   },
-  "registration": {
+  "registration-for-mainlining": {
     "package": "matrix-react-sdk",
     "files": [
       "src/components/structures/auth/Registration.tsx",

--- a/patches/registration-for-mainlining/matrix-react-sdk+3.59.0.patch
+++ b/patches/registration-for-mainlining/matrix-react-sdk+3.59.0.patch
@@ -1,0 +1,137 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
+index b577011..2ecc566 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
+@@ -38,8 +38,10 @@ import InteractiveAuth, { InteractiveAuthCallback } from "../InteractiveAuth";
+ import Spinner from "../../views/elements/Spinner";
+ import { AuthHeaderDisplay } from './header/AuthHeaderDisplay';
+ import { AuthHeaderProvider } from './header/AuthHeaderProvider';
++import { AuthHeaderModifier } from './header/AuthHeaderModifier'; // :TCHAP:
+ import SettingsStore from '../../../settings/SettingsStore';
+ import { ValidatedServerConfig } from '../../../utils/ValidatedServerConfig';
++import TchapUtils from '../../../../../../src/util/TchapUtils';
+ 
+ const debuglog = (...args: any[]) => {
+     if (SettingsStore.getValue("debug_registration")) {
+@@ -273,11 +275,22 @@ export default class Registration extends React.Component<IProps, IState> {
+     }
+ 
+     private onFormSubmit = async (formVals: Record<string, string>): Promise<void> => {
++        const server = await TchapUtils.fetchHomeserverForEmail(formVals.email);
++        const validatedServerConfig = TchapUtils.makeValidatedServerConfig(server);
++        // Note : onServerConfigChange triggers a state change at the matrixChat level. All the children are rerendered.
++        this.props.onServerConfigChange(validatedServerConfig);
++
+         this.setState({
+             errorText: "",
+             busy: true,
+             formVals,
+             doingUIAuth: true,
++            // :TCHAP: pass a new temporary client so that InteractiveAuth is set up with the right serverconfig.
++            matrixClient: createClient({
++                baseUrl: validatedServerConfig.hsUrl,
++                idBaseUrl: validatedServerConfig.isUrl,
++            }),
++            // end :TCHAP:
+         });
+     };
+ 
+@@ -286,7 +299,10 @@ export default class Registration extends React.Component<IProps, IState> {
+             emailAddress,
+             clientSecret,
+             sendAttempt,
+-            this.props.makeRegistrationUrl({
++            // :TCHAP: replace with custom registrationUrl, see TchapUtils.makeTchapRegistrationUrl for info.
++            // this.props.makeRegistrationUrl({
++            TchapUtils.makeTchapRegistrationUrl({
++            // end :TCHAP:
+                 client_secret: clientSecret,
+                 hs_url: this.state.matrixClient.getHomeserverUrl(),
+                 is_url: this.state.matrixClient.getIdentityServerUrl(),
+@@ -453,6 +469,11 @@ export default class Registration extends React.Component<IProps, IState> {
+             inhibit_login: undefined,
+         };
+         if (auth) registerParams.auth = auth;
++        //:tchap: do not send username as tchap workflow does not use username
++        // https://github.com/tchapgouv/tchap-web-v4/issues/281
++        registerParams.username = undefined;
++        //:tchap end
++
+         debuglog("Registration: sending registration request:", auth);
+         return this.state.matrixClient.registerRequest(registerParams);
+     };
+@@ -491,7 +512,7 @@ export default class Registration extends React.Component<IProps, IState> {
+                 sessionId={this.props.sessionId}
+                 clientSecret={this.props.clientSecret}
+                 emailSid={this.props.idSid}
+-                poll={true}
++                poll={/*true :TCHAP: polling results in M_THREEPID_IN_USE when account is created. Until we solve it, we disable polling. */ false}
+             />;
+         } else if (!this.state.matrixClient && !this.state.busy) {
+             return null;
+@@ -651,6 +672,12 @@ export default class Registration extends React.Component<IProps, IState> {
+                         { errorText }
+                         { serverDeadSection }
+                     </AuthHeaderDisplay>
++                    { /* :TCHAP: remove the serverpicker, using AuthHeaderModifier. Inspired by InteractiveAuthEntryComponents. */}
++                    <AuthHeaderModifier
++                        title={_t('Create account') /* we actually don't want to set this. */}
++                        hideServerPicker={true}
++                    />
++                    { /* end :TCHAP: */}
+                     { this.renderRegisterComponent() }
+                 </div>
+                 <div className="mx_Register_footerActions">
+diff --git a/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx b/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
+index d1f7c9a..4591d9d 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/auth/RegistrationForm.tsx
+@@ -262,7 +262,7 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+     };
+ 
+     private validateEmailRules = withValidation({
+-        description: () => _t("Use an email address to recover your account"),
++        // :TCHAP: this is confusing because email=username in the Tchap case. // description: () => _t("Use an email address to recover your account"),
+         hideDescriptionIfValid: true,
+         rules: [
+             {
+@@ -270,7 +270,10 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+                 test(this: RegistrationForm, { value, allowEmpty }) {
+                     return allowEmpty || !this.authStepIsRequired('m.login.email.identity') || !!value;
+                 },
+-                invalid: () => _t("Enter email address (required on this homeserver)"),
++                // :TCHAP: don't mention homeserver, Tchap hides the concept from users.
++                //invalid: () => _t("Enter email address (required on this homeserver)"),
++                invalid: () => _t("Enter email address"),
++                // end :TCHAP:
+             },
+             {
+                 key: "email",
+@@ -546,18 +549,22 @@ export default class RegistrationForm extends React.PureComponent<IProps, IState
+         return (
+             <div>
+                 <form onSubmit={this.onSubmit}>
++                    { /* :TCHAP: remove username field, the server will generate it from email.
+                     <div className="mx_AuthBody_fieldRow">
+                         { this.renderUsername() }
+                     </div>
+-                    <div className="mx_AuthBody_fieldRow">
+-                        { this.renderPassword() }
+-                        { this.renderPasswordConfirm() }
+-                    </div>
++                    end :TCHAP: */}
++                    { /** :TCHAP: switch fields : email first, password under */}
+                     <div className="mx_AuthBody_fieldRow">
+                         { this.renderEmail() }
+                         { this.renderPhoneNumber() }
+                     </div>
+-                    { emailHelperText }
++                    <div className="mx_AuthBody_fieldRow">
++                        { this.renderPassword() }
++                        { this.renderPasswordConfirm() }
++                    </div>
++                    { /* end :TCHAP: */}
++                    { /** :TCHAP: remove helper text, adds confusion since email=username in tchap. // emailHelperText */ }
+                     { registerButton }
+                 </form>
+             </div>


### PR DESCRIPTION
When sending an empty username "", the server complains that a user Id must be present.
<img width="708" alt="Capture d’écran 2022-12-07 à 15 04 45" src="https://user-images.githubusercontent.com/4077729/206199835-4ea095e9-0e5e-4b38-b3f3-2ff2c274a08a.png">


Without sending it (setting to undefined in the js object), it works as expected. 

This sequence is similar of the Android client
