### PR TITLE
Test/expiring todo comments

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,17 @@ module.exports = {
             // NOTE: These rules are frozen and new rules should not be added here.
             // New changes belong in https://github.com/matrix-org/eslint-plugin-matrix-org/
             rules: {
+                "unicorn/expiring-todo-comments": [
+                    "warn",
+                    {
+                        "allowWarningComments": true,
+                        "terms": [
+                            "todo",
+                            "fixme"
+                        ]
+                    }
+                ],
+
                 // Things we do that break the ideal style
                 "prefer-promise-reject-errors": "off",
                 "quotes": "off",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "element-web",
   "productName": "Tchap",
-  "version": "4.1.5_1.11.17",
+  "version": "4.1.5-1.11.17",
   "description": "A feature-rich client for Matrix.org",
   "author": "DINUM",
   "repository": {


### PR DESCRIPTION
Experiment in progress !

A test for using the expiring-todo-comments rule : https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/expiring-todo-comments.md#disallow-warning-comments-no-warning-comments

We could use it to get lint warnings or errors when comments for cherry-picks expire : 
`        // TODO [matrix-react-sdk@>3.59.0]: This cherry-pick should not be necessary after we upgrade to element-web 1.11.20`

Challenge : these comments are in the patch files, which cannot be linted by eslint, it's not JS. 

Place the comments in patches.json and lint that ? 
Make a home made tool to find these comments in patch files ?
Lint yarn-linked-dependencies files ? Lint only the files that are modified by patches ? 