### PR TITLE
Allow intradef users to invite users from other homeserver in a private room

### DIFF
--- a/src/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -41,8 +41,7 @@ interface IState {
     name: string;
     nameIsValid: boolean;
     tchapRoomType: TchapRoomType;
-    isDefaultFederated: boolean;
-    isForumFederated: boolean;
+    forumFederationSwitchValue: boolean;
     showFederateSwitch: boolean;
 }
 
@@ -58,9 +57,8 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
             name: this.props.defaultName || "",
             nameIsValid: false,
             tchapRoomType: TchapRoomType.Private,
-            isDefaultFederated: federationOptions.roomDefaultFederation.private,
-            isForumFederated: federationOptions.roomDefaultFederation.forum,
-            showFederateSwitch: federationOptions.showRoomFederationOption,
+            forumFederationSwitchValue: federationOptions.forumFederationSwitchDefaultValue,
+            showFederateSwitch: federationOptions.showForumFederationSwitch,
         };
     }
 
@@ -73,17 +71,15 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
         this.props.onFinished(false);
     };
 
-    private onFederatedChange = (isForumFederated: boolean) => {
-        this.setState({ isForumFederated });
+    private onForumFederatedChange = (forumFederationSwitchValue: boolean): void => {
+        this.setState({ forumFederationSwitchValue });
     };
 
-    private onTchapRoomTypeChange = (tchapRoomType: TchapRoomType) => {
-        const federationOptions = TchapUtils.getRoomFederationOptions();
-
-        this.setState({ tchapRoomType: tchapRoomType, isDefaultFederated: federationOptions.roomDefaultFederation[tchapRoomType] });
+    private onTchapRoomTypeChange = (tchapRoomType: TchapRoomType): void => {
+        this.setState({ tchapRoomType: tchapRoomType });
     };
 
-    private onNameChange = (ev: ChangeEvent<HTMLInputElement>) => {
+    private onNameChange = (ev: ChangeEvent<HTMLInputElement>): void => {
         this.setState({ name: ev.target.value });
     };
 
@@ -103,7 +99,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
         ],
     });
 
-    private onKeyDown = (event: KeyboardEvent) => {
+    private onKeyDown = (event: KeyboardEvent): void => {
         const action = getKeyBindingsManager().getAccessibilityAction(event);
         switch (action) {
             case KeyBindingAction.Enter:
@@ -113,6 +109,10 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
                 break;
         }
     };
+
+    private isSelectedRoomFederated = (): boolean => {
+        return this.state.tchapRoomType === TchapRoomType.Forum ? this.state.forumFederationSwitchValue : true;
+    }
 
     private onOk = async () => {
         const activeElement = document.activeElement as HTMLElement;
@@ -140,10 +140,6 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
         }
     };
 
