### PR TITLE
Redirect to new faq

### DIFF
--- a/patches/better-help-settings/matrix-react-sdk+3.69.1.patch
+++ b/patches/better-help-settings/matrix-react-sdk+3.69.1.patch
@@ -12,7 +12,7 @@ index 4bceab5..b7dad05 100644
  
  export interface IAccessibleButtonProps extends React.InputHTMLAttributes<Element> {
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
-index 7ad495e..fa16f8c 100644
+index 7ad495e..6b21e41 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
 @@ -98,6 +98,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
@@ -120,7 +120,7 @@ index 7ad495e..fa16f8c 100644
 +            </div>
 +        );
 +
-+        const faqUrl = "https://tchap.beta.gouv.fr/faq";
++        const faqUrl = "https://www.tchap.gouv.fr/faq";
 +        const faqSection = (
 +            <div className='mx_SettingsTab_section'>
 +                <span className='mx_SettingsTab_subheading'>{ _t("Frequently Asked Questions (FAQ)") }</span>


### PR DESCRIPTION
Cf. https://github.com/tchapgouv/tchap-web-v4/issues/559

Previously the button "Consultez la FAQ" in Parameters > Foire aux questions redirected to the old FAQ.
Now you can find the redirection to new FAQ here:

<img width="292" alt="Capture d’écran 2023-04-20 à 14 41 32" src="https://user-images.githubusercontent.com/6305268/233599464-f4d32d48-08db-47b0-a623-e55cf03bd528.png">

And here:

<img width="793" alt="Capture d’écran 2023-04-21 à 11 23 09" src="https://user-images.githubusercontent.com/6305268/233599378-82c3be0b-bf6a-44e7-bd95-f712a647c7da.png">
