### PR TITLE
Display Signalement d'anomalies only once in settings

### DIFF
--- a/patches/better-help-settings/matrix-react-sdk+3.63.0.patch
+++ b/patches/better-help-settings/matrix-react-sdk+3.63.0.patch
@@ -12,7 +12,7 @@ index 3f40961..aca97f2 100644
  
  export interface IAccessibleButtonProps extends React.InputHTMLAttributes<Element> {
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
-index 54e2b69..df5b63d 100644
+index 54e2b69..ceaea9b 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
 @@ -98,6 +98,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
@@ -172,9 +172,10 @@ index 54e2b69..df5b63d 100644
          return (
              <div className="mx_SettingsTab mx_HelpUserSettingsTab">
                  <div className="mx_SettingsTab_heading">{_t("Help & About")}</div>
+-                {bugReportingSection}
 +                { /* :TCHAP: added */ contactSection }
 +                { /* :TCHAP: added */ faqSection }
-                 {bugReportingSection}
++                { /* :TCHAP: moved down the page - bugReportingSection */}
 +                { /* :TCHAP: replaced by custom faqSection
                  <div className="mx_SettingsTab_section">
                      <span className="mx_SettingsTab_subheading">{_t("FAQ")}</span>


### PR DESCRIPTION
fixes #426

Before : 
<img width="1022" alt="image" src="https://user-images.githubusercontent.com/911434/220304370-b8fee722-7dde-4788-a88f-410ac8094e9e.png">

After : 
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/911434/221542692-1bf511b9-0db9-426c-99e2-466b4b7bdb50.png">
