### PR TITLE
Change login flow

### DIFF
--- a/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.63.0.patch
@@ -108,7 +108,7 @@ index cf0c160..9a970b9 100644
                                  kind="primary"
                                  className="mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn"
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
-index 8da8e5c..1fdb336 100644
+index 8da8e5c..2973592 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
 @@ -22,6 +22,7 @@ import SetupEncryptionBody from "./SetupEncryptionBody";
@@ -119,7 +119,18 @@ index 8da8e5c..1fdb336 100644
  
  interface IProps {
      onFinished: () => void;
-@@ -92,9 +93,16 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
+@@ -66,7 +67,9 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
+             return null;
+         } else if (phase === Phase.Intro) {
+             if (lostKeys) {
+-                icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
++                //:tchap: hide anxious icon of warning
++                //icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
++                //:tchap: end
+                 title = _t("Unable to verify this device");
+             } else {
+                 icon = <span className="mx_CompleteSecurity_headerIcon mx_E2EIcon_warning" />;
+@@ -92,9 +95,16 @@ export default class CompleteSecurity extends React.Component<IProps, IState> {
  
          let skipButton;
          if (phase === Phase.Intro || phase === Phase.ConfirmReset) {
@@ -137,6 +148,35 @@ index 8da8e5c..1fdb336 100644
                      className="mx_CompleteSecurity_skip"
                      aria-label={_t("Skip verification for now")}
                  />
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
+index 3f2fb26..ebef93e 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
+@@ -164,13 +164,23 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
+                                     "verify against.  This device will not be able to access old encrypted messages. " +
+                                     "In order to verify your identity on this device, you'll need to reset " +
+                                     "your verification keys.",
+-                            )}
++                            )
++                            }               
+                         </p>
+                         
++                        {/* :tchap: replace button of proceed with reset by a no-effect Continue button */}
+                         <div className="mx_CompleteSecurity_actionRow">
++                            <AccessibleButton kind="primary" onClick={this.onSkipConfirmClick}>
++                                {_t("Continue")}
++                            </AccessibleButton>
++
++                        {/* 
+                             <AccessibleButton kind="primary" onClick={this.onResetConfirmClick}>
+                                 {_t("Proceed with reset")}
+                             </AccessibleButton> 
++                            :tchap: end
++                            */
++                        }
+                         </div>
+                     </div>
+                 );
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 index 5dc32de..f5cb1cd 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -139,7 +139,8 @@
       "src/async-components/views/dialogs/security/CreateSecretStorageDialog.tsx",
       "src/toasts/SetupEncryptionToast.ts",
       "src/components/structures/auth/CompleteSecurity.tsx",
-      "res/css/views/auth/_CompleteSecurityBody.pcss"
+      "res/css/views/auth/_CompleteSecurityBody.pcss",
+      "src/components/structures/auth/SetupEncryptionBody.tsx"
     ]
   },
   "temp-settings-remove-enable-email-notifications-option": {

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -707,8 +707,8 @@
     "en": "Verify with Recovery code or Phrase"
   },
   "It looks like you don't have a Security Key or any other devices you can verify against.  This device will not be able to access old encrypted messages. In order to verify your identity on this device, you'll need to reset your verification keys.": {
-    "fr": "Il semblerait que vous n’avez pas de code de récupération ou d’autres appareils pour faire la vérification. Cet appareil ne pourra pas accéder aux anciens messages chiffrés. Afin de vérifier votre identité sur cet appareil, vous devrez réinitialiser vos clés de vérifications.",
-    "en": "It looks like you don't have a Recovery code or any other devices you can verify against.  This device will not be able to access old encrypted messages. In order to verify your identity on this device, you'll need to reset your verification keys."
+    "fr": "L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements. Vous pouvez y accéder dans la section Securité et vie privée > Sauvegarde automatique des messages",
+    "en": "The Tchap team is working on the deployment of a new feature to prevent encryption key loss. You can access it in the section Security and privacy > Secure Backup"
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {
     "fr": "Saisissez votre phrase de sécurité ou <button>utilisez votre code de récupération</button> pour continuer.",
@@ -741,5 +741,9 @@
   "Forgotten or lost all recovery methods? <a>Reset all</a>": {
     "fr": "Vous avez perdu votre code de récupération ? <a>Générer un nouveau code</a>",
     "en": "You have lost your recovery code? <a>Create a new code</a>"
+  },
+  "Unable to verify this device": {
+    "fr": "Vous vous connectez à un nouvel appareil",
+    "en": "You are logging into a new device"
   }
 }


### PR DESCRIPTION
The previous screenflow is here : 
fixes #470 

New flow : 
1) login
<img width="853" alt="Capture d’écran 2023-03-17 à 11 19 05" src="https://user-images.githubusercontent.com/4077729/225951368-312e3ebc-c3fe-4139-8462-c97098786357.png">

2) NEW Text
<img width="848" alt="Capture d’écran 2023-03-17 à 16 36 58" src="https://user-images.githubusercontent.com/4077729/225951270-a46e6506-4e90-409e-9ff3-13234842adb0.png">

3) home page
<img width="648" alt="Capture d’écran 2023-03-17 à 16 38 11" src="https://user-images.githubusercontent.com/4077729/225951449-ed2d76fe-0832-46e7-bb03-8f1c9f66e2da.png">


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/vector-im/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->
