### PR TITLE
hide unwanted "Search Messages" section in security settings

### DIFF
--- a/cypress/e2e/settings/security.ts
+++ b/cypress/e2e/settings/security.ts
@@ -1,0 +1,22 @@
+describe('Check settings customization', () => {
+  const homeserverUrl = Cypress.env('E2E_TEST_USER_HOMESERVER_URL');
+    const email = Cypress.env('E2E_TEST_USER_EMAIL');
+    const password = Cypress.env('E2E_TEST_USER_PASSWORD');
+
+  beforeEach(() => {
+    cy.loginUser(homeserverUrl, email, password);
+  });
+
+  it('show security configs without the things we dont like', () => {
+    cy.get(".mx_UserMenu_userAvatar").click();
+    cy.get('[aria-label="Sécurité et vie privée"]').click();
+
+    /**
+     * The section "Recherche de message" has been deleted, it was between "Sauvegarde automatique des messages" and "Signature croisée"
+     * https://github.com/tchapgouv/tchap-web-v4/issues/466
+     * see res/themes/tchap-common/css/_tchap_custom.pcss
+     */
+    cy.get(':nth-child(4) > :nth-child(1) > .mx_SettingsTab_subheading').should("contain", "Sauvegarde automatique des messages");
+    cy.get(':nth-child(3) > .mx_SettingsTab_subheading').should("contain", "Signature croisée");
+  })
+})

--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -8,3 +8,8 @@
 #mx_Dialog_StaticContainer > div > div.mx_Dialog > div.mx_CreateSecretStorageDialog > div:nth-child(2) > form > div.mx_CreateSecretStorageDialog_primaryContainer > label:nth-child(2) {
     display: none;
 }
+
+/* hide the "Recherche de message" section in security user settings */
+div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(4) > div:nth-child(2){
+    display: none;
+}


### PR DESCRIPTION
La section "Recherche de message" a été retirée

Before : 
![Capture d’écran 2023-03-16 à 17 31 12](https://user-images.githubusercontent.com/4077729/225688475-cd6b334e-2b13-4874-8dd5-24598525f3b9.png)

After : 
![Capture d’écran 2023-03-16 à 18 01 40](https://user-images.githubusercontent.com/4077729/225696435-2f072b12-0e46-48a3-84a3-ffa50907443b.png)
