### PR TITLE
Reactivate the toast : activate xsss and verify device

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -39,7 +39,7 @@
         "feature_video_rooms": false,
         "feature_new_device_manager": false,
         "tchap_activate_cross_signing_and_secure_storage": true,
-        "tchap_disable_cross_signing_setup_toast": true
+        "tchap_disable_cross_signing_setup_toast": false
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -34,7 +34,7 @@
         "feature_video_rooms": false,
         "feature_new_device_manager": false,
         "tchap_activate_cross_signing_and_secure_storage": true,
-        "tchap_disable_cross_signing_setup_toast": true
+        "tchap_disable_cross_signing_setup_toast": false
     },
     "default_federate": true,
     "default_theme": "light",

--- a/config.prod.json
+++ b/config.prod.json
@@ -109,7 +109,7 @@
         "feature_video_rooms": false,
         "feature_new_device_manager": false,
         "tchap_activate_cross_signing_and_secure_storage": true,
-        "tchap_disable_cross_signing_setup_toast": true
+        "tchap_disable_cross_signing_setup_toast": false
     },
     "default_federate": true,
     "default_theme": "light",

--- a/patches/cross-signing-ui/matrix-react-sdk+3.69.1.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.69.1.patch
@@ -155,7 +155,7 @@ index 3171a0e..8751e6b 100644
                      aria-label={_t("Skip verification for now")}
                  />
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
-index fe8a24a..c82ea3a 100644
+index fe8a24a..f216efe 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/SetupEncryptionBody.tsx
 @@ -28,6 +28,10 @@ import { SetupEncryptionStore, Phase } from "../../../stores/SetupEncryptionStor
@@ -183,17 +183,17 @@ index fe8a24a..c82ea3a 100644
      private onUsePassphraseClick = async (): Promise<void> => {
          const store = SetupEncryptionStore.sharedInstance();
          store.usePassPhrase();
-@@ -159,18 +170,39 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
+@@ -159,17 +170,28 @@ export default class SetupEncryptionBody extends React.Component<IProps, IState>
                  return (
                      <div>
                          <p>
-+                            {/* :tchap: change message to announce secure backup feature
++                            {/* :tchap: change message format by adding <p>
                              {_t(
                                  "It looks like you don't have a Security Key or any other devices you can " +
                                      "verify against.  This device will not be able to access old encrypted messages. " +
                                      "In order to verify your identity on this device, you'll need to reset " +
                                      "your verification keys.",
-                             )} 
+                             )}
 +                             :tchap: end
 +                            */}
 +
@@ -206,23 +206,13 @@ index fe8a24a..c82ea3a 100644
 +                            )}
                          </p>
  
-+                        {/* :tchap: replace button of proceed with reset by a no-effect Continue button */}
                          <div className="mx_CompleteSecurity_actionRow">
-+                            <AccessibleButton kind="primary" onClick={this.openDeviceTab}>
-+                            {/* <AccessibleButton kind="primary" onClick={this.onSkipConfirmClick}> */}
-+                                {_t("Security & Privacy")}
-+                            </AccessibleButton>
-+
-+                        {/* 
                              <AccessibleButton kind="primary" onClick={this.onResetConfirmClick}>
-                                 {_t("Proceed with reset")}
+-                                {_t("Proceed with reset")}
++                                {_t("Set up")}
                              </AccessibleButton>
-+                            :tchap: end
-+                            */
-+                        }
                          </div>
                      </div>
-                 );
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 index 7849f63..b393746 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -715,8 +715,8 @@
     "en": "Verify with Recovery Code or Phrase"
   },
   "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
-    "fr": "<p>Ce nouvel appareil n'est pas vérifié au niveau de votre compte Tchap et vous ne possédez pas d'autre appareil connecté à Tchap.</p><p> Vous pouvez avoir des difficultés à accéder à vos messages</p><p>Pour récupérer vos messages en toutes circonstances, activez votre Code de Récupération</p>",
-    "en": "<p>This new device is not verified in your Tchap account and you do not have another device connected to Tchap.</p><p>You may have difficulty accessing your messages</p ><p>To recover your messages in all circumstances, activate your Recovery Code</p>"
+    "fr": "<p>Cet appareil n'est pas vérifié.</p><p>Pour que cet appareil soit toujours vérifié et que vous puissiez toujours récupérer vos messages, activez la Sauvegarde Automatique des messages.</p>",
+    "en": "<p>This device is not verified.</p><p>To ensure this device is always verified and you can always retrieve your messages, turn on Automatic Message Backup</p>"
 
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {
@@ -892,11 +892,11 @@
     "en": "Activate on this device"
   },
   "Verify this session": {
-    "fr": "Verifier cet appareil",
+    "fr": "Vérifier cet appareil",
     "en": "Verify this device"
   },
   "Other users may not trust it": {
-    "fr": "Vous pouvez avoir des difficultés à lire vos messages",
-    "en": "You might face difficulties to read your messages"
+    "fr": "Vous risquez de ne pas pouvoir récupérer vos messages.",
+    "en": "You may not be able to recover your messages."
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -715,8 +715,8 @@
     "en": "Verify with Recovery Code or Phrase"
   },
   "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
