### PR TITLE
Rework privacy settings (change order) in parameters

### DIFF
--- a/patches/change-sections-order-in-security-privacy-settings/matrix-react-sdk+3.69.1.patch
+++ b/patches/change-sections-order-in-security-privacy-settings/matrix-react-sdk+3.69.1.patch
@@ -52,25 +52,38 @@ index 34b52e4..8085f20 100644
              </div>
          );
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
-index 9697af8..04ae847 100644
+index 9697af8..00fcc04 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+@@ -287,7 +287,7 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
+     public render(): React.ReactNode {
+         const secureBackup = (
+             <div className="mx_SettingsTab_section">
+-                <span className="mx_SettingsTab_subheading">{_t("Secure Backup")}</span>
++                <span className="mx_SettingsTab_heading">{_t("Secure Backup")}</span>
+                 <div className="mx_SettingsTab_subsectionText">
+                     <SecureBackupPanel />
+                 </div>
 @@ -414,14 +414,16 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
          return (
              <div className="mx_SettingsTab mx_SecurityUserSettingsTab">
                  {warning}
 -                {devicesSection}
-                 <div className="mx_SettingsTab_heading">{_t("Encryption")}</div>
+-                <div className="mx_SettingsTab_heading">{_t("Encryption")}</div>
 -                <div className="mx_SettingsTab_section">
 +                {/* :TCHAP: change position {devicesSection} */}
 +                {/* :TCHAP: remove class <div className="mx_SettingsTab_section"> */}
 +                <div>
                      {secureBackup}
-                     {eventIndex}
-                     {crossSigning}
-                     <CryptographyPanel />
+-                    {eventIndex}
+-                    {crossSigning}
+-                    <CryptographyPanel />
                  </div>
-+                {/* :TCHAP: */}{devicesSection}{/* end :TCHAP: */}
++                {/* {eventIndex} :TCHAP: remove section */}
++                {devicesSection}
++                <div className="mx_SettingsTab_heading">{_t("Encryption")}</div>
++                {crossSigning}
++                <CryptographyPanel />
                  {privacySection}
                  {advancedSection}
              </div>

--- a/patches/change-sections-order-in-security-privacy-settings/matrix-react-sdk+3.69.1.patch
+++ b/patches/change-sections-order-in-security-privacy-settings/matrix-react-sdk+3.69.1.patch
@@ -1,16 +1,19 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/CryptographyPanel.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/CryptographyPanel.tsx
-index 34b52e4..1383002 100644
+index 34b52e4..8085f20 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/CryptographyPanel.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/CryptographyPanel.tsx
-@@ -73,6 +73,7 @@ export default class CryptographyPanel extends React.Component<IProps, IState> {
+@@ -72,7 +72,9 @@ export default class CryptographyPanel extends React.Component<IProps, IState> {
+         }
  
          return (
-             <div className="mx_SettingsTab_section mx_CryptographyPanel">
+-            <div className="mx_SettingsTab_section mx_CryptographyPanel">
++            <div className="mx_CryptographyPanel">
++            {/* :TCHAP: remove class <div className="mx_SettingsTab_section mx_CryptographyPanel"> */}
 +                {/* :TCHAP: modify content
                  <span className="mx_SettingsTab_subheading">{_t("Cryptography")}</span>
                  <table className="mx_SettingsTab_subsectionText mx_CryptographyPanel_sessionInfo">
                      <tbody>
-@@ -92,7 +93,36 @@ export default class CryptographyPanel extends React.Component<IProps, IState> {
+@@ -92,7 +94,36 @@ export default class CryptographyPanel extends React.Component<IProps, IState> {
                          </tr>
                      </tbody>
                  </table>
@@ -48,3 +51,26 @@ index 34b52e4..1383002 100644
                  {noSendUnverifiedSetting}
              </div>
          );
+diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+index 9697af8..04ae847 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+@@ -414,14 +414,16 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
+         return (
+             <div className="mx_SettingsTab mx_SecurityUserSettingsTab">
+                 {warning}
+-                {devicesSection}
+                 <div className="mx_SettingsTab_heading">{_t("Encryption")}</div>
+-                <div className="mx_SettingsTab_section">
++                {/* :TCHAP: change position {devicesSection} */}
++                {/* :TCHAP: remove class <div className="mx_SettingsTab_section"> */}
++                <div>
+                     {secureBackup}
+                     {eventIndex}
+                     {crossSigning}
+                     <CryptographyPanel />
+                 </div>
++                {/* :TCHAP: */}{devicesSection}{/* end :TCHAP: */}
+                 {privacySection}
+                 {advancedSection}
+             </div>

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -189,11 +189,12 @@
             "src/components/views/right_panel/RoomHeaderButtons.tsx"
         ]
     },
-    "change-confusing-chiffrement-sub-session-in-parameters": {
+    "change-sections-order-in-security-privacy-settings": {
         "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/465",
         "package": "matrix-react-sdk",
         "files": [
-            "src/components/views/settings/CryptographyPanel.tsx"
+            "src/components/views/settings/CryptographyPanel.tsx",
+            "src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx"
         ]
     },
     "add-translations-for-server-errors": {

--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -13,13 +13,8 @@
     display: none;
 }
 
-/* hide the "Recherche de message" section in security user settings */
-/* :TCHAP: div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(4) > div:nth-child(2) { */
-div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(2) > div:nth-child(2) {
-    display: none;
-}
-
 /* change link color and decoration in login error when email is not autorized */
+/* EDIT : is not taken into account */  
 .mx_Login_error.mx_Login_error_link {
     color: $alert important!;
     text-decoration: underline important!;

--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -14,9 +14,8 @@
 }
 
 /* change link color and decoration in login error when email is not autorized */
-/* EDIT : is not taken into account */  
+/* EDIT : is not taken into account */
 .mx_Login_error.mx_Login_error_link {
     color: $alert important!;
     text-decoration: underline important!;
 }
-

--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -14,7 +14,8 @@
 }
 
 /* hide the "Recherche de message" section in security user settings */
-div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(4) > div:nth-child(2) {
+/* :TCHAP: div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(4) > div:nth-child(2) { */
+div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(2) > div:nth-child(2) {
     display: none;
 }
 
@@ -23,3 +24,4 @@ div.mx_SettingsTab.mx_SecurityUserSettingsTab > div:nth-child(4) > div:nth-child
     color: $alert important!;
     text-decoration: underline important!;
 }
+

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -822,5 +822,9 @@
   "Access possible only by invitation of a member of the room.": {
     "fr": "Accès possible uniquement sur invitation d'un membre du salon.",
     "en": "Access possible only by invitation of a member of the room."
+  },
+  "Where you're signed in": {
+    "fr": "Appareils connectés",
+    "en": "Connected devices"
   }
 }


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/497

NB: Instead of creating a new patch, I realized that there was an existing patch with a purpose relatively similar to what I meant to do in this PR. The patch was `change-confusing-chiffrement-sub-session-in-parameters`. I made a combo out of the two, renaming the patch `change-sections-order-in-security-privacy-settings`.

Before:
<img width="525" alt="Capture d’écran 2023-03-31 à 10 32 04" src="https://user-images.githubusercontent.com/6305268/229069010-eeac9e44-37ef-4c6e-948b-b75571a6162d.png">

After:
<img width="525" alt="Capture d’écran 2023-04-04 à 16 26 07" src="https://user-images.githubusercontent.com/6305268/229827222-6f5dcd81-7d07-48cd-861e-c05714f0a121.png">
