### PR TITLE
Secure backup label modifications post user testing

### DIFF
--- a/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.69.1.patch
+++ b/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.69.1.patch
@@ -44,7 +44,7 @@ index 00a05b1..2009120 100644
              if (MatrixClientPeg.get().isCryptoEnabled()) {
                  const blacklistEnabled = SettingsStore.getValueAt(
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
-index 0ba8f58..0c202a6 100644
+index 0ba8f58..a5ab881 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 @@ -28,6 +28,7 @@ import ConfirmDestroyCrossSigningDialog from "../dialogs/security/ConfirmDestroy
@@ -65,7 +65,7 @@ index 0ba8f58..0c202a6 100644
  
          // TODO: determine how better to expose this to users in addition to prompts at login/toast
          if (!keysExistEverywhere && homeserverSupportsCrossSigning) {
-@@ -225,7 +229,9 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -225,9 +229,12 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
          }
  
          if (keysExistAnywhere) {
@@ -74,9 +74,13 @@ index 0ba8f58..0c202a6 100644
 +            advancedActions.push(
 +            // end :TCHAP:
                  <AccessibleButton key="reset" kind="danger" onClick={this.resetCrossSigning}>
-                     {_t("Reset")}
+-                    {_t("Reset")}
++                    {/* :TCHAP: change label {_t("Reset")} */}
++                    {_t("Generate a new password. Note that your locked messages will remain locked.")}
                  </AccessibleButton>,
-@@ -237,6 +243,19 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+             );
+         }
+@@ -237,6 +244,19 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
              actionRow = <div className="mx_CrossSigningPanel_buttonRow">{actions}</div>;
          }
  
@@ -96,7 +100,7 @@ index 0ba8f58..0c202a6 100644
          return (
              <div>
                  {summarisedStatus}
-@@ -274,6 +293,7 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -274,6 +294,7 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
                              </tr>
                          </tbody>
                      </table>
@@ -152,7 +156,7 @@ index cf7506c..dca86c3 100644
      }
  
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/SecureBackupPanel.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/SecureBackupPanel.tsx
-index 7ab2273..9bc08c5 100644
+index 7ab2273..dbacc05 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/SecureBackupPanel.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/SecureBackupPanel.tsx
 @@ -31,6 +31,7 @@ import AccessibleButton from "../elements/AccessibleButton";
@@ -186,6 +190,15 @@ index 7ab2273..9bc08c5 100644
          } else {
              statusDescription = (
                  <>
+@@ -432,7 +435,7 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
+                             { b: (sub) => <b>{sub}</b> },
+                         )}
+                     </p>
+-                    <p>{_t("Back up your keys before signing out to avoid losing them.")}</p>
++                    {/* :TCHAP: remove <p>{_t("Back up your keys before signing out to avoid losing them.")}</p> */}
+                 </>
+             );
+             actions.push(
 @@ -445,7 +448,9 @@ export default class SecureBackupPanel extends React.PureComponent<{}, IState> {
          if (secretStorageKeyInAccount) {
              actions.push(

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -856,9 +856,11 @@
     "en": "Your messages are now automatically backed up on this device."
   },
   "Wrong Security Key": {
-    "fr": "Le Code de Récupération n’est pas valide. Vérifier que c’est le plus récent et qu’il comprend / ne comprend pas les espaces.",
-    "en": "The Recovery Code is not valid. Check that it is the latest one and that it includes/doesn't include spaces."
+    "fr": "Le Code de Récupération n’est pas valide. Vérifier que c’est le plus récent et qu’il comprend des espaces.",
+    "en": "The Recovery Code is not valid. Check that it is the latest one and that it includes spaces."
   },
-
-  "Reset": "Réinitialiser"
+  "Generate a new password. Note that your locked messages will remain locked.": {
+    "fr": "Générer un nouveau mot de passe. Attention, vos messages verrouillés le resteront.",
+    "en": "Generate a new password. Note that your locked messages will remain locked."
+  }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -371,7 +371,7 @@
     "fr": "Importez vos clés Tchap depuis le fichier sauvegardé"
   },
   "Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will be secured with a unique Security Key.": {
-    "en": "Automatically back up your messages and retrieve them at any time using the recovery Code.",
+    "en": "Automatically back up your messages and retrieve them at any time using the Recovery Code.",
     "fr": "Sauvegardez automatiquement vos messages et récupérez-les à tout moment à l’aide du Code de Récupération."
   },
   "Thread": {
@@ -612,7 +612,7 @@
   },
   "Safeguard against losing access to encrypted messages & data": {
     "fr" : "Activez votre Code de Récupération pour ne jamais perdre vos messages",
-    "en" : "Activate your Recovery code to never lose your messages"
+    "en" : "Activate your Recovery Code to never lose your messages"
   },
   "Activate": {
     "fr" : "Activer",
@@ -620,11 +620,11 @@
   },
   "Security Key": {
     "fr": "Code de Récupération",
-    "en": "Recovery code"
+    "en": "Recovery Code"
   },
   "Verify with Security Key": {
     "fr": "Vérifier avec un Code de Récupération",
-    "en": "Verify with Recovery code"
+    "en": "Verify with Recovery Code"
   },
   "Your new device is now verified. It has access to your encrypted messages, and other users will see it as trusted.": {
     "fr": "Votre nouvel appareil est maintenant vérifié. Il a accès à vos messages chiffrés et les autres utilisateurs le verront comme fiable.",
@@ -640,19 +640,19 @@
   },
   "Use your Security Key to continue.": {
     "fr": "Utilisez votre Code de Récupération pour continuer.",
-    "en": "Use your Recovery code to continue."
+    "en": "Use your Recovery Code to continue."
   },
   "Generate a Security Key": {
     "fr": "Générer un Code de Récupération",
-    "en": "Generate a Recovery code"
+    "en": "Generate a Recovery Code"
   },
   "Use a secret phrase only you know, and optionally save a Security Key to use for backup.": {
     "fr": "Utilisez une phrase secrète que vous êtes seul à connaître et enregistrez éventuellement un Code de Récupération à utiliser pour la sauvegarde.",
-    "en": "Use a secret phrase only you know, and optionally save a Recovery code to use for backup."
+    "en": "Use a secret phrase only you know, and optionally save a Recovery Code to use for backup."
   },
   "Save your Security Key": {
     "fr": "Notez votre Code de Récupération",
-    "en": "Write down your Recovery code"
+    "en": "Write down your Recovery Code"
   },
   "This session has detected that your Security Phrase and key for Secure Messages have been removed.": {
     "fr": "Cette session a détecté que votre phrase secrète et Code de Récupération pour les messages sécurisés ont été supprimés.",
@@ -660,59 +660,59 @@
   },
   "A new Security Phrase and key for Secure Messages have been detected.": {
     "fr": "Un nouveau Code de Récupération pour les messages sécurisés a été détecté.",
-    "en": "A new Recovery code for Secure Messages has been detected."
+    "en": "A new Recovery Code for Secure Messages has been detected."
   },
   "Make a copy of your Security Key": {
     "fr": "Faire une copie de votre Code de Récupération",
-    "en": "Make a copy of your Recovery code"
+    "en": "Make a copy of your Recovery Code"
   },
   "Secure your backup with a Security Phrase": {
     "fr": "Protégez votre sauvegarde avec un Code de Récupération",
-    "en": "Secure your backup with a Recovery code"
+    "en": "Secure your backup with a Recovery Code"
   },
   "Your Security Key is in your <b>Downloads</b> folder.": {
     "fr": "Votre Code de Récupération est dans le répertoire <b>Téléchargements</b>.",
-    "en": "Your Recovery code is in your <b>Downloads</b> folder."
+    "en": "Your Recovery Code is in your <b>Downloads</b> folder."
   },
   "Your Security Key": {
     "fr": "Votre Code de Récupération",
-    "en": "Your Recovery code"
+    "en": "Your Recovery Code"
   },
   "Your Security Key is a safety net - you can use it to restore access to your encrypted messages if you forget your Security Phrase.": {
     "fr": "Votre Code de Récupération est un filet de sécurité. Vous pouvez l’utiliser pour retrouver l’accès à vos messages chiffrés si vous oubliez votre phrase secrète.",
-    "en": "Your Recovery code is a safety net - you can use it to restore access to your encrypted messages if you forget your Security Phrase."
+    "en": "Your Recovery Code is a safety net - you can use it to restore access to your encrypted messages if you forget your Security Phrase."
   },
   "Set up with a Security Key": {
     "fr": "Configurer avec un Code de Récupération",
-    "en": "Set up with a Recovery code"
+    "en": "Set up with a Recovery Code"
   },
   "If you've forgotten your Security Key you can <button>set up new recovery options</button>": {
     "fr": "Si vous avez oublié votre Code de Récupération, vous pouvez <button>définir de nouvelles options de récupération</button>",
-    "en": "If you've forgotten your Recovery code you can <button>set up new recovery options</button>"
+    "en": "If you've forgotten your Recovery Code you can <button>set up new recovery options</button>"
   },
   "Access your secure message history and set up secure messaging by entering your Security Key.": {
     "fr": "Accédez à votre historique de messages chiffrés et mettez en place la messagerie sécurisée en entrant votre Code de Récupération.",
-    "en": "Access your secure message history and set up secure messaging by entering your Recovery code."
+    "en": "Access your secure message history and set up secure messaging by entering your Recovery Code."
   },
   "Enter Security Key": {
     "fr": "Saisir le Code de Récupération",
-    "en": "Enter Recovery code"
+    "en": "Enter Recovery Code"
   },
   "If you've forgotten your Security Phrase you can <button1>use your Security Key</button1> or <button2>set up new recovery options</button2>": {
     "fr": "Si vous avez oublié votre phrase secrète vous pouvez <button1>utiliser votre Code de Récupération</button1> ou <button2>définir de nouvelles options de récupération</button2>",
-    "en": "If you've forgotten your Security Phrase you can <button1>use your Recovery code</button1> or <button2>set up new recovery options</button2>"
+    "en": "If you've forgotten your Security Phrase you can <button1>use your Recovery Code</button1> or <button2>set up new recovery options</button2>"
   },
   "Backup could not be decrypted with this Security Key: please verify that you entered the correct Security Key.": {
     "fr": "La sauvegarde n’a pas pu être déchiffrée avec cette clé de sécurité : merci de vérifier que vous avez saisi le bon Code de Récupération.",
-    "en": "Backup could not be decrypted with this Recovery Key: please verify that you entered the correct Recovery code."
+    "en": "Backup could not be decrypted with this Recovery Key: please verify that you entered the correct Recovery Code."
   },
   "Please only proceed if you're sure you've lost all of your other devices and your security key.": {
     "fr": "Veuillez ne continuer que si vous êtes certain d’avoir perdu tous vos autres appareils et votre Code de Récupération.",
-    "en": "Please only proceed if you're sure you've lost all of your other devices and your recovery code."
+    "en": "Please only proceed if you're sure you've lost all of your other devices and your Recovery Code."
   },
   "Verify with Security Key or Phrase": {
     "fr": "Vérifier avec un Code de Récupération ou une phrase",
-    "en": "Verify with Recovery code or Phrase"
+    "en": "Verify with Recovery Code or Phrase"
   },
   "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
     "fr": "<p>L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements.</p><p>Vous pouvez y accéder depuis les Paramètres : </p><p>Securité et vie privée > Sauvegarde automatique des messages</p>",
@@ -721,11 +721,11 @@
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {
     "fr": "Saisissez votre phrase de sécurité ou <button>utilisez votre Code de Récupération</button> pour continuer.",
-    "en": "Enter your Security Phrase or <button>use your Recovery code</button> to continue."
+    "en": "Enter your Security Phrase or <button>use your Recovery Code</button> to continue."
   },
   "We'll generate a Security Key for you to store somewhere safe, like a password manager or a safe.": {
     "fr": "Nous génèrerons votre Code de Récupération unique que vous devrez stocker dans un endroit sûr, comme un gestionnaire de mots de passe ou un coffre.",
-    "en": "We'll generate your unique Recovery code for you to store somewhere safe, like a password manager or a safe."
+    "en": "We'll generate your unique Recovery Code for you to store somewhere safe, like a password manager or a safe."
   },
   "Invite someone using their name, email address, username (like <userId/>) or <a>share this room</a>.": {
     "fr": "Invitez quelqu’un via son nom, mail ou pseudo (p. ex. <userId/>) ou <a>partagez ce salon</a>. Il est possible d'inviter en masse en copiant et collant une liste de mails séparés par une virgule (prenom1.nom1@beta.gouv.fr, prenom2.nom2@beta.gouv.fr, prenom3.nom3@beta.gouv.fr) ou séparés par un saut à la ligne.",
@@ -749,7 +749,7 @@
   },
   "Forgotten or lost all recovery methods? <a>Reset all</a>": {
     "fr": "Vous avez perdu votre Code de Récupération ? <a>Générer un nouveau code</a>",
-    "en": "You have lost your recovery code? <a>Create a new code</a>"
+    "en": "You have lost your Recovery Code? <a>Create a new code</a>"
   },
   "Unable to verify this device": {
     "fr": "Vous vous connectez à un nouvel appareil",
@@ -797,7 +797,7 @@
   },
   "Please note this is not your recovery code for your automatic backup.": {
     "fr": "Attention ceci n’est pas votre Code de Récupération pour votre sauvegarde automatique.",
-    "en": "Please note this is not your recovery code for your automatic backup."
+    "en": "Please note this is not your Recovery Code for your automatic backup."
   },
   "Tchap keys": {
     "fr": "Clés Tchap",

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -372,7 +372,7 @@
   },
   "Back up your encryption keys with your account data in case you lose access to your sessions. Your keys will be secured with a unique Security Key.": {
     "en": "Automatically back up your messages and retrieve them at any time using the recovery Code.",
-    "fr": "Sauvegardez automatiquement vos messages et récupérez-les à tout moment à l’aide du Code de récupération."
+    "fr": "Sauvegardez automatiquement vos messages et récupérez-les à tout moment à l’aide du Code de Récupération."
   },
   "Thread": {
     "en": "Thread",
@@ -603,15 +603,15 @@
     "en": "Warning: this is the only time this code will be displayed!"
   },
   "Store your Security Key somewhere safe, like a password manager or a safe, as it's used to safeguard your encrypted data.": {
-    "fr": "Pensez à le conserver dans un endroit sûr, par exemple dans votre gestionnaire de mot de passe, sur un papier dans une armoire ou un tiroir fermé à clé.",
-    "en": "Remember to keep it in a safe place, for example in your password manager, on a piece of paper in a locked cupboard or drawer."
+    "fr": "Conservez-le dans un endroit sûr, comme votre gestionnaire de mot de passe ou un document protégé sur votre ordinateur. Vous aurez à le copier / coller pour récupérer vos messages, donc évitez la capture d’écran.",
+    "en": "Keep it in a safe place, such as your password manager or a protected document on your computer. You will need to copy/paste it to retrieve your messages, so avoid taking screenshots."
   },
   "I wrote down my code": {
     "fr": "J'ai noté mon code",
     "en": "I wrote down my code"
   },
   "Safeguard against losing access to encrypted messages & data": {
-    "fr" : "Activez votre code de récupération pour ne jamais perdre vos messages",
+    "fr" : "Activez votre Code de Récupération pour ne jamais perdre vos messages",
     "en" : "Activate your Recovery code to never lose your messages"
   },
   "Activate": {
@@ -619,11 +619,11 @@
     "en" : "Activate"
   },
   "Security Key": {
-    "fr": "Code de récupération",
+    "fr": "Code de Récupération",
     "en": "Recovery code"
   },
   "Verify with Security Key": {
-    "fr": "Vérifier avec un code de récupération",
+    "fr": "Vérifier avec un Code de Récupération",
     "en": "Verify with Recovery code"
   },
   "Your new device is now verified. It has access to your encrypted messages, and other users will see it as trusted.": {
@@ -639,79 +639,79 @@
     "en": "Use automatic Backup"
   },
   "Use your Security Key to continue.": {
-    "fr": "Utilisez votre code de récupération pour continuer.",
+    "fr": "Utilisez votre Code de Récupération pour continuer.",
     "en": "Use your Recovery code to continue."
   },
   "Generate a Security Key": {
-    "fr": "Générer un code de récupération",
+    "fr": "Générer un Code de Récupération",
     "en": "Generate a Recovery code"
   },
   "Use a secret phrase only you know, and optionally save a Security Key to use for backup.": {
-    "fr": "Utilisez une phrase secrète que vous êtes seul à connaître et enregistrez éventuellement un code de récupération à utiliser pour la sauvegarde.",
+    "fr": "Utilisez une phrase secrète que vous êtes seul à connaître et enregistrez éventuellement un Code de Récupération à utiliser pour la sauvegarde.",
     "en": "Use a secret phrase only you know, and optionally save a Recovery code to use for backup."
   },
   "Save your Security Key": {
-    "fr": "Notez votre code de récupération",
+    "fr": "Notez votre Code de Récupération",
     "en": "Write down your Recovery code"
   },
   "This session has detected that your Security Phrase and key for Secure Messages have been removed.": {
-    "fr": "Cette session a détecté que votre phrase secrète et code de récupération pour les messages sécurisés ont été supprimés.",
+    "fr": "Cette session a détecté que votre phrase secrète et Code de Récupération pour les messages sécurisés ont été supprimés.",
     "en": "This session has detected that your Security Phrase and code for Secure Messages have been removed."
   },
   "A new Security Phrase and key for Secure Messages have been detected.": {
-    "fr": "Un nouveau code de récupération pour les messages sécurisés a été détecté.",
+    "fr": "Un nouveau Code de Récupération pour les messages sécurisés a été détecté.",
     "en": "A new Recovery code for Secure Messages has been detected."
   },
   "Make a copy of your Security Key": {
-    "fr": "Faire une copie de votre code de récupération",
+    "fr": "Faire une copie de votre Code de Récupération",
     "en": "Make a copy of your Recovery code"
   },
   "Secure your backup with a Security Phrase": {
-    "fr": "Protégez votre sauvegarde avec un code de récupération",
+    "fr": "Protégez votre sauvegarde avec un Code de Récupération",
     "en": "Secure your backup with a Recovery code"
   },
   "Your Security Key is in your <b>Downloads</b> folder.": {
-    "fr": "Votre code de récupération est dans le répertoire <b>Téléchargements</b>.",
+    "fr": "Votre Code de Récupération est dans le répertoire <b>Téléchargements</b>.",
     "en": "Your Recovery code is in your <b>Downloads</b> folder."
   },
   "Your Security Key": {
-    "fr": "Votre code de récupération",
+    "fr": "Votre Code de Récupération",
     "en": "Your Recovery code"
   },
   "Your Security Key is a safety net - you can use it to restore access to your encrypted messages if you forget your Security Phrase.": {
-    "fr": "Votre code de récupération est un filet de sécurité. Vous pouvez l’utiliser pour retrouver l’accès à vos messages chiffrés si vous oubliez votre phrase secrète.",
+    "fr": "Votre Code de Récupération est un filet de sécurité. Vous pouvez l’utiliser pour retrouver l’accès à vos messages chiffrés si vous oubliez votre phrase secrète.",
     "en": "Your Recovery code is a safety net - you can use it to restore access to your encrypted messages if you forget your Security Phrase."
   },
   "Set up with a Security Key": {
-    "fr": "Configurer avec un code de récupération",
+    "fr": "Configurer avec un Code de Récupération",
     "en": "Set up with a Recovery code"
   },
   "If you've forgotten your Security Key you can <button>set up new recovery options</button>": {
-    "fr": "Si vous avez oublié votre code de récupération, vous pouvez <button>définir de nouvelles options de récupération</button>",
+    "fr": "Si vous avez oublié votre Code de Récupération, vous pouvez <button>définir de nouvelles options de récupération</button>",
     "en": "If you've forgotten your Recovery code you can <button>set up new recovery options</button>"
   },
   "Access your secure message history and set up secure messaging by entering your Security Key.": {
-    "fr": "Accédez à votre historique de messages chiffrés et mettez en place la messagerie sécurisée en entrant votre code de récupération.",
+    "fr": "Accédez à votre historique de messages chiffrés et mettez en place la messagerie sécurisée en entrant votre Code de Récupération.",
     "en": "Access your secure message history and set up secure messaging by entering your Recovery code."
   },
   "Enter Security Key": {
-    "fr": "Saisir le code de récupération",
+    "fr": "Saisir le Code de Récupération",
     "en": "Enter Recovery code"
   },
   "If you've forgotten your Security Phrase you can <button1>use your Security Key</button1> or <button2>set up new recovery options</button2>": {
-    "fr": "Si vous avez oublié votre phrase secrète vous pouvez <button1>utiliser votre code de récupération</button1> ou <button2>définir de nouvelles options de récupération</button2>",
+    "fr": "Si vous avez oublié votre phrase secrète vous pouvez <button1>utiliser votre Code de Récupération</button1> ou <button2>définir de nouvelles options de récupération</button2>",
     "en": "If you've forgotten your Security Phrase you can <button1>use your Recovery code</button1> or <button2>set up new recovery options</button2>"
   },
   "Backup could not be decrypted with this Security Key: please verify that you entered the correct Security Key.": {
-    "fr": "La sauvegarde n’a pas pu être déchiffrée avec cette clé de sécurité : merci de vérifier que vous avez saisi le bon code de récupération.",
+    "fr": "La sauvegarde n’a pas pu être déchiffrée avec cette clé de sécurité : merci de vérifier que vous avez saisi le bon Code de Récupération.",
     "en": "Backup could not be decrypted with this Recovery Key: please verify that you entered the correct Recovery code."
   },
   "Please only proceed if you're sure you've lost all of your other devices and your security key.": {
-    "fr": "Veuillez ne continuer que si vous êtes certain d’avoir perdu tous vos autres appareils et votre code de récupération.",
+    "fr": "Veuillez ne continuer que si vous êtes certain d’avoir perdu tous vos autres appareils et votre Code de Récupération.",
     "en": "Please only proceed if you're sure you've lost all of your other devices and your recovery code."
   },
   "Verify with Security Key or Phrase": {
-    "fr": "Vérifier avec un code de récupération ou une phrase",
+    "fr": "Vérifier avec un Code de Récupération ou une phrase",
     "en": "Verify with Recovery code or Phrase"
   },
   "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
@@ -720,11 +720,11 @@
 
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {
-    "fr": "Saisissez votre phrase de sécurité ou <button>utilisez votre code de récupération</button> pour continuer.",
+    "fr": "Saisissez votre phrase de sécurité ou <button>utilisez votre Code de Récupération</button> pour continuer.",
     "en": "Enter your Security Phrase or <button>use your Recovery code</button> to continue."
   },
   "We'll generate a Security Key for you to store somewhere safe, like a password manager or a safe.": {
-    "fr": "Nous génèrerons votre code de récupération unique que vous devrez stocker dans un endroit sûr, comme un gestionnaire de mots de passe ou un coffre.",
+    "fr": "Nous génèrerons votre Code de Récupération unique que vous devrez stocker dans un endroit sûr, comme un gestionnaire de mots de passe ou un coffre.",
     "en": "We'll generate your unique Recovery code for you to store somewhere safe, like a password manager or a safe."
   },
   "Invite someone using their name, email address, username (like <userId/>) or <a>share this room</a>.": {
@@ -748,7 +748,7 @@
     "en": "Verify this device"
   },
   "Forgotten or lost all recovery methods? <a>Reset all</a>": {
-    "fr": "Vous avez perdu votre code de récupération ? <a>Générer un nouveau code</a>",
+    "fr": "Vous avez perdu votre Code de Récupération ? <a>Générer un nouveau code</a>",
     "en": "You have lost your recovery code? <a>Create a new code</a>"
   },
   "Unable to verify this device": {
@@ -796,7 +796,7 @@
     "en": "These keys only apply to the current session."
   },
   "Please note this is not your recovery code for your automatic backup.": {
-    "fr": "Attention ceci n’est pas votre code de récupération pour votre sauvegarde automatique.",
+    "fr": "Attention ceci n’est pas votre Code de Récupération pour votre sauvegarde automatique.",
     "en": "Please note this is not your recovery code for your automatic backup."
   },
   "Tchap keys": {
@@ -824,12 +824,12 @@
     "en": "Access possible only by invitation of a member of the room."
   },
   "Restore from Backup": {
-    "fr": "Récupérer les messages",
-    "en": "Restore messages"
+    "fr": "Récupérer mes messages",
+    "en": "Retrieve my messages"
   },
   "This session is backing up your keys.": {
-    "fr": "Cette session sauvegarde vos messages.",
-    "en": "This session is backing up your messages."
+    "fr": "Cet appareil sauvegarde automatiquement vos messages.",
+    "en": "This device automatically backs up your messages."
   },
   "Cross-signing is not set up.": {
     "fr": "La signature croisée n’est pas active",
@@ -842,5 +842,23 @@
   "Cross-signing is ready for use.": {
     "fr": "La signature croisée est activée sur cet appareil.",
     "en": "Cross-signing is activated on this device."
-  }
+  },
+  "Your keys are <b>not being backed up from this session</b>.": {
+    "fr": "Cet appareil ne sauvegarde pas vos messages.",
+    "en": "This device is not backing up your messages."
+  },
+  "Secure Backup successful": {
+    "fr": "Sauvegarde automatique activée avec succès",
+    "en": "Secure backup successfully enabled."
+  },
+  "Your keys are now being backed up from this device.": {
+    "fr": "Vos messages sont maintenant automatiquement sauvegardés sur cet appareil.",
+    "en": "Your messages are now automatically backed up on this device."
+  },
+  "Wrong Security Key": {
+    "fr": "Le Code de Récupération n’est pas valide. Vérifier que c’est le plus récent et qu’il comprend / ne comprend pas les espaces.",
+    "en": "The Recovery Code is not valid. Check that it is the latest one and that it includes/doesn't include spaces."
+  },
+
+  "Reset": "Réinitialiser"
 }


### PR DESCRIPTION
Cf. https://www.notion.so/mercurial-timer-ec4/R-sultats-Sauvegarde-Automatique-47755e5334ed45cfb51a3a21928e1f0e

Wording:

1. Before: 
<img width="743" alt="Capture d’écran 2023-04-17 à 14 16 50" src="https://user-images.githubusercontent.com/6305268/232481678-ec09e032-f7ae-4830-ae61-ac442a6d0904.png">

- [x] change “Vos clés ne sont pas sauvegardées sur cette session” into “Cet appareil ne sauvegarde pas vos messages”. (And the same for the positif "vos cles sont sauvegardees" > "cet appareil sauvegarde")
- [x] remove 3rd sentence "Sauvegarder vos cles avant de vous deconnecter pour eviter de les perdre."

After:
<img width="628" alt="Capture d’écran 2023-04-17 à 13 58 48" src="https://user-images.githubusercontent.com/6305268/232479332-985eec95-f5c1-40a2-9abb-69f104835095.png">

2. Before:
<img width="708" alt="Capture d’écran 2023-04-17 à 14 23 19" src="https://user-images.githubusercontent.com/6305268/232482959-4be78e3f-60f4-496a-a0d1-8d5e13401c87.png">

- [x] Change 3rd sentence "Pensez a le conserver dans un endroit sur [...]" into "Conservez-le dans un endroit sûr, comme votre gestionnaire de mot de passe ou un document protégé sur votre ordinateur. 
Vous aurez à le copier / coller pour récupérer vos messages, donc évitez la capture d’écran."

After:
<img width="609" alt="Capture d’écran 2023-04-17 à 14 01 29" src="https://user-images.githubusercontent.com/6305268/232479656-9b2b6435-bbcd-498d-aab6-9acf719fc532.png">



- [x] Change all “code de récupération” into “Code de Récupération”.



3. Before:
<img width="587" alt="Capture d’écran 2023-04-17 à 14 32 24" src="https://user-images.githubusercontent.com/6305268/232484962-d832d70b-9820-4935-ad51-9c5e0f06ee81.png">

- [x] Change the two sentences into “Sauvegarde automatique activée avec succès” and “Vos messages sont maintenant automatiquement sauvegardés sur cet appareil.”

After:
<img width="722" alt="Capture d’écran 2023-04-17 à 13 52 38" src="https://user-images.githubusercontent.com/6305268/232479689-42d66fbd-6e3b-49b4-b7a1-e85a1383fddb.png">

4. Before:
<img width="742" alt="Capture d’écran 2023-04-17 à 14 34 10" src="https://user-images.githubusercontent.com/6305268/232485577-72df4143-020e-4ae3-ad41-5f3486a08235.png">

- [x] Change “Cette session sauvegarde vos clés” into “Cet appareil sauvegarde automatiquement vos messages”
- [x] Change "Restaurer depuis la sauvegarde" into "Récupérer mes messages"
- [x] Delete button “Supprimer la sauvegarde” > already done
- [x] Hide the section “chiffrement” with the Tchap Keys

After:
<img width="625" alt="Capture d’écran 2023-04-17 à 14 34 35" src="https://user-images.githubusercontent.com/6305268/232485645-efd999a8-458c-4b91-97e9-10006a57f6f4.png">

5. Before:
<img width="712" alt="Capture d’écran 2023-04-17 à 14 42 51" src="https://user-images.githubusercontent.com/6305268/232487519-147aec98-89cc-485d-bb07-bd0213814126.png">

- [x] Change "Mauvaise cle de securite" into “Le Code de Récupération n’est pas valide. Vérifier que c’est le plus récent et qu’il comprend des espaces.”

After:
<img width="753" alt="Capture d’écran 2023-04-17 à 14 57 42" src="https://user-images.githubusercontent.com/6305268/232490887-9e2fe063-7279-4a8c-94ba-42ee374a712d.png">

6. Before:
<img width="382" alt="Capture d’écran 2023-04-17 à 15 07 31" src="https://user-images.githubusercontent.com/6305268/232493325-8fc1ee1b-2662-4e1d-89e5-dba00b38252e.png">

- [x] Change button "Réinitialiser" into "Générer un nouveau mot de passe"
- [x] Question : si on génère un nouveau mot de passe quand on a des messages verrouillés, est-ce que ça veut dire qu’on ne récupère pas nos messages verrouillés ? On pourrait le préciser aux users ?

After:
<img width="629" alt="Capture d’écran 2023-04-17 à 15 06 10" src="https://user-images.githubusercontent.com/6305268/232493143-02300a5e-f54c-4cd2-8a5f-639911218b92.png">