-    "fr": "<p>L'équipe de Tchap travaille au déploiement d'une nouvelle fonctionnalité permettant d'éviter la perte de clef de chiffrements.</p><p>Vous pouvez y accéder depuis les Paramètres : </p><p>Securité et vie privée > Sauvegarde automatique des messages</p>",
-    "en": "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access from the settings :</p><p>Security and privacy > Secure Backup</p>"
+    "fr": "<p>Ce nouvel appareil n'est pas vérifié au niveau de votre compte Tchap et vous ne possédez pas d'autre appareil connecté à Tchap.</p><p> Vous pouvez avoir des difficultés à accéder à vos messages</p><p>Pour récupérer vos messages en toutes circonstances, activer votre Code de Récupération</p>",
+    "en": "<p>This new device is not verified in your Tchap account and you do not have another device connected to Tchap.</p><p>You may have difficulty accessing your messages</p ><p>To recover your messages in all circumstances, activate your Recovery Code</p>"
 
   },
   "Enter your Security Phrase or <button>use your Security Key</button> to continue.": {
@@ -890,5 +890,13 @@
   "Activate on this device": {
     "fr": "Activer sur cet appareil",
     "en": "Activate on this device"
+  },
+  "Verify this session": {
+    "fr": "Verifier cet appareil",
+    "en": "Verify this device"
+  },
+  "Other users may not trust it": {
+    "fr": "Vous pouvez avoir des difficultés à lire vos messages",
+    "en": "You might face difficulties to read your messages"
   }
 }

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -427,8 +427,8 @@
     "fr": "Vous pouvez aussi configurer la sauvegarde automatique des messages et gérer vos clés depuis les paramètres."
   },
   "Set up Secure Backup": {
-    "en": "Activate",
-    "fr": "Activer"
+    "en": "Activate message Secure Backup",
+    "fr": "Activer la sauvegarde automatique des messages"
   },
   "Email": {
     "en": "Email",

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -715,7 +715,7 @@
     "en": "Verify with Recovery Code or Phrase"
   },
   "<p>The Tchap team is working on the deployment of a new feature to prevent encryption key loss.</p><p> You can access it in the section :</p><p>Security and privacy > Secure Backup</p>" : {
-    "fr": "<p>Ce nouvel appareil n'est pas vérifié au niveau de votre compte Tchap et vous ne possédez pas d'autre appareil connecté à Tchap.</p><p> Vous pouvez avoir des difficultés à accéder à vos messages</p><p>Pour récupérer vos messages en toutes circonstances, activer votre Code de Récupération</p>",
+    "fr": "<p>Ce nouvel appareil n'est pas vérifié au niveau de votre compte Tchap et vous ne possédez pas d'autre appareil connecté à Tchap.</p><p> Vous pouvez avoir des difficultés à accéder à vos messages</p><p>Pour récupérer vos messages en toutes circonstances, activez votre Code de Récupération</p>",
     "en": "<p>This new device is not verified in your Tchap account and you do not have another device connected to Tchap.</p><p>You may have difficulty accessing your messages</p ><p>To recover your messages in all circumstances, activate your Recovery Code</p>"
 
   },


### PR DESCRIPTION
- activate feature flag to show xsss toast

## 1/ When cross signing is trusted : 
it happens when :  
- cross signing is active on this session
- secure backup has not been configured yet
![Capture d’écran 2023-04-26 à 15 25 24](https://user-images.githubusercontent.com/4077729/234589551-8703f771-4ae9-4d12-bef1-e9319868e179.png)

## 2/ When cross signing is not trusted (needs verify)
it happens when : 
- cross signing has been activated on web session but the user disconnected from this session
- user has no other session. Then the only cross signing has been lost.

![Capture d’écran 2023-04-26 à 17 13 09](https://user-images.githubusercontent.com/4077729/234621063-235c2da4-3524-4d76-b377-b5a10dd109c1.png)

and then : 
![Capture d’écran 2023-04-26 à 16 13 35](https://user-images.githubusercontent.com/4077729/234603424-5c01eb1c-ff94-47f1-a037-f71965fa77e3.png)

## 2.1
As a side effect, this flow is updated

login then 
![Capture d’écran 2023-04-26 à 17 10 44](https://user-images.githubusercontent.com/4077729/234621195-68c5084d-15ec-4a4f-9bd5-48b1e7c701ab.png)


