### PR TITLE
Cross-signing change button label

### DIFF
--- a/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.71.1.patch
+++ b/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.71.1.patch
@@ -60,7 +60,7 @@ index 575ff07..782cdd1 100644
              dis.dispatch({
                  action: "start_registration",
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
-index e3f62d4..aba3ef4 100644
+index e3f62d4..8186df9 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 @@ -28,6 +28,7 @@ import ConfirmDestroyCrossSigningDialog from "../dialogs/security/ConfirmDestroy
@@ -71,7 +71,7 @@ index e3f62d4..aba3ef4 100644
  
  interface IState {
      error?: Error;
-@@ -210,10 +211,16 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -210,22 +211,46 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
              userSigningPrivateKeyCached;
  
          const actions: JSX.Element[] = [];
@@ -82,14 +82,41 @@ index e3f62d4..aba3ef4 100644
          // TODO: determine how better to expose this to users in addition to prompts at login/toast
          if (!keysExistEverywhere && homeserverSupportsCrossSigning) {
 -            let buttonCaption = _t("Set up Secure Backup");
-+            // :TCHAP: change > let buttonCaption = _t("Set up Secure Backup");
-+            let buttonCaption = _t("Activate on this device");
-+            // end :TCHAP:
-+            
-             if (crossSigningPrivateKeysInStorage) {
-                 buttonCaption = _t("Verify this session");
+-            if (crossSigningPrivateKeysInStorage) {
+-                buttonCaption = _t("Verify this session");
++            // :TCHAP:
++            if (!crossSigningPrivateKeysInStorage) {
++                advancedActions.push(
++                    <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
++                        {_t("Activate on this device")}
++                    </AccessibleButton>,
++                );
              }
-@@ -225,7 +232,9 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+-            actions.push(
+-                <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
+-                    {buttonCaption}
+-                </AccessibleButton>,
+-            );
++
++            // Remove Element code:
++            // let buttonCaption = _t("Set up Secure Backup");
++            // if (crossSigningPrivateKeysInStorage) {
++            //     buttonCaption = _t("Verify this session");
++            // }
++            // actions.push(
++            //     <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
++            //         {buttonCaption}
++            //     </AccessibleButton>,
++            // );
++
++            else {
++                actions.push(
++                    <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
++                        {_t("Verify this session")}
++                    </AccessibleButton>,
++                );
++            }
++            // end :TCHAP:
          }
  
          if (keysExistAnywhere) {
@@ -100,7 +127,7 @@ index e3f62d4..aba3ef4 100644
                  <AccessibleButton key="reset" kind="danger" onClick={this.resetCrossSigning}>
                      {_t("Reset")}
                  </AccessibleButton>,
-@@ -237,6 +246,19 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -237,6 +262,19 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
              actionRow = <div className="mx_CrossSigningPanel_buttonRow">{actions}</div>;
          }
  
@@ -120,7 +147,7 @@ index e3f62d4..aba3ef4 100644
          return (
              <div>
                  {summarisedStatus}
-@@ -274,6 +296,7 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -274,6 +312,7 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
                              </tr>
                          </tbody>
                      </table>

--- a/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.71.1.patch
+++ b/patches/activate-cross-signing-and-secure-storage-react/matrix-react-sdk+3.71.1.patch
@@ -60,7 +60,7 @@ index 575ff07..782cdd1 100644
              dis.dispatch({
                  action: "start_registration",
 diff --git a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
-index e3f62d4..8186df9 100644
+index e3f62d4..d3967a0 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/settings/CrossSigningPanel.tsx
 @@ -28,6 +28,7 @@ import ConfirmDestroyCrossSigningDialog from "../dialogs/security/ConfirmDestroy
@@ -71,7 +71,7 @@ index e3f62d4..8186df9 100644
  
  interface IState {
      error?: Error;
-@@ -210,22 +211,46 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -210,14 +211,21 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
              userSigningPrivateKeyCached;
  
          const actions: JSX.Element[] = [];
@@ -82,41 +82,20 @@ index e3f62d4..8186df9 100644
          // TODO: determine how better to expose this to users in addition to prompts at login/toast
          if (!keysExistEverywhere && homeserverSupportsCrossSigning) {
 -            let buttonCaption = _t("Set up Secure Backup");
--            if (crossSigningPrivateKeysInStorage) {
--                buttonCaption = _t("Verify this session");
-+            // :TCHAP:
-+            if (!crossSigningPrivateKeysInStorage) {
-+                advancedActions.push(
-+                    <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
-+                        {_t("Activate on this device")}
-+                    </AccessibleButton>,
-+                );
++            // :TCHAP: change > let buttonCaption = _t("Set up Secure Backup");
++            let buttonCaption = _t("Activate on this device");
++            // end :TCHAP:
++            
+             if (crossSigningPrivateKeysInStorage) {
+                 buttonCaption = _t("Verify this session");
              }
 -            actions.push(
--                <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
--                    {buttonCaption}
--                </AccessibleButton>,
--            );
-+
-+            // Remove Element code:
-+            // let buttonCaption = _t("Set up Secure Backup");
-+            // if (crossSigningPrivateKeysInStorage) {
-+            //     buttonCaption = _t("Verify this session");
-+            // }
-+            // actions.push(
-+            //     <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
-+            //         {buttonCaption}
-+            //     </AccessibleButton>,
-+            // );
-+
-+            else {
-+                actions.push(
-+                    <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
-+                        {_t("Verify this session")}
-+                    </AccessibleButton>,
-+                );
-+            }
-+            // end :TCHAP:
++            // TCHAP: change actions.push(
++            advancedActions.push(
+                 <AccessibleButton key="setup" kind="primary" onClick={this.onBootstrapClick}>
+                     {buttonCaption}
+                 </AccessibleButton>,
+@@ -225,7 +233,9 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
          }
  
          if (keysExistAnywhere) {
@@ -127,7 +106,7 @@ index e3f62d4..8186df9 100644
                  <AccessibleButton key="reset" kind="danger" onClick={this.resetCrossSigning}>
                      {_t("Reset")}
                  </AccessibleButton>,
-@@ -237,6 +262,19 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -237,6 +247,19 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
              actionRow = <div className="mx_CrossSigningPanel_buttonRow">{actions}</div>;
          }
  
@@ -147,7 +126,7 @@ index e3f62d4..8186df9 100644
          return (
              <div>
                  {summarisedStatus}
-@@ -274,6 +312,7 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
+@@ -274,6 +297,7 @@ export default class CrossSigningPanel extends React.PureComponent<{}, IState> {
                              </tr>
                          </tbody>
                      </table>

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -888,8 +888,8 @@
     "en": "Connected devices"
   },
   "Activate on this device": {
-    "fr": "Activer la sauvegarde des messages",
-    "en": "Activate message backup"
+    "fr": "Activer sur cet appareil",
+    "en": "Activate on this device"
   },
   "Verify this session": {
     "fr": "Vérifier cet appareil",

--- a/src/i18n/strings/tchap_translations.json
+++ b/src/i18n/strings/tchap_translations.json
@@ -888,8 +888,8 @@
     "en": "Connected devices"
   },
   "Activate on this device": {
-    "fr": "Activer sur cet appareil",
-    "en": "Activate on this device"
+    "fr": "Activer la sauvegarde des messages",
+    "en": "Activate message backup"
   },
   "Verify this session": {
     "fr": "Vérifier cet appareil",


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/560

Put button "Activate on this device" in the advanced section of parameters > security > cross signing.

Before:
<img width="628" alt="Capture d’écran 2023-05-10 à 10 59 28" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/e5f135b8-4f91-43c5-8451-71a42375bed6">

After:
<img width="645" alt="Capture d’écran 2023-05-10 à 10 51 08" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/6541b4ba-7a0f-4dc1-b4c8-f3b3374d0804">

and when clicking on "Advanced":
<img width="628" alt="Capture d’écran 2023-05-10 à 10 51 15" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/dfc94715-1d74-45a4-8393-70f95ff9cf99">

And same for the "Verify this device" button:
<img width="627" alt="Capture d’écran 2023-05-10 à 14 53 04" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/d3dc977c-03a4-4d8e-8b38-f6937f9e3a83">


