### PR TITLE
More patch checks : missing entries in patches.json or in patch/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ electron/pub
 /matrix-js-sdk
 /matrix-analytics-events
 # yarn links dependencies generated with /scripts/install-yarn-linked-repositories.sh
-/yarn-linked-dependencies
+# /yarn-linked-dependencies
 
 
 # Auto-generated file

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -13,12 +13,6 @@
       "src/components/views/avatars/DecoratedRoomAvatar.tsx"
     ]
   },
-  "rename-exported-keys": {
-    "package": "matrix-react-sdk",
-    "files": [
-      "src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx"
-    ]
-  },
   "simplify-exchange-key-message": {
     "package": "matrix-react-sdk",
     "files": [

--- a/scripts/checkPatchFile.js
+++ b/scripts/checkPatchFile.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+
 function checkForDuplicateFiles(patchFile) {
   console.log("Checking patch file for files that are patched twice...");
   const findFirstDuplicate = (arr) => {
@@ -23,11 +25,11 @@ function checkForDuplicateFiles(patchFile) {
   console.log("... no files that are patched twice.");
 };
 
-function checkForMissingPatchDirs(patchFile) {
+function checkForMissingPatchDirs(patchFile, patchDirs) {
   console.log("Checking for missing patch directories...");
-  const patchDirs = []; // todo list dirs
-  Object.keys(patchFile).forEach(patchName => {
-    const found = patchDirs.find(patchDir => patchDir = patchName);
+  const patchNames = Object.keys(patchFile);
+  patchNames.forEach(patchName => {
+    const found = patchDirs.find(patchDir => patchDir === patchName);
     if (!found) {
       console.error("\nPATCH PROBLEM!")
       console.error("The patch", patchName, "is listed in patches.json but there is no corresponding directory in /patches.");
@@ -39,6 +41,30 @@ function checkForMissingPatchDirs(patchFile) {
   console.log("... no missing patch directories.");
 }
 
+function checkForMissingElementsInPatchFile(patchFile, patchDirs) {
+  console.log("Checking for missing elements in patches.json...");
+  const patchNames = Object.keys(patchFile);
+  patchDirs.forEach(patchDir => {
+    const found = patchNames.find(patchName => patchName === patchDir);
+    if (!found) {
+      console.error("\nPATCH PROBLEM!")
+      console.error("The patch", patchDir, "has a directory in /patches, but it is not listed in patches.json.");
+      console.error("Either add it to patches.json, or remove the directory in /patches.");
+      console.error("\n");
+      process.exit(1);
+    }
+  });
+  console.log("... no missing elements in patches.json.");
+}
+
+const getPatchDirs = () => {
+  return fs.readdirSync("patches", { withFileTypes: true })
+    .filter(file => file.isDirectory())
+    .map(dir => dir.name);
+}
+
 const patchFile = require('../patches/patches.json');
+const patchDirs = getPatchDirs();
 checkForDuplicateFiles(patchFile);
-checkForMissingPatchDirs(patchFile);
+checkForMissingPatchDirs(patchFile, patchDirs);
+checkForMissingElementsInPatchFile(patchFile, patchDirs);

--- a/scripts/checkPatchFile.js
+++ b/scripts/checkPatchFile.js
@@ -1,10 +1,10 @@
-function checkPatchFile(patchFile) {
-  console.log("Checking patch file is valid...");
+function checkForDuplicateFiles(patchFile) {
+  console.log("Checking patch file for files that are patched twice...");
   const findFirstDuplicate = (arr) => {
-    let sorted_arr = arr.slice().sort();
-    for (let i = 0; i < sorted_arr.length - 1; i++) {
-      if (sorted_arr[i + 1] == sorted_arr[i]) {
-        return sorted_arr[i];
+    const sortedArr = arr.slice().sort();
+    for (let i = 0; i < sortedArr.length - 1; i++) {
+      if (sortedArr[i + 1] == sortedArr[i]) {
+        return sortedArr[i];
       }
     }
     return;
@@ -20,8 +20,25 @@ function checkPatchFile(patchFile) {
     console.error("The changes of the two packages will be mixed up. Don't do this.");
     process.exit(1);
   }
-  console.log("... patch file is valid.");
+  console.log("... no files that are patched twice.");
 };
 
+function checkForMissingPatchDirs(patchFile) {
+  console.log("Checking for missing patch directories...");
+  const patchDirs = []; // todo list dirs
+  Object.keys(patchFile).forEach(patchName => {
+    const found = patchDirs.find(patchDir => patchDir = patchName);
+    if (!found) {
+      console.error("\nPATCH PROBLEM!")
+      console.error("The patch", patchName, "is listed in patches.json but there is no corresponding directory in /patches.");
+      console.error("Either remove it from patches.json, or use yarn patch-make to make the missing patch file.");
+      console.error("\n");
+      process.exit(1);
+    }
+  });
+  console.log("... no missing patch directories.");
+}
+
 const patchFile = require('../patches/patches.json');
-checkPatchFile(patchFile);
+checkForDuplicateFiles(patchFile);
+checkForMissingPatchDirs(patchFile);


### PR DESCRIPTION
This is to avoid having patches that are listed in patches.json but there is no corresponding patch file present.
And the reverse as well. 