-    private isSelectedRoomFederated = (): boolean => {
-        return this.state.tchapRoomType === TchapRoomType.Forum ? this.state.isForumFederated : this.state.isDefaultFederated
-    }
-
     public render() {
         const shortDomain: string = TchapUtils.getShortDomain();
 
@@ -167,14 +163,13 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
                         />
 
                         <TchapRoomTypeSelector
-                            onChange={this.onTchapRoomTypeChange}
                             value={this.state.tchapRoomType}
                             label={_t("Type of room")}
                             showFederateSwitch={this.state.showFederateSwitch}
                             shortDomain={shortDomain}
-                            isFederated={this.isSelectedRoomFederated()}
-                            isForumFederated={this.state.isForumFederated}
-                            onFederatedChange={this.onFederatedChange}
+                            forumFederationSwitchValue={this.state.forumFederationSwitchValue}
+                            setForumFederationSwitchValue={this.onForumFederatedChange}
+                            setRoomType={this.onTchapRoomTypeChange}
                         />
 
                     </div>

--- a/src/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -41,14 +41,15 @@ interface IState {
     name: string;
     nameIsValid: boolean;
     tchapRoomType: TchapRoomType;
-    isFederated: boolean;
+    isDefaultFederated: boolean;
+    isForumFederated: boolean;
     showFederateSwitch: boolean;
 }
 
 export default class TchapCreateRoomDialog extends React.Component<IProps, IState> {
     private nameField = createRef<Field>();
 
-    constructor(props) {
+    public constructor(props) {
         super(props);
 
         const federationOptions = TchapUtils.getRoomFederationOptions();
@@ -57,7 +58,8 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
             name: this.props.defaultName || "",
             nameIsValid: false,
             tchapRoomType: TchapRoomType.Private,
-            isFederated: federationOptions.roomFederationDefault,
+            isDefaultFederated: federationOptions.roomDefaultFederation.private,
+            isForumFederated: federationOptions.roomDefaultFederation.forum,
             showFederateSwitch: federationOptions.showRoomFederationOption,
         };
     }
@@ -67,19 +69,18 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
         this.nameField.current.focus();
     }
 
-    componentWillUnmount() {
-    }
-
     private onCancel = () => {
         this.props.onFinished(false);
     };
 
-    private onFederatedChange = (isFederated: boolean) => {
-        this.setState({ isFederated: isFederated });
+    private onFederatedChange = (isForumFederated: boolean) => {
+        this.setState({ isForumFederated });
     };
 
     private onTchapRoomTypeChange = (tchapRoomType: TchapRoomType) => {
-        this.setState({ tchapRoomType: tchapRoomType });
+        const federationOptions = TchapUtils.getRoomFederationOptions();
+
+        this.setState({ tchapRoomType: tchapRoomType, isDefaultFederated: federationOptions.roomDefaultFederation[tchapRoomType] });
     };
 
     private onNameChange = (ev: ChangeEvent<HTMLInputElement>) => {
@@ -126,7 +127,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
             this.props.onFinished(true, TchapCreateRoom.roomCreateOptions(
                 this.state.name,
                 this.state.tchapRoomType,
-                this.state.isFederated));
+                this.isSelectedRoomFederated()));
         } else {
             let field;
             if (!this.state.nameIsValid) {
@@ -139,7 +140,11 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
         }
     };
 
-    render() {
+    private isSelectedRoomFederated = (): boolean => {
+        return this.state.tchapRoomType === TchapRoomType.Forum ? this.state.isForumFederated : this.state.isDefaultFederated
+    }
+
+    public render() {
         const shortDomain: string = TchapUtils.getShortDomain();
 
         const title = _t("Create a room");
@@ -167,7 +172,8 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
                             label={_t("Type of room")}
                             showFederateSwitch={this.state.showFederateSwitch}
                             shortDomain={shortDomain}
-                            isFederated={this.state.isFederated}
+                            isFederated={this.isSelectedRoomFederated()}
+                            isForumFederated={this.state.isForumFederated}
                             onFederatedChange={this.onFederatedChange}
                         />
 

--- a/src/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -111,7 +111,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
     };
 
     private isSelectedRoomFederated = (): boolean => {
-        return this.state.tchapRoomType === TchapRoomType.Forum ? this.state.forumFederationSwitchValue : true;
+        return this.state.tchapRoomType === TchapRoomType.Forum  && this.state.showFederateSwitch ? this.state.forumFederationSwitchValue : true;
     }
 
     private onOk = async () => {

--- a/src/components/views/elements/TchapRoomTypeSelector.tsx
+++ b/src/components/views/elements/TchapRoomTypeSelector.tsx
@@ -18,10 +18,9 @@ interface IProps {
     width?: number;
     showFederateSwitch: boolean;
     shortDomain: string;
-    isFederated: boolean;
-    isForumFederated: boolean;
-    onChange(value: TchapRoomType, isFederated?: boolean): void;
-    onFederatedChange(isForumFederated?: boolean): void;
+    forumFederationSwitchValue: boolean;
+    setRoomType(value: TchapRoomType): void;
+    setForumFederationSwitchValue(forumFederationSwitchValue?: boolean): void;
 }
 
 interface IState {
@@ -29,7 +28,7 @@ interface IState {
 }
 
 export default class TchapRoomTypeSelector extends React.Component<IProps, IState> {
-    constructor(props: IProps) {
+    public constructor(props: IProps) {
         super(props);
 
         this.state = {
@@ -41,7 +40,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
         const roomType = e.target.value as TchapRoomType;
 
         this.setState({ roomType: roomType });
-        this.props.onChange(roomType, null);
+        this.props.setRoomType(roomType);
     };
 
     public render(): JSX.Element {
@@ -73,8 +72,8 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                             "Allow access to this room to all users, even outside \"%(domain)s\" domain",
                             { domain: this.props.shortDomain },
                         )}
-                        onChange={this.props.onFederatedChange}
-                        value={this.props.isForumFederated} />
+                        onChange={this.props.setForumFederationSwitchValue}
+                        value={this.props.forumFederationSwitchValue} />
                 </div>
             );
         }

--- a/src/components/views/elements/TchapRoomTypeSelector.tsx
+++ b/src/components/views/elements/TchapRoomTypeSelector.tsx
@@ -19,8 +19,9 @@ interface IProps {
     showFederateSwitch: boolean;
     shortDomain: string;
     isFederated: boolean;
+    isForumFederated: boolean;
     onChange(value: TchapRoomType, isFederated?: boolean): void;
-    onFederatedChange(isFederated?: boolean): void;
+    onFederatedChange(isForumFederated?: boolean): void;
 }
 
 interface IState {
@@ -73,7 +74,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                             { domain: this.props.shortDomain },
                         )}
                         onChange={this.props.onFederatedChange}
-                        value={this.props.isFederated} />
+                        value={this.props.isForumFederated} />
                 </div>
             );
         }

