### PR TITLE
Change wrong Personal Messages label when searching a person in tchap…

### DIFF
--- a/patches/change-personal-messages-to-people-wording/matrix-react-sdk+3.63.0.patch
+++ b/patches/change-personal-messages-to-people-wording/matrix-react-sdk+3.63.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/spotlight/SpotlightDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+index 266021a..9fdfd8a 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/spotlight/SpotlightDialog.tsx
+@@ -132,7 +132,7 @@ export enum Filter {
+ function filterToLabel(filter: Filter): string {
+     switch (filter) {
+         case Filter.People:
+-            return _t("People");
++            return _t("Persons");
+         case Filter.PublicRooms:
+             return _t("Public rooms");
+     }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -209,5 +209,12 @@
       "src/components/structures/UserMenu.tsx",
       "res/css/structures/_UserMenu.pcss"
     ]
+  },
+  "change-personal-messages-to-people-wording": {
+    "github-issue" : "https://github.com/tchapgouv/tchap-web-v4/issues/448",
+    "package": "matrix-react-sdk",
+    "files": [
+      "src/components/views/dialogs/spotlight/SpotlightDialog.tsx"
+    ]
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -539,6 +539,11 @@
     "en": "Direct messages",
     "fr": "Messages directs"
   },
+  "Persons": {
+    "comments" : "Use persons to differenciate from Element label 'People' which we use in Tchap as 'Messages directs'",
+    "en": "People",
+    "fr": "Personnes"
+  },
   "Group all your people in one place.": {
     "en":"Group all your direct message room in one place.",
     "fr":"Regroupe tous vos salons de message directs au même endroit."


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/448

See screenshots with modifications (from "Messages personnels" to "Personnes"):

<img width="719" alt="Screenshot 2023-03-14 at 11 14 54" src="https://user-images.githubusercontent.com/6305268/224970447-f2663a64-045f-4720-bfc1-44432c0e6289.png">
<img width="722" alt="Screenshot 2023-03-14 at 11 14 49" src="https://user-images.githubusercontent.com/6305268/224970462-865cd030-56de-4c71-a440-36a377d894bb.png">
