### PR TITLE
Deactivate setup xsss toast, activate xsss ff in production

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -38,7 +38,8 @@
         "feature_thread": true,
         "feature_video_rooms" : false,
         "feature_new_device_manager" : false,
-        "tchap_activate_cross_signing_and_secure_storage" : true
+        "tchap_activate_cross_signing_and_secure_storage" : true,
+        "tchap_disable_cross_signing_setup_toast": true
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -33,7 +33,8 @@
         "feature_thread": true,
         "feature_video_rooms" : false,
         "feature_new_device_manager" : false,
-        "tchap_activate_cross_signing_and_secure_storage" : true
+        "tchap_activate_cross_signing_and_secure_storage" : true,
+        "tchap_disable_cross_signing_setup_toast": true
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.prod.json
+++ b/config.prod.json
@@ -108,7 +108,8 @@
         "feature_thread": true,
         "feature_video_rooms" : false,
         "feature_new_device_manager" : false,
-        "tchap_activate_cross_signing_and_secure_storage" : false
+        "tchap_activate_cross_signing_and_secure_storage" : false,
+        "tchap_disable_cross_signing_setup_toast": false
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.prod.json
+++ b/config.prod.json
@@ -108,8 +108,8 @@
         "feature_thread": true,
         "feature_video_rooms" : false,
         "feature_new_device_manager" : false,
-        "tchap_activate_cross_signing_and_secure_storage" : false,
-        "tchap_disable_cross_signing_setup_toast": false
+        "tchap_activate_cross_signing_and_secure_storage" : true,
+        "tchap_disable_cross_signing_setup_toast": true
     },
     "default_federate": true,
     "default_theme": "light",

--- a/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
@@ -138,7 +138,7 @@ index 8da8e5c..746ab0a 100644
                      aria-label={_t("Skip verification for now")}
                  />
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-index 5dc32de..170e429 100644
+index 5dc32de..f5cb1cd 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 +++ b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 @@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
@@ -160,12 +160,16 @@ index 5dc32de..170e429 100644
          case Kind.UPGRADE_ENCRYPTION:
              return _t("Upgrade");
          case Kind.VERIFY_THIS_SESSION:
