### PR TITLE
Améliorer l'UX sur la migration de salon lors de l'ouverture aux Spaces

### DIFF
--- a/customisations.json
+++ b/customisations.json
@@ -21,5 +21,6 @@
     "src/tchap/components/views/messages/OriginalVideoBody.tsx": "node_modules/matrix-react-sdk/src/components/views/messages/MVideoBody.tsx",
     "src/tchap/components/views/messages/OriginalVoiceMessageBody.tsx": "node_modules/matrix-react-sdk/src/components/views/messages/MVoiceMessageBody.tsx",
     "src/components/views/messages/UnknownBody.tsx": "src/tchap/components/views/messages/TchapUnknownBody.tsx",
-    "src/components/views/settings/JoinRuleSettings.tsx": "src/tchap/components/views/settings/TchapJoinRuleSettings.tsx"
+    "src/components/views/settings/JoinRuleSettings.tsx": "src/tchap/components/views/settings/TchapJoinRuleSettings.tsx",
+    "src/components/views/dialogs/RoomUpgradeWarningDialog.tsx": "src/tchap/components/views/dialogs/TchapRoomUpgradeWarningDialog.tsx"
 }

--- a/src/tchap/components/views/dialogs/TchapRoomUpgradeWarningDialog.tsx
+++ b/src/tchap/components/views/dialogs/TchapRoomUpgradeWarningDialog.tsx
@@ -1,0 +1,254 @@
+/*
+Copyright 2019 - 2021 The Matrix.org Foundation C.I.C.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { ReactNode, SyntheticEvent } from "react";
+import { EventType } from "matrix-js-sdk/src/@types/event";
+import { JoinRule } from "matrix-js-sdk/src/@types/partials";
+
+import { _t } from "matrix-react-sdk/src/languageHandler";
+import SdkConfig from "matrix-react-sdk/src/SdkConfig";
+import LabelledToggleSwitch from "matrix-react-sdk/src/components/views/elements/LabelledToggleSwitch";
+import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
+import Modal from "matrix-react-sdk/src/Modal";
+import BugReportDialog from "matrix-react-sdk/src/components/views/dialogs/BugReportDialog";
+import BaseDialog from "matrix-react-sdk/src/components/views/dialogs/BaseDialog";
+import DialogButtons from "matrix-react-sdk/src/components/views/elements/DialogButtons";
+import ProgressBar from "matrix-react-sdk/src/components/views/elements/ProgressBar";
+import AccessibleButton from "matrix-react-sdk/src/components/views/elements/AccessibleButton";
+import { TchapRoomType } from "../../../@types/tchap";
+import TchapUtils from "../../../util/TchapUtils";
+import TchapRoomUtils from "../../../util/TchapRoomUtils";
+
+export interface IFinishedOpts {
+    continue: boolean;
+    invite: boolean;
+}
+
+interface IProps {
+    roomId: string;
+    targetVersion: string;
+    description?: ReactNode;
+    doUpgrade?(opts: IFinishedOpts, fn: (progressText: string, progress: number, total: number) => void): Promise<void>;
+    onFinished(opts?: IFinishedOpts): void;
+}
+
+interface Progress {
+    text: string;
+    progress: number;
+    total: number;
+}
+
+interface IState {
+    inviteUsersToNewRoom: boolean;
+    progress?: Progress;
+}
+
+export default class RoomUpgradeWarningDialog extends React.Component<IProps, IState> {
+    private readonly isPrivate: boolean;
+    private readonly currentVersion?: string;
+    private readonly tchapRoomType: TchapRoomType;
+
+    public constructor(props: IProps) {
+        super(props);
+
+        const room = MatrixClientPeg.get().getRoom(this.props.roomId);
+        const joinRules = room?.currentState.getStateEvents(EventType.RoomJoinRules, "");
+        this.isPrivate = joinRules?.getContent()["join_rule"] !== JoinRule.Public ?? true;
+        this.currentVersion = room?.getVersion();
+        this.tchapRoomType = TchapRoomUtils.getTchapRoomType(room);
+        this.state = {
+            inviteUsersToNewRoom: true,
+        };
+    }
+
+    private onProgressCallback = (text: string, progress: number, total: number): void => {
+        this.setState({
+            progress: {
+                text,
+                progress,
+                total,
+            },
+        });
+    };
+
+    private onContinue = async (): Promise<void> => {
+        const opts = {
+            continue: true,
+            invite: this.isPrivate && this.state.inviteUsersToNewRoom,
+        };
+
+        await this.props.doUpgrade?.(opts, this.onProgressCallback);
+        this.props.onFinished(opts);
+    };
+
+    private onCancel = (): void => {
+        this.props.onFinished({ continue: false, invite: false });
+    };
+
+    private onInviteUsersToggle = (inviteUsersToNewRoom: boolean): void => {
+        this.setState({ inviteUsersToNewRoom });
+    };
+
+    private openBugReportDialog = (e: SyntheticEvent): void => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        Modal.createDialog(BugReportDialog, {});
+    };
+
+    public render(): React.ReactNode {
+        const brand = SdkConfig.get().brand;
+
+        /*
+        users are invited by default do not show toogle
+        let inviteToggle: JSX.Element | undefined;
+        
+        if (this.isPrivate) {
+            inviteToggle = (
+                <LabelledToggleSwitch
+                    value={this.state.inviteUsersToNewRoom}
+                    onChange={this.onInviteUsersToggle}
+                    label={_t("Automatically invite members from this room to the new one")}
+                />
+            );
+        }
+        */
+
+        let externalNotice: JSX.Element | undefined;
+        
+        if (this.tchapRoomType === TchapRoomType.External) {
+            externalNotice = (
+                <p><b>
+                    {_t(
+                        "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room"
+                    )}
+                    </b>
+                </p>
+            );
+        }
+
+
+        //const title = this.isPrivate ? _t("Upgrade private room") : _t("Upgrade public room");
+        const title =_t("Upgrade private room");
+        /*
+        let bugReports = (
+            <p>
+                {_t(
+                    "This usually only affects how the room is processed on the server. If you're " +
+                        "having problems with your %(brand)s, please report a bug.",
+                    { brand },
+                )}
+            </p>
+        );
+        */
+       /*
+        if (SdkConfig.get().bug_report_endpoint_url) {
+            bugReports = (
+                <p>
+                    {_t(
+                        "This usually only affects how the room is processed on the server. If you're " +
+                            "having problems with your %(brand)s, please <a>report a bug</a>.",
+                        {
+                            brand,
+                        },
+                        {
+                            a: (sub) => {
+                                return (
+                                    <AccessibleButton kind="link_inline" onClick={this.openBugReportDialog}>
+                                        {sub}
+                                    </AccessibleButton>
+                                );
+                            },
+                        },
+                    )}
+                </p>
+            );
+        }
+        */
+
+        let footer: JSX.Element;
+        if (this.state.progress) {
+            footer = (
+                <span className="mx_RoomUpgradeWarningDialog_progress">
+                    <ProgressBar value={this.state.progress.progress} max={this.state.progress.total} />
+                    <div className="mx_RoomUpgradeWarningDialog_progressText">{this.state.progress.text}</div>
+                </span>
+            );
+        } else {
+            footer = (
+                <DialogButtons
+                    primaryButton={_t("Upgrade")}
+                    onPrimaryButtonClick={this.onContinue}
+                    cancelButton={_t("Cancel")}
+                    onCancel={this.onCancel}
+                />
+            );
+        }
+
+        return (
+            <BaseDialog
+                className="mx_RoomUpgradeWarningDialog"
+                hasCancel={true}
+                fixedWidth={false}
+                onFinished={this.props.onFinished}
+                title={title}
+            >
+                <div>
+                    <p>
+                        {this.props.description ||
+                            _t(
+                                "Upgrading a room is an advanced action and is usually recommended when a room " +
+                                    "is unstable due to bugs, missing features or security vulnerabilities.",
+                            )}
+                    </p>
+                    <p>
+                        {_t(
+                            "<b>Please note upgrading will make a new version of the room</b>. " +
+                                "All current messages will stay in this archived room.",
+                            {},
+                            {
+                                b: (sub) => <b>{sub}</b>,
+                            },
+                        )}
+                    </p>
+                    {externalNotice}
+
+                    {/*
+                    do not show bug reports
+                    {bugReports} 
+                    */}
+                        {/*
+                    <p>
+                        {_t(
+                            "You'll upgrade this room from <oldVersion /> to <newVersion />.",
+                            {},
+                            {
+                                oldVersion: () => <code>{this.currentVersion}</code>,
+                                newVersion: () => <code>{this.props.targetVersion}</code>,
+                            },
+                        )}
+                    </p>
+                         */}
+                    
+                    {/* 
+                    do not show toogle, users are invite by default
+                    {inviteToggle} */}
+                </div>
+                {footer}
+            </BaseDialog>
+        );
+    }
+}

