### PR TITLE
remove new_device_manager from lab

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -36,7 +36,8 @@
     "showLabsSettings": false,
     "features": {
         "feature_thread": true,
-        "feature_video_rooms" : false
+        "feature_video_rooms" : false,
+        "feature_new_device_manager" : false
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -31,7 +31,8 @@
     "showLabsSettings": false,
     "features": {
         "feature_thread": true,
-        "feature_video_rooms" : false
+        "feature_video_rooms" : false,
+        "feature_new_device_manager" : false
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.prod.json
+++ b/config.prod.json
@@ -106,7 +106,8 @@
     "showLabsSettings": false,
     "features": {
         "feature_thread": true,
-        "feature_video_rooms" : false
+        "feature_video_rooms" : false,
+        "feature_new_device_manager" : false
     },
     "default_federate": true,
     "default_theme": "light",


### PR DESCRIPTION
Remove this new device manager from the lab, it could deployed and reworked when the cross signing is roll out

![Capture d’écran 2023-01-16 à 16 21 54](https://user-images.githubusercontent.com/4077729/212718632-931d7842-88ac-4cfe-a604-816f16bd312f.png)