-@@ -79,6 +82,12 @@ const onReject = () => {
+@@ -79,6 +82,16 @@ const onReject = () => {
  };
  
  export const showToast = (kind: Kind) => {
 +    /* :TCHAP: hide cross-signing setup toast when feature flag tchap_disable_cross_signing_setup_toast is on */
-+    if (TchapUIFeature.isCrossSigningAndSecureStorageActiveWithoutSetupToast() && (kind === Kind.SET_UP_ENCRYPTION || kind === Kind.UPGRADE_ENCRYPTION)) {
++    if (
++        TchapUIFeature.isCrossSigningAndSecureStorageActive()
++        && TchapUIFeature.isCrossSigningSetupToastDisabled()
++        && (kind === Kind.SET_UP_ENCRYPTION || kind === Kind.UPGRADE_ENCRYPTION)
++    ) {
 +        return;
 +    }
 +    /* end :TCHAP: */

--- a/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
@@ -138,10 +138,18 @@ index 8da8e5c..746ab0a 100644
                      aria-label={_t("Skip verification for now")}
                  />
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-index 5dc32de..c087058 100644
+index 5dc32de..170e429 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 +++ b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-@@ -50,7 +50,9 @@ const getIcon = (kind: Kind) => {
+@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+ 
++import TchapUIFeature from "../../../../src/util/TchapUIFeature";
+ import Modal from "../Modal";
+ import { _t } from "../languageHandler";
+ import DeviceListener from "../DeviceListener";
+@@ -50,7 +51,9 @@ const getIcon = (kind: Kind) => {
  const getSetupCaption = (kind: Kind) => {
      switch (kind) {
          case Kind.SET_UP_ENCRYPTION:
@@ -152,3 +160,16 @@ index 5dc32de..c087058 100644
          case Kind.UPGRADE_ENCRYPTION:
              return _t("Upgrade");
          case Kind.VERIFY_THIS_SESSION:
+@@ -79,6 +82,12 @@ const onReject = () => {
+ };
+ 
+ export const showToast = (kind: Kind) => {
++    /* :TCHAP: hide cross-signing setup toast when feature flag tchap_disable_cross_signing_setup_toast is on */
++    if (TchapUIFeature.isCrossSigningAndSecureStorageActiveWithoutSetupToast() && (kind === Kind.SET_UP_ENCRYPTION || kind === Kind.UPGRADE_ENCRYPTION)) {
++        return;
++    }
++    /* end :TCHAP: */
++
+     if (SecurityCustomisations.setupEncryptionNeeded?.(kind)) {
+         return;
+     }

--- a/src/util/TchapUIFeature.ts
+++ b/src/util/TchapUIFeature.ts
@@ -38,6 +38,19 @@ export default class TchapUIFeature {
         return isCrossSigningAndSecureStorageActive;
     };
 
+    /**
+     * This flag activates cross-signing and secure storage. But it also hides the xsss setup toast. 
+     * needs to be initialized to access the config.json (where the flag is set)
+     */
+        public static isCrossSigningAndSecureStorageActiveWithoutSetupToast = () : Boolean => {
+            //retrieve the feature flag from the config.json features flag section. 
+            //beware SdkConfig does not like to be invoked before the MatrixClient is initialized
+            const isCrossSigningAndSecureStorageActive =  SdkConfig.get("features")['tchap_activate_cross_signing_and_secure_storage'];
+            const isSetupToastDisabled =  SdkConfig.get("features")['tchap_disable_cross_signing_setup_toast'];
+            console.log(":tchap: tchap_activate_cross_signing_and_secure_storage and tchap_disable_cross_signing_setup_toast from config.json: ", { isCrossSigningAndSecureStorageActive, isSetupToastDisabled });
+            return isCrossSigningAndSecureStorageActive && isSetupToastDisabled;
+        };
+
      /**
      * This flag controls whether to force incoming key legacy verification (usefull for older mobile device than android 2.6, ios 2.2.3)
      */

--- a/src/util/TchapUIFeature.ts
+++ b/src/util/TchapUIFeature.ts
@@ -42,13 +42,12 @@ export default class TchapUIFeature {
      * This flag activates cross-signing and secure storage. But it also hides the xsss setup toast. 
      * needs to be initialized to access the config.json (where the flag is set)
      */
-        public static isCrossSigningAndSecureStorageActiveWithoutSetupToast = () : Boolean => {
+        public static isCrossSigningSetupToastDisabled = () : Boolean => {
             //retrieve the feature flag from the config.json features flag section. 
             //beware SdkConfig does not like to be invoked before the MatrixClient is initialized
-            const isCrossSigningAndSecureStorageActive =  SdkConfig.get("features")['tchap_activate_cross_signing_and_secure_storage'];
-            const isSetupToastDisabled =  SdkConfig.get("features")['tchap_disable_cross_signing_setup_toast'];
-            console.log(":tchap: tchap_activate_cross_signing_and_secure_storage and tchap_disable_cross_signing_setup_toast from config.json: ", { isCrossSigningAndSecureStorageActive, isSetupToastDisabled });
-            return isCrossSigningAndSecureStorageActive && isSetupToastDisabled;
+            const isCrossSigningSetupToastDisabled =  SdkConfig.get("features")['tchap_disable_cross_signing_setup_toast'];
+            console.log(":tchap: tchap_disable_cross_signing_setup_toast from config.json: ", isCrossSigningSetupToastDisabled);
+            return isCrossSigningSetupToastDisabled;
         };
 
      /**


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/445

Hide this setup toast:
<img width="402" alt="Screenshot 2023-03-13 at 11 40 45" src="https://user-images.githubusercontent.com/6305268/224678650-171e1f34-148d-48de-8ec3-7547b1ac7f6a.png">

To reproduce:
- create a new account
- on first log in, create a private room. Then the setup toast which previously popped up with cross-signing on, doesn't. Like this:
<img width="634" alt="Screenshot 2023-03-13 at 11 28 30" src="https://user-images.githubusercontent.com/6305268/224679163-919db752-d0cd-49e1-9053-e9d20ae4bfed.png">

However, this other toast still pops-up on re-login (as it should; make sure that it does in your test):
<img width="618" alt="Screenshot 2023-03-13 at 11 28 55" src="https://user-images.githubusercontent.com/6305268/224679120-32275f30-50f6-4645-aea6-3df85ec20e66.png">
