### PR TITLE
Fix reset password unworking buttons

### DIFF
--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -1,9 +1,6 @@
 /* override components style */
 /* those overrides are imported in all themes of tchap */
-/* [TEMPORARY] hide "Sign in instead" button on password forgotten page because the redirection is currently broken */
-.mx_AuthBody.mx_AuthBody_forgot-password .mx_AccessibleButton {
-    display: none;
-}
+
 /* hide the passphrase option in the setup options of the secure storage */
 #mx_Dialog_StaticContainer
     > div


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/477

When not working it looked like:
<img width="395" alt="Capture d’écran 2023-03-27 à 16 56 11" src="https://user-images.githubusercontent.com/6305268/227979001-97b6c85f-ff95-4948-a408-d1b667bbb6d3.png">


And after fixing, it looks like this (and the buttons work):
<img width="670" alt="Capture d’écran 2023-03-27 à 16 56 33" src="https://user-images.githubusercontent.com/6305268/227979021-06e2c101-0090-45e9-a25a-864006b8c3bd.png">
