### PR TITLE
Allow all users to see forum history

### DIFF
--- a/src/lib/createTchapRoom.ts
+++ b/src/lib/createTchapRoom.ts
@@ -48,7 +48,10 @@ export default class TchapCreateRoom {
 
                 opts.joinRule = JoinRule.Public;
                 opts.encryption = false;
-                opts.historyVisibility = HistoryVisibility.Shared;
+                // :TCHAP: change to anyone being able to see history in forum
+                // opts.historyVisibility = HistoryVisibility.Shared;
+                opts.historyVisibility = HistoryVisibility.WorldReadable;
+                // end :TCHAP:
                 break;
             }
             case TchapRoomType.Private: {

--- a/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -197,7 +197,7 @@ describe("TchapCreateRoomDialog", () => {
             guestAccess: false,
             joinRule: "public",
             encryption: false,
-            historyVisibility: "shared",
+            historyVisibility: "world_readable",
         };
         const wrapper = getComponent({ onFinished });
 
@@ -240,7 +240,7 @@ describe("TchapCreateRoomDialog", () => {
             guestAccess: false,
             joinRule: "public",
             encryption: false,
-            historyVisibility: "shared",
+            historyVisibility: "world_readable",
         };
         const wrapper = getComponent({ onFinished });
 
@@ -283,7 +283,7 @@ describe("TchapCreateRoomDialog", () => {
             guestAccess: false,
             joinRule: "public",
             encryption: false,
-            historyVisibility: "shared",
+            historyVisibility: "world_readable",
         };
         const wrapper = getComponent({ onFinished });
 

--- a/test/unit-tests/lib/createTchapRoom-test.ts
+++ b/test/unit-tests/lib/createTchapRoom-test.ts
@@ -58,7 +58,7 @@ describe("Create room options", () => {
             guestAccess: false,
             joinRule: "public",
             encryption: false,
-            historyVisibility: "shared",
+            historyVisibility: "world_readable",
         };
         expect(TchapCreateRoom.roomCreateOptions("testName", TchapRoomType.Forum, false)).toStrictEqual(
             publicRoomWithoutFederationExpectedOpts,
@@ -88,7 +88,7 @@ describe("Create room options", () => {
             guestAccess: false,
             joinRule: "public",
             encryption: false,
-            historyVisibility: "shared",
+            historyVisibility: "world_readable",
         };
         expect(TchapCreateRoom.roomCreateOptions("testName", TchapRoomType.Forum, true)).toStrictEqual(
             publicRoomWithFederationExpectedOpts,


### PR DESCRIPTION
Cf. https://github.com/tchapgouv/tchap-web-v4/issues/523

To reproduce: 
Go to an existing forum, in the side parameters, and click on "Paramètres du salon" > "Sécurité et vie privée".

Before:
<img width="456" alt="Capture d’écran 2023-04-18 à 17 04 53" src="https://user-images.githubusercontent.com/6305268/232819908-2080d4fd-a91b-46da-b131-370ef7f1801d.png">

After:
<img width="652" alt="Capture d’écran 2023-04-18 à 17 04 33" src="https://user-images.githubusercontent.com/6305268/232819762-2df5ae1c-dd49-42bb-a324-a5e5eb303db1.png">
