### PR TITLE
replace continue button by open privacy settigns

### DIFF
--- a/patches/cross-signing-ui/matrix-react-sdk+3.68.0.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.68.0.patch
@@ -155,22 +155,62 @@ index 3171a0e..8751e6b 100644
                      aria-label={_t("Skip verification for now")}
                  />
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
-index fe8a24a..4611cb6 100644
+index fe8a24a..c82ea3a 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
-@@ -164,13 +164,23 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
+@@ -28,6 +28,10 @@ import { SetupEncryptionStore, Phase } from "../../../stores/SetupEncryptionStor
+ import EncryptionPanel from "../../views/right_panel/EncryptionPanel";
+ import AccessibleButton from "../../views/elements/AccessibleButton";
+ import Spinner from "../../views/elements/Spinner";
++import defaultDispatcher from "../../../dispatcher/dispatcher";
++import { Action } from "matrix-react-sdk/src/dispatcher/actions";
++import { UserTab } from "matrix-react-sdk/src/components/views/dialogs/UserTab";
++import { OpenToTabPayload } from "matrix-react-sdk/src/dispatcher/payloads/OpenToTabPayload";
+ 
+ function keyHasPassphrase(keyInfo: ISecretStorageKeyInfo): boolean {
+     return Boolean(keyInfo.passphrase && keyInfo.passphrase.salt && keyInfo.passphrase.iterations);
+@@ -81,6 +85,13 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
+         store.stop();
+     }
+ 
++    private openDeviceTab = async (): Promise<void> => {
++        const store = SetupEncryptionStore.sharedInstance();
++        store.skipConfirm();
++        const payload: OpenToTabPayload = { action: Action.ViewUserSettings, initialTabId: UserTab.Security };
++        defaultDispatcher.dispatch(payload);
++    };
++
+     private onUsePassphraseClick = async (): Promise<void> => {
+         const store = SetupEncryptionStore.sharedInstance();
+         store.usePassPhrase();
+@@ -159,18 +170,39 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
+                 return (
+                     <div>
+                         <p>
++                            {/* :tchap: change message to announce secure backup feature
+                             {_t(
+                                 "It looks like you don't have a Security Key or any other devices you can " +
                                      "verify against.  This device will not be able to access old encrypted messages. " +
                                      "In order to verify your identity on this device, you'll need to reset " +
                                      "your verification keys.",
--                            )}
-+                            )
-+                            }               
+                             )} 
++                             :tchap: end
++                            */}
++
++
++                            {_t(
++                                "<p>The Tchap team is working on the deployment of a new feature to "+
++                                "prevent encryption key loss.</p>"+
++                                "<p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>",
++                                 {}, { 'p': (sub) => <p>{sub}</p>}      
++                            )}
                          </p>
  
 +                        {/* :tchap: replace button of proceed with reset by a no-effect Continue button */}
                          <div className="mx_CompleteSecurity_actionRow">
-+                            <AccessibleButton kind="primary" onClick={this.onSkipConfirmClick}>
-+                                {_t("Continue")}
++                            <AccessibleButton kind="primary" onClick={this.openDeviceTab}>
++                            {/* <AccessibleButton kind="primary" onClick={this.onSkipConfirmClick}> */}
++                                {_t("Security & Privacy")}
 +                            </AccessibleButton>
 +
 +                        {/* 

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -714,9 +714,10 @@
     "fr": "Vérifier avec un code de récupération ou une phrase",
     "en": "Verify with Recovery code or Phrase"
   },
-  "It looks like you don't have a Security Key or any other devices you can verify against.  This device will not be able to access old encrypted messages. In order to verify your identity on this device, you'll need to reset your verification keys.": {
-    "fr": "L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements. Vous pouvez y accéder dans la section Securité et vie privée > Sauvegarde automatique des messages",
-    "en": "The Tchap team is working on the deployment of a new feature to prevent encryption key loss. You can access it in the section Security and privacy > Secure Backup"
+  "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
+    "fr": "<p>L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements.</p><p>Vous pouvez y accéder dans la section : </p><p>Securité et vie privée > Sauvegarde automatique des messages</p>",
+    "en": "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>"
+
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {
     "fr": "Saisissez votre phrase de sécurité ou <button>utilisez votre code de récupération</button> pour continuer.",

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -715,8 +715,8 @@
     "en": "Verify with Recovery code or Phrase"
   },
   "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
-    "fr": "<p>L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements.</p><p>Vous pouvez y accéder dans la section : </p><p>Securité et vie privée > Sauvegarde automatique des messages</p>",
-    "en": "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>"
+    "fr": "<p>L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements.</p><p>Vous pouvez y accéder depuis les Paramètres : </p><p>Securité et vie privée > Sauvegarde automatique des messages</p>",
+    "en": "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access from the settings :</p><p>Security and privacy > Secure Backup</p>"
 
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {


### PR DESCRIPTION
New flow
**Before** : a continue button that was buggy
**Now** : a "Security and Privacy" button that open the security settings

Flow : 
Reconnect to a isolated web session with xsss activated : 

1) login
2) first warning
![Capture d’écran 2023-03-27 à 15 50 31](https://user-images.githubusercontent.com/4077729/227960790-d5778bb2-8db5-4fa3-9f72-acb58804b4ad.png)

If you are not interesting in keeping your messages, you can close the panel

3) you get another toast warning 
![Capture d’écran 2023-03-27 à 15 58 32](https://user-images.githubusercontent.com/4077729/227961204-b0f3ea97-3ed7-4835-a1c8-8db0f36e8d87.png)

Which leads to 

![Capture d’écran 2023-03-27 à 15 37 04](https://user-images.githubusercontent.com/4077729/227961429-f2a7b256-15b1-49d0-a1e8-423e6e17bb81.png)

4) Again the "verify" button is getting you to this screen, we really need you to activate secure backup
![Capture d’écran 2023-03-27 à 16 08 03](https://user-images.githubusercontent.com/4077729/227964257-92cbffc2-fd36-4f42-a59e-a530fe8c019a.png)
