### PR TITLE
Remove enable email notifications options

### DIFF
--- a/patches/patches.json
+++ b/patches/patches.json
@@ -164,5 +164,13 @@
       "src/components/views/context_menus/RoomContextMenu.tsx",
       "src/components/views/dialogs/SpacePreferencesDialog.tsx"
     ]
+  },
+  "temp-settings-remove-enable-email-notifications-option": {
+    "comments" : "Notifications by email is currently not activated on Tchap backend. So we must remove this option.",
+    "github-issue" : "https://github.com/tchapgouv/tchap-web-v4/issues/405",
+    "package": "matrix-react-sdk",
+    "files": [
+      "src/components/views/settings/Notifications.tsx"
+    ]
   }
 }

--- a/patches/temp-settings-remove-enable-email-notifications-option/matrix-react-sdk+3.63.0.patch
+++ b/patches/temp-settings-remove-enable-email-notifications-option/matrix-react-sdk+3.63.0.patch
@@ -1,0 +1,31 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/Notifications.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/Notifications.tsx
+index 96269ae..c152118 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/settings/Notifications.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/settings/Notifications.tsx
+@@ -566,6 +566,7 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
+             return masterSwitch;
+         }
+ 
++        /* :TCHAP disable for now
+         const emailSwitches = (this.state.threepids || [])
+             .filter((t) => t.medium === ThreepidMedium.Email)
+             .map((e) => (
+@@ -578,6 +579,7 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
+                     disabled={this.state.phase === Phase.Persisting}
+                 />
+             ));
++        :tchap end */
+ 
+         return (
+             <>
+@@ -617,7 +619,9 @@ export default class Notifications extends React.PureComponent<IProps, IState> {
+                     </>
+                 )}
+ 
+-                {emailSwitches}
++                {/* :TCHAP disable for now
++                emailSwitches
++                :tchap end */}
+             </>
+         );
+     }


### PR DESCRIPTION
Cf. https://github.com/tchapgouv/tchap-web-v4/issues/405

Remove section "Activer les notifications par e-mail pour xxx"
<img width="807" alt="Screenshot 2023-02-08 at 11 41 59" src="https://user-images.githubusercontent.com/6305268/217507317-c935cccb-f915-4575-904e-38f55521f4d7.png">
