### PR TITLE
Green confirmation flag for device verification

### DIFF
--- a/patches/green-confirmation-shield/matrix-react-sdk+3.63.0.patch
+++ b/patches/green-confirmation-shield/matrix-react-sdk+3.63.0.patch
@@ -1,0 +1,11 @@
+diff --git a/node_modules/matrix-react-sdk/res/css/views/rooms/_E2EIcon.pcss b/node_modules/matrix-react-sdk/res/css/views/rooms/_E2EIcon.pcss
+index 5ae6de0..832a4ab 100644
+--- a/node_modules/matrix-react-sdk/res/css/views/rooms/_E2EIcon.pcss
++++ b/node_modules/matrix-react-sdk/res/css/views/rooms/_E2EIcon.pcss
+@@ -76,5 +76,5 @@ limitations under the License.
+ 
+ .mx_E2EIcon_verified::after {
+     mask-image: url("$(res)/img/e2e/verified.svg");
+-    background-color: $accent;
++    background-color: var(--confirmation-color);
+ }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -183,5 +183,13 @@
     "files": [
       "src/components/views/settings/Notifications.tsx"
     ]
+  },
+  "green-confirmation-shield" : {
+    "comments" : "When finishing a session verification with mobile using the QR code, we need the shield image to be green on all clients.",
+    "github-issue" : "https://github.com/tchapgouv/tchap-web-v4/issues/432",
+    "package": "matrix-react-sdk",
+    "files": [
+      "res/css/views/rooms/_E2EIcon.pcss"
+    ]
   }
 }

--- a/res/themes/tchap-light/css/_tchap_custom_vars.pcss
+++ b/res/themes/tchap-light/css/_tchap_custom_vars.pcss
@@ -5,6 +5,7 @@ body {
     --accent: #000091;
     --primary-color: #4C69F6;
     --warning-color: #E1000F;
+    --confirmation-color: #0dbd8b;
     --private-color: #eb5757;
     --external-color: #f07a12;
     --forum-color: #27ae60;


### PR DESCRIPTION
Fixes #432 

I used the same green as element's main accent color, as a green confirmation color.
It had been replaced by tchap's accent color, which is blue. 

Before : 
<img width="769" alt="Screen Shot 2023-02-27 at 11 16 00 AM" src="https://user-images.githubusercontent.com/911434/221536580-8f6798bd-692b-49d2-9bee-5685df5c8b58.png">

After : 
<img width="757" alt="Screen Shot 2023-02-27 at 11 25 30 AM" src="https://user-images.githubusercontent.com/911434/221540221-dc9b27fb-75b5-40a1-8188-fd8bd7a46055.png">
