### PR TITLE
Change xsss labels

### DIFF
--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -371,8 +371,8 @@
     "fr": "Importez vos clés Tchap depuis le fichier sauvegardé"
   },
   "Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will be secured with a unique Security Key.": {
-    "en": "This function allows you to save your messages automatically and retrieve them anytime thanks to a recovery Code.",
-    "fr": "Cette fonction vous permet de sauvegarder automatiquement vos messages et de les récupérer à tout moment à l’aide du Code de récupération."
+    "en": "Automatically back up your messages and retrieve them at any time using the recovery Code.",
+    "fr": "Sauvegardez automatiquement vos messages et récupérez-les à tout moment à l’aide du Code de récupération."
   },
   "Thread": {
     "en": "Thread",
@@ -744,8 +744,8 @@
     "en": "Activate"
   },
   "Connect this session to Key Backup": {
-    "fr": "Vérifier cette session",
-    "en": "Verify this session"
+    "fr": "Vérifier cet appareil",
+    "en": "Verify this device"
   },
   "Forgotten or lost all recovery methods? <a>Reset all</a>": {
     "fr": "Vous avez perdu votre code de récupération ? <a>Générer un nouveau code</a>",
@@ -830,6 +830,14 @@
   "This session is backing up your keys.": {
     "fr": "Cette session sauvegarde vos messages.",
     "en": "This session is backing up your messages."
+  },
+  "Cross-signing is not set up.": {
+    "fr": "La signature croisée n’est pas active",
+    "en": "Cross-signing is not active."
+  },
+  "Cross-signing is ready but keys are not backed up.": {
+    "fr": "La signature croisée est activée mais pas la sauvegarde automatique des messages.",
+    "en": "Cross-signing is ready but not the secure backup."
   },
   "Cross-signing is ready for use.": {
     "fr": "La signature croisée est activée sur cet appareil.",

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -822,5 +822,17 @@
   "Access possible only by invitation of a member of the room.": {
     "fr": "Accès possible uniquement sur invitation d'un membre du salon.",
     "en": "Access possible only by invitation of a member of the room."
+  },
+  "Restore from Backup": {
+    "fr": "Récupérer les messages",
+    "en": "Restore messages"
+  },
+  "This session is backing up your keys.": {
+    "fr": "Cette session sauvegarde vos messages.",
+    "en": "This session is backing up your messages."
+  },
+  "Cross-signing is ready for use.": {
+    "fr": "La signature croisée est activée sur cet appareil.",
+    "en": "Cross-signing is activated on this device."
   }
 }


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-product/issues/127#issuecomment-1494265569

Change labels:
- Restaurer depuis la sauvegarde > Récupérer les messages
- Cette session sauvegarde vos clés > Cette session sauvegarde vos messages
- La signature croisée est prête à être utilisée > La signature croisée est activée sur cet appareil

Before:
<img width="611" alt="Capture d’écran 2023-04-11 à 15 49 26" src="https://user-images.githubusercontent.com/6305268/231184170-eb8725b0-3888-4286-9d9c-9bf920a28c99.png">

After:
<img width="593" alt="Capture d’écran 2023-04-11 à 15 41 31" src="https://user-images.githubusercontent.com/6305268/231183855-8cd13d3b-5d87-46b3-bf5f-bae66cfd47c2.png">

Before:
<img width="340" alt="Capture d’écran 2023-04-11 à 15 49 32" src="https://user-images.githubusercontent.com/6305268/231184253-76a03af6-64bc-44bd-ab44-89c11c09fc0d.png">

After:
<img width="360" alt="Capture d’écran 2023-04-11 à 15 45 03" src="https://user-images.githubusercontent.com/6305268/231183878-6a7c6f44-61d4-42bd-bd0d-f694db8a14c7.png">
