### PR TITLE
Add a permalink to open security settings

### DIFF
--- a/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.69.1.patch
+++ b/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.69.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/MatrixChat.tsx b/node_modules/matrix-react-sdk/src/components/structures/MatrixChat.tsx
-index 00a05b1..2009120 100644
+index 00a05b1..46f4f7b 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/MatrixChat.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/MatrixChat.tsx
 @@ -32,6 +32,8 @@ import { throttle } from "lodash";
@@ -43,6 +43,23 @@ index 00a05b1..2009120 100644
          cli.on(ClientEvent.Room, (room) => {
              if (MatrixClientPeg.get().isCryptoEnabled()) {
                  const blacklistEnabled = SettingsStore.getValueAt(
+@@ -1710,6 +1730,16 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
+             return;
+         }
+ 
++
++        //:tchap:
++        if (screen === "sauvegarde-automatique") {
++            //open the security tab
++            //there is no anchor to sauvegarde-automatique subection
++            const payload: OpenToTabPayload = { action: Action.ViewUserSettings, initialTabId: UserTab.Security };
++            dis.dispatch(payload);
++        } else
++        //:tchap: end
++
+         if (screen === "register") {
+             dis.dispatch({
+                 action: "start_registration",
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 index 0ba8f58..0c202a6 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -150,7 +150,7 @@
     },
     "activate-cross-signing-and-secure-storage-react": {
         "comments": "introduce a feature flag for activating cross signing and secure storage (unify previous patches)",
-        "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/433",
+        "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/433, https://github.com/tchapgouv/tchap-web-v4/issues/540",
         "package": "matrix-react-sdk",
         "files": [
             "src/components/views/settings/SecureBackupPanel.tsx",


### PR DESCRIPTION
close #540 

links like this one : https://tchap.gouv.fr/#/sauvegarde-automatique

if the user is
-  connected : opens the security tab panel as mentionned in the issue
- not connected : the login page, then the home page



