### PR TITLE
When I send an infected document, change english error message to french

### DIFF
--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -63,7 +63,7 @@
   },
   "Content blocked": {
     "en": "Content blocked",
-    "fr": "Content blocked"
+    "fr": "Contenu bloqué"
   },
   "Trusted": {
     "en": "Trusted",


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/486

However I haven't yet succeeded in creating an infected file so I can't test it or upload a screenshot.