--- a/src/tchap/components/views/dialogs/TchapRoomUpgradeWarningDialog.tsx
+++ b/src/tchap/components/views/dialogs/TchapRoomUpgradeWarningDialog.tsx
@@ -29,7 +29,6 @@ import DialogButtons from "matrix-react-sdk/src/components/views/elements/Dialog
 import ProgressBar from "matrix-react-sdk/src/components/views/elements/ProgressBar";
 import AccessibleButton from "matrix-react-sdk/src/components/views/elements/AccessibleButton";
 import { TchapRoomType } from "../../../@types/tchap";
-import TchapUtils from "../../../util/TchapUtils";
 import TchapRoomUtils from "../../../util/TchapRoomUtils";
 
 export interface IFinishedOpts {
@@ -131,11 +130,10 @@ export default class RoomUpgradeWarningDialog extends React.Component<IProps, IS
         
         if (this.tchapRoomType === TchapRoomType.External) {
             externalNotice = (
-                <p><b>
+                <p className="text-warning">
                     {_t(
                         "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room"
                     )}
-                    </b>
                 </p>
             );
         }
@@ -190,7 +188,7 @@ export default class RoomUpgradeWarningDialog extends React.Component<IProps, IS
         } else {
             footer = (
                 <DialogButtons
-                    primaryButton={_t("Upgrade")}
+                    primaryButton={_t("Upgrade room")}
                     onPrimaryButtonClick={this.onContinue}
                     cancelButton={_t("Cancel")}
                     onCancel={this.onCancel}

--- a/src/tchap/components/views/settings/TchapJoinRuleSettings.tsx
+++ b/src/tchap/components/views/settings/TchapJoinRuleSettings.tsx
@@ -287,7 +287,11 @@ const JoinRuleSettings = ({ room, promptUpgrade, aliasWarning, onError, beforeCh
                 label: (
                     <>
                         {_t("Space members")}
-                        {upgradeRequiredPill}
+                         
+                        {/* :tchap: do not show the pill upgrade room as it is not user friendly
+                        https://github.com/tchapgouv/tchap-web-v4/issues/578
+                         {upgradeRequiredPill} */}
+                        
                     </>
                 ),
                 description,

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -898,5 +898,17 @@
   "Other users may not trust it": {
     "fr": "Vous risquez de ne pas pouvoir récupérer vos messages.",
     "en": "You may not be able to recover your messages."
+  },
+  "<b>Please note upgrading will make a new version of the room</b>. All current messages will stay in this archived room.":{
+    "fr" : "<b>Une nouvelle version de ce salon va être créée</b>. Tous les messages actuels resteront accessibles dans ce salon. Tous les membres vont être réinvités.",
+    "en" : "<b>A new version of this room will be created</b>. All current messages will remain accessible in this room. All members will be invited back."
+  },
+  "Upgrade private room" : {
+    "fr" : "Ce salon va être mis à jour",
+    "en" : "This room will be updated"
+  },
+  "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room":{
+    "fr" : "Les membres externes ne pourront pas être réinvités. Si vous avez besoin de donner accès aux externes, il faudra créer un nouveau salon",
+    "en" : "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room"
   }
 }

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -908,7 +908,11 @@
     "en" : "This room will be updated"
   },
   "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room":{
-    "fr" : "Les membres externes ne pourront pas être réinvités. Si vous avez besoin de donner accès aux externes, il faudra créer un nouveau salon",
-    "en" : "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room"
+    "fr" : "Les membres externes ne pourront pas être réinvités. Si vous avez besoin de donner accès aux externes, il faudra créer un nouveau salon.",
+    "en" : "External members cannot be re-invited. If you need to give access to externals, you will have to create a new room."
+  },
+  "Upgrade room":{
+    "fr" : "Mettre à jour le salon",
+    "en" : "Upgrade room"
   }
 }


### PR DESCRIPTION
- enlever les textes autour de la mise à jour des salons en version 9 : ce n'est pas nécessaire d'en informer les utilisateurs
- ajouter un warning si le salon est ouvert aux externes. Actuellement, les salons externes ne sont pas migrables automatiquement

## salon privé

![Capture d’écran 2023-05-11 à 14 43 02](https://github.com/tchapgouv/tchap-web-v4/assets/4077729/b53d1509-b54e-4f63-afcc-55849d24bbf2)
puis
![Capture d’écran 2023-05-11 à 14 43 08](https://github.com/tchapgouv/tchap-web-v4/assets/4077729/4aa1f673-e38e-47f8-bd12-252b77fe07f7)


## salon externe 
![Capture d’écran 2023-05-11 à 15 04 40](https://github.com/tchapgouv/tchap-web-v4/assets/4077729/5a088b7d-42c0-4c0c-81f6-c228b61ed51b)