--- a/src/components/views/elements/TchapRoomTypeSelector.tsx
+++ b/src/components/views/elements/TchapRoomTypeSelector.tsx
@@ -18,9 +18,9 @@ interface IProps {
     width?: number;
     showFederateSwitch: boolean;
     shortDomain: string;
-    forumFederationSwitchValue: boolean;
+    forumFederationSwitchValue?: boolean;
     setRoomType(value: TchapRoomType): void;
-    setForumFederationSwitchValue(forumFederationSwitchValue?: boolean): void;
+    setForumFederationSwitchValue(forumFederationSwitchValue: boolean): void;
 }
 
 interface IState {

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -35,7 +35,7 @@ export default class TchapUtils {
         // Only show the federate switch to defense users : it's difficult to understand, so we avoid
         // displaying it unless it's really necessary.
         if (baseDomain === 'agent.intradef.tchap.gouv.fr') {
-            return { showRoomFederationOption: true, roomFederationDefault: false };
+            return { showRoomFederationOption: true, roomFederationDefault: true };
         }
 
         return { showRoomFederationOption: false, roomFederationDefault: true };

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -26,15 +26,11 @@ export default class TchapUtils {
     /**
      * For the current user, get the room federation options.
      *
-     * @returns { showRoomFederationOption: boolean,roomDefaultFederation: { external: boolean, private: boolean, forum: boolean } } options
+     * @returns { showForumFederationSwitch: boolean, forumFederationSwitchDefaultValue?: boolean } options
      */
     public static getRoomFederationOptions(): {
-        showRoomFederationOption: boolean,
-        roomDefaultFederation: {
-            external: boolean,
-            private: boolean,
-            forum: boolean
-        }
+        showForumFederationSwitch: boolean,
+        forumFederationSwitchDefaultValue?: boolean
     } {
         const cli = MatrixClientPeg.get();
         const baseDomain = cli.getDomain();
@@ -43,22 +39,13 @@ export default class TchapUtils {
         // displaying it unless it's really necessary.
         if (baseDomain === 'agent.intradef.tchap.gouv.fr') {
             return {
-                showRoomFederationOption: true,
-                roomDefaultFederation: {
-                    external: true,
-                    private: true,
-                    forum: false,
-                }
-            };
+                showForumFederationSwitch: true,
+                forumFederationSwitchDefaultValue: false
+            }
         }
 
         return {
-            showRoomFederationOption: false,
-            roomDefaultFederation: {
-                external: true,
-                private: true,
-                forum: true,
-            }
+            showForumFederationSwitch: false
         };
     }
 

--- a/src/util/TchapUtils.ts
+++ b/src/util/TchapUtils.ts
@@ -26,19 +26,40 @@ export default class TchapUtils {
     /**
      * For the current user, get the room federation options.
      *
-     * @returns { showRoomFederationOption: boolean, roomFederationDefault: boolean } options
+     * @returns { showRoomFederationOption: boolean,roomDefaultFederation: { external: boolean, private: boolean, forum: boolean } } options
      */
-    static getRoomFederationOptions(): { showRoomFederationOption: boolean, roomFederationDefault: boolean } {
+    public static getRoomFederationOptions(): {
+        showRoomFederationOption: boolean,
+        roomDefaultFederation: {
+            external: boolean,
+            private: boolean,
+            forum: boolean
+        }
+    } {
         const cli = MatrixClientPeg.get();
         const baseDomain = cli.getDomain();
 
         // Only show the federate switch to defense users : it's difficult to understand, so we avoid
         // displaying it unless it's really necessary.
         if (baseDomain === 'agent.intradef.tchap.gouv.fr') {
-            return { showRoomFederationOption: true, roomFederationDefault: true };
+            return {
+                showRoomFederationOption: true,
+                roomDefaultFederation: {
+                    external: true,
+                    private: true,
+                    forum: false,
+                }
+            };
         }
 
-        return { showRoomFederationOption: false, roomFederationDefault: true };
+        return {
+            showRoomFederationOption: false,
+            roomDefaultFederation: {
+                external: true,
+                private: true,
+                forum: true,
+            }
+        };
     }
 
     /**

--- a/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -158,7 +158,8 @@ describe("TchapCreateRoomDialog", () => {
             wrapper.setState({
                 name: roomName,
                 tchapRoomType: TchapRoomType.Private,
-                isFederated: true,
+                forumFederationSwitchValue: false,
+                showFederateSwitch: false,
             });
         });
 
@@ -200,7 +201,8 @@ describe("TchapCreateRoomDialog", () => {
             wrapper.setState({
                 name: roomName,
                 tchapRoomType: TchapRoomType.Forum,
-                isFederated: false,
+                forumFederationSwitchValue: false,
+                showFederateSwitch: true,
             });
         });
 
@@ -242,7 +244,8 @@ describe("TchapCreateRoomDialog", () => {
             wrapper.setState({
                 name: roomName,
                 tchapRoomType: TchapRoomType.Forum,
-                isFederated: true,
+                forumFederationSwitchValue: true,
+                showFederateSwitch: true,
             });
         });
 
@@ -284,7 +287,8 @@ describe("TchapCreateRoomDialog", () => {
             wrapper.setState({
                 name: roomName,
                 tchapRoomType: TchapRoomType.External,
-                isFederated: true,
+                forumFederationSwitchValue: false,
+                showFederateSwitch: false,
             });
         });
 

--- a/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -72,12 +72,12 @@ describe("TchapCreateRoomDialog", () => {
         //mock tchap utils
         jest.spyOn(TchapUtils, 'getShortDomain').mockReturnValue("AGENT");
         jest.spyOn(TchapUtils, 'getRoomFederationOptions').mockReturnValue(
-            { showRoomFederationOption: true, roomDefaultFederation: { external: true, private: true, forum: false }});
+            { showForumFederationSwitch: true, forumFederationSwitchDefaultValue: false });
     });
 
     it('should render the whole component with with the allow access switch', () => {
         jest.spyOn(TchapUtils, 'getRoomFederationOptions').mockReturnValue(
-            { showRoomFederationOption: true, roomDefaultFederation: { external: true, private: true, forum: false } });
+            { showForumFederationSwitch: true, forumFederationSwitchDefaultValue: false });
         const component = getComponent();
         const allowAccessSwitch = component.find(".mx_SettingsFlag");
         expect(toJson(allowAccessSwitch)).toMatchSnapshot(
@@ -86,7 +86,7 @@ describe("TchapCreateRoomDialog", () => {
 
     it('should render the room dialog without the allow access switch', () => {
         jest.spyOn(TchapUtils, 'getRoomFederationOptions').mockReturnValue(
-            { showRoomFederationOption: false, roomDefaultFederation: { external: true, private: true, forum: false } });
+            { showForumFederationSwitch: false, forumFederationSwitchDefaultValue: false });
         const component = getComponent();
         const allowAccessSwitch = component.find(".mx_SettingsFlag");
         expect(allowAccessSwitch).toEqual({});

--- a/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -72,12 +72,12 @@ describe("TchapCreateRoomDialog", () => {
         //mock tchap utils
         jest.spyOn(TchapUtils, 'getShortDomain').mockReturnValue("AGENT");
         jest.spyOn(TchapUtils, 'getRoomFederationOptions').mockReturnValue(
-            { showRoomFederationOption: true, roomFederationDefault: false });
+            { showRoomFederationOption: true, roomDefaultFederation: { external: true, private: true, forum: false }});
     });
 
     it('should render the whole component with with the allow access switch', () => {
         jest.spyOn(TchapUtils, 'getRoomFederationOptions').mockReturnValue(
-            { showRoomFederationOption: true, roomFederationDefault: false });
+            { showRoomFederationOption: true, roomDefaultFederation: { external: true, private: true, forum: false } });
         const component = getComponent();
         const allowAccessSwitch = component.find(".mx_SettingsFlag");
         expect(toJson(allowAccessSwitch)).toMatchSnapshot(
@@ -86,7 +86,7 @@ describe("TchapCreateRoomDialog", () => {
 
     it('should render the room dialog without the allow access switch', () => {
         jest.spyOn(TchapUtils, 'getRoomFederationOptions').mockReturnValue(
-            { showRoomFederationOption: false, roomFederationDefault: false });
+            { showRoomFederationOption: false, roomDefaultFederation: { external: true, private: true, forum: false } });
         const component = getComponent();
         const allowAccessSwitch = component.find(".mx_SettingsFlag");
         expect(allowAccessSwitch).toEqual({});

--- a/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -158,7 +158,6 @@ describe("TchapCreateRoomDialog", () => {
             wrapper.setState({
                 name: roomName,
                 tchapRoomType: TchapRoomType.Private,
-                forumFederationSwitchValue: false,
                 showFederateSwitch: false,
             });
         });
@@ -211,7 +210,7 @@ describe("TchapCreateRoomDialog", () => {
         expect(onFinished).toHaveBeenCalledWith(true, publicRoomWithoutFederationExpectedOpts);
     });
 
-    it("Should create a public room with federation", async () => {
+    it("Should create a public room with federation and switch", async () => {
         const onFinished = jest.fn();
 
         const publicRoomWithFederationExpectedOpts = {
@@ -254,6 +253,48 @@ describe("TchapCreateRoomDialog", () => {
         expect(onFinished).toHaveBeenCalledWith(true, publicRoomWithFederationExpectedOpts);
     });
 
+    it("Should create a public room with federation but no switch", async () => {
+        const onFinished = jest.fn();
+
+        const publicRoomWithFederationExpectedOpts = {
+            createOpts: {
+                name: roomName,
+                creation_content: {
+                    "m.federate": true,
+                },
+                initial_state: [
+                    {
+                        "content": {
+                            "rule": "restricted",
+                        },
+                        "state_key": "",
+                        "type": "im.vector.room.access_rules",
+                    },
+                ],
+                visibility: "public",
+                preset: "public_chat",
+            },
+            guestAccess: false,
+            joinRule: "public",
+            encryption: false,
+            historyVisibility: "shared",
+        };
+        const wrapper = getComponent({ onFinished });
+
+        // set state in component
+        act(() => {
+            wrapper.setState({
+                name: roomName,
+                tchapRoomType: TchapRoomType.Forum,
+                showFederateSwitch: false,
+            });
+        });
+
+        await submitForm(wrapper);
+
+        expect(onFinished).toHaveBeenCalledWith(true, publicRoomWithFederationExpectedOpts);
+    });
+
     it("Should create an external room", async () => {
         const onFinished = jest.fn();
 
@@ -287,7 +328,6 @@ describe("TchapCreateRoomDialog", () => {
             wrapper.setState({
                 name: roomName,
                 tchapRoomType: TchapRoomType.External,
-                forumFederationSwitchValue: false,
                 showFederateSwitch: false,
             });
         });


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/370

To reproduce the bugfix:

1. Create a private room
<img width="755" alt="Screenshot 2023-03-02 at 10 12 00" src="https://user-images.githubusercontent.com/6305268/222384007-bea4421a-cdf5-49a9-9cf5-2dcbdf722481.png">

2. Then add a user to this new private room. It works, because this PR changes the state of the room to federated by default.
Cf. before there was a popin saying:

<img width="576" alt="Screenshot 2023-03-02 at 10 15 37" src="https://user-images.githubusercontent.com/6305268/222384759-c9a21ff4-6a1e-47ad-89db-436105e1110f.png">

