### PR TITLE
Re-add yarn-linked-dependencies to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ electron/pub
 /matrix-js-sdk
 /matrix-analytics-events
 # yarn links dependencies generated with /scripts/install-yarn-linked-repositories.sh
-# /yarn-linked-dependencies
+/yarn-linked-dependencies
 
 
 # Auto-generated file


### PR DESCRIPTION
It was removed by https://github.com/tchapgouv/tchap-web-v4/pull/389 which seems unrelated. I'm guessing it was a mistake, so I'm putting it back.