### PR TITLE
add translation for decryption error messages

### DIFF
--- a/src/components/views/messages/TchapUnknownBody.tsx
+++ b/src/components/views/messages/TchapUnknownBody.tsx
@@ -14,8 +14,8 @@ export default forwardRef(({ mxEvent, children }: IProps, ref: React.RefObject<H
     // :TCHAP: user-friendly message in the case of lost keys
     const content = mxEvent.getContent();
     if (content.msgtype && content.msgtype === "m.bad.encrypted") {
-        const userFriendlyText =
-            _t("Decryption fail: Please open Tchap on an other connected device to allow key sharing.");
+        const reason = content.body.replace(/\*\* Unable to decrypt: /, '').replace(/ \*\*/, '');
+        const userFriendlyText = _t(reason);
         return (
             <div className="mx_UnknownBody" ref={ref}>
                 { userFriendlyText }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -382,7 +382,6 @@
     "en": "The sender's device has not sent us the keys for this message.",
     "fr": "L'appareil de l'émetteur ne nous a pas envoyé les clés pour ce message."
   },
-  //
   "Message intended for room <room id>":{
     "en": "",
     "fr": ""

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -322,6 +322,102 @@
     "en": "Decryption fail: Please open Tchap on an other connected device to allow key sharing.",
     "fr": "Message verrouillé par sécurité. Récupérez vos clés Tchap pour déverrouiller vos messages."
   },
+  "Unknown encryption algorithm m.olm.v1.curve25519-aes-sha2.":{
+    "en": "Unknown encryption algorithm m.olm.v1.curve25519-aes-sha2.",
+    "fr": "Algorithme de chiffrement inconnu: m.olm.v1.curve25519-aes-sha2."
+  },
+  "Unknown encryption algorithm m.megolm.v1.aes-sha2.":{
+    "en": "Unknown encryption algorithm m.megolm.v1.aes-sha2.",
+    "fr": "Algorithme de chiffrement inconnu: m.megolm.v1.aes-sha2."
+  },
+  "Unknown encryption algorithm m.megolm_backup.v1.curve25519-aes-sha2.":{
+    "en": "Unknown encryption algorithm m.megolm_backup.v1.curve25519-aes-sha2.",
+    "fr": "Algorithme de chiffrement inconnu: m.megolm_backup.v1.curve25519-aes-sha2."
+  },
+  "Encryption not enabled":{
+    "en": "Encryption not enabled",
+    "fr": "Chiffrement non activé"
+  },
+  "decryption key withheld":{
+    "en": "decryption key withheld",
+    "fr": "Clé de déchiffrement retenue"
+  },
+  "The sender has disabled encrypting to unverified devices.":{
+    "en": "The sender has disabled encrypting to unverified devices.",
+    "fr": "L'émetteur a désactivé le déchiffrement sur les appareils non-vérifiés."
+  },
+  "The sender has blocked you.":{
+    "en": "The sender has blocked you.",
+    "fr": "L'émetteur vous a bloqué."
+  },
+  "You are not authorised to read the message.":{
+    "en": "You are not authorised to read the message.",
+    "fr": "Vous n'êtes pas autorisé à lire ce message/"
+  },
+  "Unable to establish a secure channel.":{
+    "en": "Unable to establish a secure channel.",
+    "fr": "Impossible d'établir un tunnel sécurisé."
+  },
+  "Missing fields in input":{
+    "en": "Megolm Missing fields in input",
+    "fr": "Champs nécessaires à l'algorithme Megolm sont manquants dans l'événement."
+  },
+  "Unknown Error: Error is undefined":{
+    "en": "Unknown Error: Error is undefined",
+    "fr": "Erreur inconnue: Erreur non définie"
+  },
+  "Trying to create a new secure channel and re-requesting the keys.":{
+    "en": "Trying to create a new secure channel and re-requesting the keys.",
+    "fr": "En cours de création d'un nouveau tunnel sécurisé et de redemander les clés."
+  },
+  "The sender was unable to establish a secure channel.":{
+    "en": "The sender was unable to establish a secure channel.",
+    "fr": "L'émetteur n'a pas pu établir un tunnel sécurisé."
+  },
+  "The secure channel with the sender was corrupted.":{
+    "en": "The secure channel with the sender was corrupted.",
+    "fr": "Le tunnel sécurisé avec l'émetteur a été corrompu."
+  },
+  "The sender's device has not sent us the keys for this message.":{
+    "en": "The sender's device has not sent us the keys for this message.",
+    "fr": "L'appareil de l'émetteur ne nous a pas envoyé les clés pour ce message."
+  },
+  "Message intended for room <room id>":{
+    "en": "",
+    "fr": ""
+  },
+  "Missing ciphertext":{
+    "en": "Missing ciphertext",
+    "fr": "Texte chiffré manquant dans l'algorithme Olm"
+  },
+  "Not included in recipients":{
+    "en": "Not included in recipients",
+    "fr": "L'algorithme Olm n'est pas inclu dans les appareils destinataires"
+  },
+  "Bad Encrypted Message":{
+    "en": "Bad Encrypted Message",
+    "fr": "Erreur de chiffrement du message"
+  },
+  "Message was intented for <recipient>":{
+    "en": "",
+    "fr": ""
+  },
+  "Message not intended for this device":{
+    "en": "Message not intended for this device",
+    "fr": "Le message n'est pas destiné à votre appareil"
+  },
+  "Message claimed to be from <sender>":{
+    "en": "",
+    "fr": ""
+  },
+  "Message forwarded from <sender>":{
+    "en": "",
+    "fr": ""
+  },
+  "Message intended for room <roomId>":{
+    "en": "",
+    "fr": ""
+  },
   "<requestLink>Re-send a request to your other devices</requestLink>": {
     "en": "<requestLink>Re-send a request to your other devices</requestLink>",
     "fr": "<requestLink>Renvoyer une demande à un autre appareil</requestLink>"

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -352,7 +352,7 @@
   },
   "You are not authorised to read the message.":{
     "en": "You are not authorised to read the message.",
-    "fr": "Vous n'êtes pas autorisé à lire ce message/"
+    "fr": "Vous n'êtes pas autorisé à lire ce message."
   },
   "Unable to establish a secure channel.":{
     "en": "Unable to establish a secure channel.",
@@ -382,6 +382,7 @@
     "en": "The sender's device has not sent us the keys for this message.",
     "fr": "L'appareil de l'émetteur ne nous a pas envoyé les clés pour ce message."
   },
+  //
   "Message intended for room <room id>":{
     "en": "",
     "fr": ""
@@ -414,7 +415,7 @@
     "en": "",
     "fr": ""
   },
-  "Message intended for room <roomId>":{
+  "Message intended for room <rooId>":{
     "en": "",
     "fr": ""
   },


### PR DESCRIPTION
We can only translate static translation (as opposed to parameterized translation) or we could translate the most common errors to start with and add translation when they are coming through support.

benefits : easiest solution as we would have to add to only the translations(only tchap_translations.json) and quickest to implement, easier to maintain also 
drawback : we have a lot of translation which are parameterized and they cannot be covered in a generic way with this solution, and not all errors will be translated but we translate this when the english errors will be highlighted through the support channel

This PR performs the following translations : 
- [x] Unknown encryption algorithm `<algo id>`.
  - [x] Unknown encryption algorithm m.olm.v1.curve25519-aes-sha2.
  - [x] Unknown encryption algorithm m.megolm.v1.aes-sha2.
  - [x] Unknown encryption algorithm m.megolm_backup.v1.curve25519-aes-sha2.
- [x] Encryption not enabled
- [x] decryption key withheld
- [x] The sender has disabled encrypting to unverified devices.
- [x] The sender has blocked you.
- [x] You are not authorised to read the message.
- [x] Unable to establish a secure channel.
- [x] Missing fields in input
- [x] Unknown Error: Error is undefined
- [x] Trying to create a new secure channel and re-requesting the keys.
- [x] The sender was unable to establish a secure channel.
- [x] The secure channel with the sender was corrupted.
- [x] The sender's device has not sent us the keys for this message.
- [ ] Message intended for room `<room id>` : parameterized translation
  - this translation will not work but was included for documentation to inform it is as part of decryption error
- [x] Missing ciphertext
- [x] Not included in recipients
- [x] Bad Encrypted Message
- [ ] Message was intented for `<recipient>` : parameterized translation
  - this translation will not work but was included for documentation to inform it is as part of decryption error
- [x] Message not intended for this device
- [ ] Message claimed to be from `<sender>` : parameterized translation
  - this translation will not work but was included for documentation to inform it is as part of decryption error
- [ ] Message forwarded from `<sender>` : parameterized translation
  - this translation will not work but was included for documentation to inform it is as part of decryption error
- [ ] Message intended for room `<roomId>` : parameterized translation
  - this translation will not work but was included for documentation to inform it is as part of decryption error