### PR TITLE
Translate "Personne" to "Messages directs" in menus

### DIFF
--- a/patches/change-keys-in-room-summary-card/matrix-react-sdk+3.59.0.patch
+++ b/patches/change-keys-in-room-summary-card/matrix-react-sdk+3.59.0.patch
@@ -12,21 +12,6 @@ index b9923d9..3f11062 100644
              iconClassName="mx_RoomTile_iconPeople"
          >
              <span className="mx_IconizedContextMenu_sublabel">
-diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx
-index 1d35aa3..49a35e7 100644
---- a/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx
-+++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx
-@@ -52,7 +52,9 @@ const SpacePreferencesAppearanceTab = ({ space }: Pick<IProps, "space">) => {
-                         );
-                     }}
-                 >
--                    { _t("People") }
-+                    {/* :tchap: { _t("People") } */}
-+                    { _t("Room Members") }
-+
-                 </StyledCheckbox>
-                 <p>
-                     { _t("This groups your chats with members of this space. " +
 diff --git a/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx b/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx
 index 006a00f..4d889bb 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx

--- a/patches/change-keys-in-room-summary-card/matrix-react-sdk+3.59.0.patch
+++ b/patches/change-keys-in-room-summary-card/matrix-react-sdk+3.59.0.patch
@@ -1,12 +1,42 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/context_menus/RoomContextMenu.tsx b/node_modules/matrix-react-sdk/src/components/views/context_menus/RoomContextMenu.tsx
+index b9923d9..3f11062 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/context_menus/RoomContextMenu.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/context_menus/RoomContextMenu.tsx
+@@ -214,7 +214,8 @@ const RoomContextMenu = ({ room, onFinished, ...props }: IProps) => {
+                 onFinished();
+                 PosthogTrackers.trackInteraction("WebRoomHeaderContextMenuPeopleItem", ev);
+             }}
+-            label={_t("People")}
++            //:tchap: label={_t("People")}
++            label={_t("Room members")}
+             iconClassName="mx_RoomTile_iconPeople"
+         >
+             <span className="mx_IconizedContextMenu_sublabel">
+diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx
+index 1d35aa3..49a35e7 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/SpacePreferencesDialog.tsx
+@@ -52,7 +52,9 @@ const SpacePreferencesAppearanceTab = ({ space }: Pick<IProps, "space">) => {
+                         );
+                     }}
+                 >
+-                    { _t("People") }
++                    {/* :tchap: { _t("People") } */}
++                    { _t("Room Members") }
++
+                 </StyledCheckbox>
+                 <p>
+                     { _t("This groups your chats with members of this space. " +
 diff --git a/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx b/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx
-index 006a00f..90dfad0 100644
+index 006a00f..4d889bb 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/right_panel/RoomSummaryCard.tsx
-@@ -303,7 +303,7 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, onClose }) => {
+@@ -303,7 +303,8 @@ const RoomSummaryCard: React.FC<IProps> = ({ room, onClose }) => {
      return <BaseCard header={header} className="mx_RoomSummaryCard" onClose={onClose}>
          <Group title={_t("About")} className="mx_RoomSummaryCard_aboutGroup">
              <Button className="mx_RoomSummaryCard_icon_people" onClick={onRoomMembersClick}>
 -                { _t("People") }
++                {/* :tchap: { _t("People") } */}
 +                { _t("Room members") }
                  <span className="mx_BaseCard_Button_sublabel">
                      { memberCount }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -169,9 +169,13 @@
     ]
   },
   "change-keys-in-room-summary-card": {
+    "comments" : "add RoomContextMenu and SpacePreferencesDialog under the same patch (same update)",
+    "github-issue" : "https://github.com/tchapgouv/tchap-web-v4/issues/365",
     "package": "matrix-react-sdk",
     "files": [
-      "src/components/views/right_panel/RoomSummaryCard.tsx"
+      "src/components/views/right_panel/RoomSummaryCard.tsx",
+      "src/components/views/context_menus/RoomContextMenu.tsx",
+      "src/components/views/dialogs/SpacePreferencesDialog.tsx"
     ]
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -556,7 +556,7 @@
     "fr": "Affiche tous vos salons dans l’accueil"  
   }, 
   "This groups your chats with members of this space. Turning this off will hide those chats from your view of %(spaceName)s." : {
-    "fr": "Cela rassemble vos messages direst avec les membres de cet espace. Le désactiver masquera ces salons de votre vue de %(spaceName)s.",
+    "fr": "Cela rassemble vos messages directs avec les membres de cet espace. Le désactiver masquera ces salons de votre vue de %(spaceName)s.",
     "en": "This groups your direct messages with members of this space. Turning this off will hide those rooms from your view of %(spaceName)s.",
   }
 

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -403,8 +403,8 @@
     "fr": "Nouveau message direct"
   },
   "Direct Messages": {
-    "en": "Start new chat",
-    "fr": "Nouveau message direct"
+    "en":"Direct Messages",
+    "fr":"Messages directs"
   },
   "Recently Direct Messaged": {
     "en": "Recents chats",
@@ -529,5 +529,26 @@
   "Ban from space": {
     "en": "Ban from space",
     "fr": "Interdire l’accès à l'espace (définitif)"
+  },
+  "People": {
+    "comments" : "in element, People label is used to title direct messages room and sometimes room members, use Room Members label in this case)",
+    "en": "Direct messages",
+    "fr": "Messages directs"
+  },
+  "Group all your people in one place.": {
+    "en":"Group all your direct message room in one place.",
+    "fr":"Regroupez tous vos salons de message directs au même endroit."
+  },
+  "Group all your favourite rooms and people in one place.": {
+    "en":"Group all your favourite rooms in one place.",
+    "fr":"Regroupez tous vos salons favoris au même endroit."
+  },
+  "Spaces are ways to group rooms and people. Alongside the spaces you're in, you can use some pre-built ones too.": {
+    "en":"Spaces are ways to group rooms and direct messages.",
+    "fr":"Les espaces permettent de regrouper des salons et des messages directs."
+  },
+  "Show all your rooms in Home, even if they're in a space." : {
+    "en": "Show all your rooms in Home",
+    "fr": "Affiche tous vos salons dans l’accueil"  
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -557,7 +557,7 @@
   }, 
   "This groups your chats with members of this space. Turning this off will hide those chats from your view of %(spaceName)s." : {
     "fr": "Cela rassemble vos messages directs avec les membres de cet espace. Le désactiver masquera ces salons de votre vue de %(spaceName)s.",
-    "en": "This groups your direct messages with members of this space. Turning this off will hide those rooms from your view of %(spaceName)s.",
+    "en": "This groups your direct messages with members of this space. Turning this off will hide those rooms from your view of %(spaceName)s."
   }
 
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -391,15 +391,19 @@
     "fr": "Rejoindre un forum"
   },
   "Start chat": {
-    "en": "Start new chat",
+    "en": "New direct message",
     "fr": "Nouveau message direct"
   },
   "Start new chat": {
-    "en": "Start new chat",
+    "en": "New direct message",
+    "fr": "Nouveau message direct"
+  },
+  "Start a new chat": {
+    "en": "New direct message",
     "fr": "Nouveau message direct"
   },
   "Chat": {
-    "en": "Start new chat",
+    "en": "New direct message",
     "fr": "Nouveau message direct"
   },
   "Direct Messages": {
@@ -537,11 +541,11 @@
   },
   "Group all your people in one place.": {
     "en":"Group all your direct message room in one place.",
-    "fr":"Regroupez tous vos salons de message directs au même endroit."
+    "fr":"Regroupe tous vos salons de message directs au même endroit."
   },
   "Group all your favourite rooms and people in one place.": {
     "en":"Group all your favourite rooms in one place.",
-    "fr":"Regroupez tous vos salons favoris au même endroit."
+    "fr":"Regroupe tous vos salons favoris au même endroit."
   },
   "Spaces are ways to group rooms and people. Alongside the spaces you're in, you can use some pre-built ones too.": {
     "en":"Spaces are ways to group rooms and direct messages.",
@@ -550,5 +554,10 @@
   "Show all your rooms in Home, even if they're in a space." : {
     "en": "Show all your rooms in Home",
     "fr": "Affiche tous vos salons dans l’accueil"  
+  }, 
+  "This groups your chats with members of this space. Turning this off will hide those chats from your view of %(spaceName)s." : {
+    "fr": "Cela rassemble vos messages direst avec les membres de cet espace. Le désactiver masquera ces salons de votre vue de %(spaceName)s.",
+    "en": "This groups your direct messages with members of this space. Turning this off will hide those rooms from your view of %(spaceName)s.",
   }
+
 }


### PR DESCRIPTION
Before: 
(see ticket)

After:
<img width="549" alt="Capture d’écran 2023-01-10 à 12 43 14" src="https://user-images.githubusercontent.com/4077729/211549007-c0167d84-9919-4418-8f70-1cd7a325d13f.png">

<img width="504" alt="Capture d’écran 2023-01-10 à 12 14 22" src="https://user-images.githubusercontent.com/4077729/211549019-04e9e8b5-51c3-4efe-858b-b95e80cf3ed3.png">

<img width="632" alt="Capture d’écran 2023-01-10 à 12 54 46" src="https://user-images.githubusercontent.com/4077729/211549033-4c5b464c-2d64-4f05-9135-5809f7586640.png">


