### PR TITLE
429 change csss process

### DIFF
--- a/customisations.json
+++ b/customisations.json
@@ -2,7 +2,6 @@
   "src/@types/tchap.ts": "src/@types/tchap.ts",
   "src/async-components/views/dialogs/security/ExportE2eKeysDialog.tsx": "src/async-components/views/dialogs/security/TchapExportE2eKeysDialog.tsx",
   "src/components/views/dialogs/CreateRoomDialog.tsx": "src/components/views/dialogs/TchapCreateRoomDialog.tsx",
-  "src/components/views/dialogs/LogoutDialog.tsx": "src/components/views/dialogs/TchapLogoutDialog.tsx",
   "src/components/views/verification/VerificationComplete.tsx": "src/components/views/verification/TchapVerificationComplete.tsx",
   "src/components/views/elements/TchapRoomTypeSelector.tsx": "src/components/views/elements/TchapRoomTypeSelector.tsx",
   "src/customisations/ComponentVisibility.ts": "src/customisations/TchapComponentVisibility.ts",

--- a/patches/change-csss-process/matrix-react-sdk+3.63.0.patch
+++ b/patches/change-csss-process/matrix-react-sdk+3.63.0.patch
@@ -114,6 +114,25 @@ index cf0c160..861ff87 100644
                              <AccessibleButton
                                  kind="primary"
                                  className="mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn"
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
+index 8da8e5c..b261324 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
+@@ -92,9 +92,13 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
+ 
+         let skipButton;
+         if (phase === Phase.Intro || phase === Phase.ConfirmReset) {
++            // :Tchap: Condition to skip Phase.ConfirmSkip and its "Are you sure" modal after login for csss
++            const tchapOnSkipClick = phase === Phase.Intro ? this.props.onFinished : this.onSkipClick;
++            // end :Tchap:
++
+             skipButton = (
+                 <AccessibleButton
+-                    onClick={this.onSkipClick}
++                    onClick={tchapOnSkipClick}
+                     className="mx_CompleteSecurity_skip"
+                     aria-label={_t("Skip verification for now")}
+                 />
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 index 5dc32de..868cd7b 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts

--- a/patches/change-csss-process/matrix-react-sdk+3.63.0.patch
+++ b/patches/change-csss-process/matrix-react-sdk+3.63.0.patch
@@ -14,7 +14,7 @@ index c23f53b..0e206d7 100644
      background-color: $background;
      border-radius: 4px;
 diff --git a/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx b/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
-index cf0c160..b268494 100644
+index cf0c160..861ff87 100644
 --- a/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
 +++ b/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
 @@ -57,7 +57,7 @@ enum Phase {
@@ -26,7 +26,7 @@ index cf0c160..b268494 100644
      Storing = "storing",
      ConfirmSkip = "confirm_skip",
  }
-@@ -177,13 +177,28 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
+@@ -177,13 +177,38 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                  MatrixClientPeg.get().isCryptoEnabled() && (await MatrixClientPeg.get().isKeyBackupTrusted(backupInfo));
  
              const { forceReset } = this.props;
@@ -34,12 +34,16 @@ index cf0c160..b268494 100644
 +            //const phase = backupInfo && !forceReset ? Phase.Migrate : Phase.ChooseKeyPassphrase;
 +            const phase = backupInfo && !forceReset ? Phase.Migrate : Phase.ShowKey;//:tchap: goes directly to showkey
  
--            this.setState({
--                phase,
--                backupInfo,
--                backupSigStatus,
--            });
-+            if(phase === Phase.ShowKey){
++            /* :TCHAP: remove
+             this.setState({
+                 phase,
+                 backupInfo,
+                 backupSigStatus,
+             });
++            end :TCHAP: */
++
++            // add :TCHAP:
++            if (phase === Phase.ShowKey) {
 +                this.recoveryKey = await MatrixClientPeg.get().createRecoveryKeyFromPassphrase();
 +                this.setState({
 +                    phase,
@@ -50,7 +54,7 @@ index cf0c160..b268494 100644
 +                    downloaded: false,
 +                    setPassphrase: false 
 +                });
-+            }else{
++            } else {
 +                //if phase is Phase.Migrate
 +                this.setState({
 +                    phase,
@@ -58,29 +62,33 @@ index cf0c160..b268494 100644
 +                    backupSigStatus,
 +                });
 +            }
++            // end :TCHAP:
  
              return {
                  backupInfo,
-@@ -717,7 +732,9 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
+@@ -717,7 +742,10 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
          if (this.state.phase === Phase.ShowKey) {
              continueButton = (
                  <DialogButtons
 -                    primaryButton={_t("Continue")}
-+                    //primaryButton={_t("Continue")}
-+                    //:tchap: change label
-+                    primaryButton={_t("Activate my backup")}
++                    // :tchap: change label
++                    // primaryButton={_t("Continue")}
++                    // end :tchap:
++                    primaryButton={_t("Activate")}
                      disabled={!this.state.downloaded && !this.state.copied && !this.state.setPassphrase}
                      onPrimaryButtonClick={this.onShowKeyContinueClick}
                      hasCancel={false}
-@@ -733,12 +750,18 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
+@@ -733,18 +761,27 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
  
          return (
              <div>
++                {/* tchap: add this <p /> */}
 +                <p>
 +                    {_t(
-+                        "This is your synchronization key"
++                        "This is your recovery key"
 +                    )}
 +                </p>
++                {/* end tchap */}
                  <p>
                      {_t(
                          "Store your Security Key somewhere safe, like a password manager or a safe, " +
@@ -91,54 +99,26 @@ index cf0c160..b268494 100644
                  <div className="mx_CreateSecretStorageDialog_primaryContainer mx_CreateSecretStorageDialog_recoveryKeyPrimarycontainer">
                      <div className="mx_CreateSecretStorageDialog_recoveryKeyContainer">
                          <div className="mx_CreateSecretStorageDialog_recoveryKey">
-diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
-index 3f2fb26..8238857 100644
---- a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
-+++ b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
-@@ -169,7 +169,10 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
- 
-                         <div className="mx_CompleteSecurity_actionRow">
-                             <AccessibleButton kind="primary" onClick={this.onResetConfirmClick}>
--                                {_t("Proceed with reset")}
-+                                {/* :TCHAP: change this trad
-+                                _t("Proceed with reset")
-+                                end :TCHAP: */}
-+                                {_t("Activate")}
-                             </AccessibleButton>
+                             <code ref={this.recoveryKeyNode}>{this.recoveryKey.encodedPrivateKey}</code>
                          </div>
-                     </div>
-diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/DevicesPanelEntry.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/DevicesPanelEntry.tsx
-index 37b65bc..986586d 100644
---- a/node_modules/matrix-react-sdk/src/components/views/settings/DevicesPanelEntry.tsx
-+++ b/node_modules/matrix-react-sdk/src/components/views/settings/DevicesPanelEntry.tsx
-@@ -125,7 +125,10 @@ export default class DevicesPanelEntry extends React.Component<IProps, IState> {
-             if (!this.props.verified && this.props.canBeVerified) {
-                 verifyButton = (
-                     <AccessibleButton kind="primary" onClick={this.verify}>
--                        {_t("Verify")}
-+                        {/* :TCHAP: change this trad
-+                        _t("Verify")
-+                        end :TCHAP: */}
-+                        {_t("Synchronize")}
-                     </AccessibleButton>
-                 );
-             }
+                         <div className="mx_CreateSecretStorageDialog_recoveryKeyButtons">
++                            {/* :TCHAP: remove
+                             <AccessibleButton
+                                 kind="primary"
+                                 className="mx_Dialog_primary"
+@@ -759,6 +796,7 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
+                                     copyButton: "",
+                                 })}
+                             </span>
++                            end :TCHAP: */}
+                             <AccessibleButton
+                                 kind="primary"
+                                 className="mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn"
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-index 5dc32de..6b01c0f 100644
+index 5dc32de..868cd7b 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 +++ b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-@@ -33,7 +33,10 @@ const getTitle = (kind: Kind) => {
-         case Kind.UPGRADE_ENCRYPTION:
-             return _t("Encryption upgrade available");
-         case Kind.VERIFY_THIS_SESSION:
-+            /* :TCHAP: change this trad
-             return _t("Verify this session");
-+            end :TCHAP: */
-+            return _t("Synchronize this device");
-     }
- };
- 
-@@ -50,11 +53,15 @@ const getIcon = (kind: Kind) => {
+@@ -50,7 +50,8 @@ const getIcon = (kind: Kind) => {
  const getSetupCaption = (kind: Kind) => {
      switch (kind) {
          case Kind.SET_UP_ENCRYPTION:
@@ -148,10 +128,3 @@ index 5dc32de..6b01c0f 100644
          case Kind.UPGRADE_ENCRYPTION:
              return _t("Upgrade");
          case Kind.VERIFY_THIS_SESSION:
-+            /* :TCHAP: change this trad
-             return _t("Verify");
-+            end :TCHAP: */
-+            return _t("Synchronize");
-     }
- };
- 

--- a/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
@@ -1,37 +1,30 @@
 diff --git a/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss b/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss
-index c23f53b..0e206d7 100644
+index c23f53b..7aa9f25 100644
 --- a/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss
 +++ b/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss
-@@ -16,7 +16,10 @@ limitations under the License.
+@@ -16,7 +16,12 @@ limitations under the License.
  */
  
  .mx_CompleteSecurityBody {
-+    /* :TCHAP: remove
++    /* :TCHAP:
      width: 600px;
-+    end :TCHAP: */
++    */
 +    width: 660px;
++    /* end :TCHAP: */
++
      color: $authpage-primary-color;
      background-color: $background;
      border-radius: 4px;
 diff --git a/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx b/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
-index cf0c160..861ff87 100644
+index cf0c160..9a970b9 100644
 --- a/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
 +++ b/node_modules/matrix-react-sdk/src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx
-@@ -57,7 +57,7 @@ enum Phase {
-     Migrate = "migrate",
-     Passphrase = "passphrase",
-     PassphraseConfirm = "passphrase_confirm",
--    ShowKey = "show_key",
-+    ShowKey = "show_key", //:tchap: we use this screen
-     Storing = "storing",
-     ConfirmSkip = "confirm_skip",
- }
 @@ -177,13 +177,38 @@ export default class CreateSecretStorageDialog extends React.PureComponent<IProp
                  MatrixClientPeg.get().isCryptoEnabled() && (await MatrixClientPeg.get().isKeyBackupTrusted(backupInfo));
  
              const { forceReset } = this.props;
 -            const phase = backupInfo && !forceReset ? Phase.Migrate : Phase.ChooseKeyPassphrase;
-+            //const phase = backupInfo && !forceReset ? Phase.Migrate : Phase.ChooseKeyPassphrase;
++            // :tchap: const phase = backupInfo && !forceReset ? Phase.Migrate : Phase.ChooseKeyPassphrase;
 +            const phase = backupInfo && !forceReset ? Phase.Migrate : Phase.ShowKey;//:tchap: goes directly to showkey
  
 +            /* :TCHAP: remove
@@ -73,8 +66,8 @@ index cf0c160..861ff87 100644
 -                    primaryButton={_t("Continue")}
 +                    // :tchap: change label
 +                    // primaryButton={_t("Continue")}
-+                    // end :tchap:
 +                    primaryButton={_t("Activate")}
++                    // end :tchap:
                      disabled={!this.state.downloaded && !this.state.copied && !this.state.setPassphrase}
                      onPrimaryButtonClick={this.onShowKeyContinueClick}
                      hasCancel={false}
@@ -115,10 +108,10 @@ index cf0c160..861ff87 100644
                                  kind="primary"
                                  className="mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn"
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
-index 8da8e5c..b261324 100644
+index 8da8e5c..b2c463f 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
-@@ -92,9 +92,13 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
+@@ -92,9 +92,16 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
  
          let skipButton;
          if (phase === Phase.Intro || phase === Phase.ConfirmReset) {
@@ -129,21 +122,25 @@ index 8da8e5c..b261324 100644
              skipButton = (
                  <AccessibleButton
 -                    onClick={this.onSkipClick}
++                    // :tchap: remove onClick={this.onSkipClick}
++                    // add instead
 +                    onClick={tchapOnSkipClick}
++                    // end :tchap:
                      className="mx_CompleteSecurity_skip"
                      aria-label={_t("Skip verification for now")}
                  />
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-index 5dc32de..868cd7b 100644
+index 5dc32de..c087058 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 +++ b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-@@ -50,7 +50,8 @@ const getIcon = (kind: Kind) => {
+@@ -50,7 +50,9 @@ const getIcon = (kind: Kind) => {
  const getSetupCaption = (kind: Kind) => {
      switch (kind) {
          case Kind.SET_UP_ENCRYPTION:
 -            return _t("Continue");
-+            //:tchap: return _t("Continue");
++            // :tchap: return _t("Continue");
 +            return _t("Activate");
++            // end :tchap:
          case Kind.UPGRADE_ENCRYPTION:
              return _t("Upgrade");
          case Kind.VERIFY_THIS_SESSION:

--- a/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
@@ -108,10 +108,18 @@ index cf0c160..9a970b9 100644
                                  kind="primary"
                                  className="mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn"
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
-index 8da8e5c..b2c463f 100644
+index 8da8e5c..746ab0a 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
-@@ -92,9 +92,16 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
+@@ -22,6 +22,7 @@ import SetupEncryptionBody from "./SetupEncryptionBody";
+ import AccessibleButton from "../../views/elements/AccessibleButton";
+ import CompleteSecurityBody from "../../views/auth/CompleteSecurityBody";
+ import AuthPage from "../../views/auth/AuthPage";
++import TchapUIFeature from "../../../../../../src/util/TchapUIFeature";
+ 
+ interface IProps {
+     onFinished: () => void;
+@@ -92,9 +93,16 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
  
          let skipButton;
          if (phase === Phase.Intro || phase === Phase.ConfirmReset) {
@@ -124,7 +132,7 @@ index 8da8e5c..b2c463f 100644
 -                    onClick={this.onSkipClick}
 +                    // :tchap: remove onClick={this.onSkipClick}
 +                    // add instead
-+                    onClick={tchapOnSkipClick}
++                    onClick={TchapUIFeature.isCrossSigningAndSecureStorageActive ? tchapOnSkipClick : this.onSkipClick}
 +                    // end :tchap:
                      className="mx_CompleteSecurity_skip"
                      aria-label={_t("Skip verification for now")}

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -165,8 +165,8 @@
       "src/components/views/dialogs/SpacePreferencesDialog.tsx"
     ]
   },
-  "change-csss-process": {
-    "comments" : "rewording on key backup configuration",
+  "cross-signing-ui": {
+    "comments" : "reword cross-signing dialogs and remove confirmation dialog",
     "github-issue" : "https://github.com/tchapgouv/tchap-web-v4/issues/406",
     "package": "matrix-react-sdk",
     "files": [

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -165,16 +165,14 @@
       "src/components/views/dialogs/SpacePreferencesDialog.tsx"
     ]
   },
-  "rewording-key-backup-configuration": {
+  "change-csss-process": {
     "comments" : "rewording on key backup configuration",
     "github-issue" : "https://github.com/tchapgouv/tchap-web-v4/issues/406",
     "package": "matrix-react-sdk",
     "files": [
       "src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx",
       "src/toasts/SetupEncryptionToast.ts",
-      "src/components/views/settings/DevicesPanelEntry.tsx",
-      "res/css/views/auth/_CompleteSecurityBody.pcss",
-      "src/components/structures/auth/SetupEncryptionBody.tsx"
+      "res/css/views/auth/_CompleteSecurityBody.pcss"
     ]
   },
   "temp-settings-remove-enable-email-notifications-option": {

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -172,6 +172,7 @@
     "files": [
       "src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx",
       "src/toasts/SetupEncryptionToast.ts",
+      "src/components/structures/auth/CompleteSecurity.tsx",
       "res/css/views/auth/_CompleteSecurityBody.pcss"
     ]
   },


### PR DESCRIPTION
See issue https://github.com/tchapgouv/tchap-web-v4/issues/429

## This PR:
- removes a customization file that is not used any more > TchapLogoutDialog
- adds a patch
- goes back to previous patch state, more compatible with Element but with variations 

## Nouveau parcours

Pour reproduire :

1. Créer un compte.

2. Se connecter

3. A la première connexion, affichage sur la page d'accueil de :
<img width="435" alt="Screenshot 2023-02-21 at 15 50 01" src="https://user-images.githubusercontent.com/6305268/220378552-8426eba4-c335-4ecf-8417-8bb5744aa236.png">

4. Cliquer sur "Plus tard"

5. Cliquer dans le menu sur "Se déconnecter"

6. Cette modale s'affiche :
<img width="770" alt="Screenshot 2023-02-21 at 15 50 17" src="https://user-images.githubusercontent.com/6305268/220379093-4acb6440-253d-4567-bb14-6135979c8aab.png">

7. Si on clique sur Utiliser la sauvegarde automatique, on arrive sur cette modale :
<img width="628" alt="Screenshot 2023-02-21 at 15 50 23" src="https://user-images.githubusercontent.com/6305268/220379310-39831dff-4b69-4bff-9b3d-f5f40e305551.png">

8. Si on clique sur "Se déconnecter quand-même", on est déconnecté.

9. Se reconnecter. Avant d'arriver sur la page d'accueil, une modale s'affiche :
<img width="675" alt="Screenshot 2023-02-21 at 15 50 47" src="https://user-images.githubusercontent.com/6305268/220380325-17ec6cd4-9e82-402a-a027-528dc08e45f3.png">

10. Cliquer sur la croix (fermer la fenêtre)

11. Arriver sur la page d'accueil
<img width="338" alt="Screenshot 2023-02-21 at 15 51 28" src="https://user-images.githubusercontent.com/6305268/220382824-2ee7e124-2663-43f1-aae2-063de57fd0c5.png">

Cliquer sur "Vérifier"

<img width="763" alt="Screenshot 2023-02-21 at 15 51 36" src="https://user-images.githubusercontent.com/6305268/220382948-70e44771-1f14-42da-98f7-f41e349749cb.png">

Cliquer sur faire la réinitialisation

<img width="625" alt="Screenshot 2023-02-21 at 15 51 44" src="https://user-images.githubusercontent.com/6305268/220383050-b4445368-17a3-43c6-8a20-73a5256bac8e.png">

Dernière étape
<img width="770" alt="Screenshot 2023-02-21 at 16 11 23" src="https://user-images.githubusercontent.com/6305268/220383342-adaa8a18-bd8f-43a5-8378-5de0dc1fe121.png">


