### PR TITLE
Activate force legacy incoming key room verification

### DIFF
--- a/src/lib/IncomingKeyRequestHandler.ts
+++ b/src/lib/IncomingKeyRequestHandler.ts
@@ -39,7 +39,7 @@ export default class KeyRequestHandler {
         const deviceId: string = keyRequest.deviceId;
         const requestId: string = keyRequest.requestId;
 
-        console.log(":tchap: recevieving a key request event for device ",deviceId, " requestId ", requestId);
+        console.log(":tchap: receiving a legacy key request event for device ",deviceId, " requestId ", requestId);
 
         //This instruction hides the toast that appears when a new device is detected
         //As we are receiving a legacy incomingroomkeyrequest we can assume the veryfing

--- a/src/lib/IncomingKeyRequestHandler.ts
+++ b/src/lib/IncomingKeyRequestHandler.ts
@@ -1,6 +1,9 @@
 import { IncomingRoomKeyRequest, verificationMethods } from 'matrix-js-sdk/src/crypto';
 import VerificationRequestDialog from 'matrix-react-sdk/src/components/views/dialogs/VerificationRequestDialog';
 import Modal from 'matrix-react-sdk/src/Modal';
+import {
+    hideToast as hideUnverifiedSessionsToast
+} from "matrix-react-sdk/src/toasts/UnverifiedSessionToast";
 
 /**
  * :tchap: inspired from
@@ -31,11 +34,17 @@ export default class KeyRequestHandler {
      * @param keyRequest
      * @returns
      */
-    public handleKeyRequest(keyRequest: IncomingRoomKeyRequest) {
+    public handleKeyRequest(keyRequest: IncomingRoomKeyRequest): void {
         const userId: string = keyRequest.userId;
         const deviceId: string = keyRequest.deviceId;
         const requestId: string = keyRequest.requestId;
 
+        //This instruction hides the toast that appears when a new device is detected
+        //As we are receiving a legacy incomingroomkeyrequest we can assume the veryfing
+        //will occur via this process and hide the toast
+        hideUnverifiedSessionsToast(deviceId);
+
+        
         if (!this._pendingKeyRequests.has(userId)) {
             this._pendingKeyRequests.set(userId, new Map<string, Array<IncomingRoomKeyRequest>>());
         }

--- a/src/lib/IncomingKeyRequestHandler.ts
+++ b/src/lib/IncomingKeyRequestHandler.ts
@@ -39,9 +39,12 @@ export default class KeyRequestHandler {
         const deviceId: string = keyRequest.deviceId;
         const requestId: string = keyRequest.requestId;
 
+        console.log(":tchap: recevieving a key request event for device ",deviceId, " requestId ", requestId);
+
         //This instruction hides the toast that appears when a new device is detected
         //As we are receiving a legacy incomingroomkeyrequest we can assume the veryfing
         //will occur via this process and hide the toast
+        console.log(":tchap: hidding UnverifiedSessionsToast for ",deviceId);
         hideUnverifiedSessionsToast(deviceId);
 
         

--- a/src/util/TchapUIFeature.ts
+++ b/src/util/TchapUIFeature.ts
@@ -32,5 +32,5 @@ export default class TchapUIFeature {
      /**
      * This flag controls whether to force incoming key legacy verification (usefull for older mobile device than android 2.6, ios 2.2.3)
      */
-     public static forceLegacyIncomingRoomKeyVerification = false;
+     public static forceLegacyIncomingRoomKeyVerification = true;
 }

--- a/src/util/TchapUserSettings.ts
+++ b/src/util/TchapUserSettings.ts
@@ -1,12 +1,17 @@
 import { SettingLevel } from "matrix-react-sdk/src/settings/SettingLevel";
 import SettingsStore from "matrix-react-sdk/src/settings/SettingsStore";
 
+import TchapUIFeature from "./TchapUIFeature";
+
 export default class TchapUserSettings {
     /**
      * Override User Settings
      */
     public static override() {
-        console.log(":tchap: hardcode e2ee.manuallyVerifyAllSessions to true");
-        SettingsStore.setValue('e2ee.manuallyVerifyAllSessions', null, SettingLevel.DEVICE, true);
+        if(!TchapUIFeature.isCrossSigningAndSecureStorageActive){
+            //hard code this option in to order to hide secure storage in the user info > sessions panel
+            console.log(":tchap: hardcode e2ee.manuallyVerifyAllSessions to true");
+            SettingsStore.setValue('e2ee.manuallyVerifyAllSessions', null, SettingLevel.DEVICE, true);
+        }
     }
 }


### PR DESCRIPTION
This PR is for testing **new web xsss with double verification** with **legacy mobile** like android 2.6


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->
