### PR TITLE
Remove forgotten patch : rename-exported-keys

### DIFF
--- a/patches/patches.json
+++ b/patches/patches.json
@@ -13,12 +13,6 @@
       "src/components/views/avatars/DecoratedRoomAvatar.tsx"
     ]
   },
-  "rename-exported-keys": {
-    "package": "matrix-react-sdk",
-    "files": [
-      "src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx"
-    ]
-  },
   "simplify-exchange-key-message": {
     "package": "matrix-react-sdk",
     "files": [


### PR DESCRIPTION
The patch rename-exported-keys was still listed in patches.json, even though the patch file had been deleted.

The patch is not necessary any more because we replaced ExportE2eKeysDialog.tsx by TchapExportE2eKeysDialog.tsx, so no need to patch the file any more.