### PR TITLE
Fix N bug with change of wording and associated FAQ page

### DIFF
--- a/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
@@ -108,7 +108,7 @@ index 3e48739..926d18b 100644
                                  kind="primary"
                                  className="mx_Dialog_primary mx_CreateSecretStorageDialog_recoveryKeyButtons_copyBtn"
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
-index 3171a0e..8751e6b 100644
+index 3171a0e..0c8555a 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/CompleteSecurity.tsx
 @@ -22,6 +22,7 @@ import SetupEncryptionBody from "./SetupEncryptionBody";
@@ -207,7 +207,7 @@ index 2cbfbf8..efe6b26 100644
                          </div>
                      </div>
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
-index 94cf02d..56447d7 100644
+index 94cf02d..7cb2e7f 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 @@ -193,6 +193,7 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
@@ -218,7 +218,7 @@ index 94cf02d..56447d7 100644
              button = (
                  <AccessibleButton
                      className="mx_DecryptionFailureBar_end_button"
-@@ -203,28 +204,37 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
+@@ -203,28 +204,43 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
                      {_t("Reset")}
                  </AccessibleButton>
              );
@@ -251,6 +251,12 @@ index 94cf02d..56447d7 100644
 -                {_t("View your device list")}
 -            </AccessibleButton>
 -        );
++        /* :TCHAP: Add for N bug */ message = <React.Fragment>{_t(
++            "Or if that doesn't work, please clear your cache by following these steps <a>here</a>.",
++            {},
++            {a: (sub)=><a href="https://aide.tchap.beta.gouv.fr/fr/article/que-faire-si-le-message-dun-interlocuteur-nest-pas-dechiffre-web-1ezes9e/?bust=1684163497280" target="_blank">{sub}</a>}
++        )}</React.Fragment>;
++        
 +        // :TCHAP: shrink long banner
 +        // message = (
 +        //     <React.Fragment>
@@ -275,7 +281,7 @@ index 94cf02d..56447d7 100644
          className = "mx_DecryptionFailureBar";
          headline = <React.Fragment>{_t("Some messages could not be decrypted")}</React.Fragment>;
 diff --git a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
-index 3b60705..aeeaee0 100644
+index 3b60705..a11711d 100644
 --- a/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 +++ b/node_modules/matrix-react-sdk/src/toasts/SetupEncryptionToast.ts
 @@ -14,6 +14,7 @@ See the License for the specific language governing permissions and

--- a/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
@@ -1,3 +1,4 @@
+
 diff --git a/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss b/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss
 index c23f53b..7aa9f25 100644
 --- a/node_modules/matrix-react-sdk/res/css/views/auth/_CompleteSecurityBody.pcss
@@ -207,7 +208,7 @@ index 2cbfbf8..efe6b26 100644
                          </div>
                      </div>
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
-index 94cf02d..2dfec0d 100644
+index 94cf02d..52b9e53 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 @@ -193,6 +193,7 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
@@ -254,7 +255,7 @@ index 94cf02d..2dfec0d 100644
 +        /* :TCHAP: Add for N bug */ message = <React.Fragment>{_t(
 +            "Or if that doesn't work, please follow <a>these steps</a>.",
 +            {},
-+            {a: (sub)=><a href="https://beta.tchap.beta.gouv.fr/faq/messages-verrouilles" target="_blank">{sub}</a>}
++            {a: (sub)=><a href="https://tchap.beta.gouv.fr/faq/messages-verrouilles" target="_blank">{sub}</a>}
 +        )}</React.Fragment>;
 +        
 +        // :TCHAP: shrink long banner

--- a/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
@@ -207,7 +207,7 @@ index 2cbfbf8..efe6b26 100644
                          </div>
                      </div>
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
-index 94cf02d..7cb2e7f 100644
+index 94cf02d..c774ccb 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 @@ -193,6 +193,7 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
@@ -254,7 +254,7 @@ index 94cf02d..7cb2e7f 100644
 +        /* :TCHAP: Add for N bug */ message = <React.Fragment>{_t(
 +            "Or if that doesn't work, please clear your cache by following these steps <a>here</a>.",
 +            {},
-+            {a: (sub)=><a href="https://aide.tchap.beta.gouv.fr/fr/article/que-faire-si-le-message-dun-interlocuteur-nest-pas-dechiffre-web-1ezes9e/?bust=1684163497280" target="_blank">{sub}</a>}
++            {a: (sub)=><a href="https://aide.tchap.beta.gouv.fr/fr/article/que-faire-si-le-message-dun-interlocuteur-nest-pas-dechiffre-web-1ezes9e" target="_blank">{sub}</a>}
 +        )}</React.Fragment>;
 +        
 +        // :TCHAP: shrink long banner

--- a/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
@@ -207,7 +207,7 @@ index 2cbfbf8..efe6b26 100644
                          </div>
                      </div>
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
-index 94cf02d..c774ccb 100644
+index 94cf02d..f1d8fbe 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 @@ -193,6 +193,7 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
@@ -252,9 +252,9 @@ index 94cf02d..c774ccb 100644
 -            </AccessibleButton>
 -        );
 +        /* :TCHAP: Add for N bug */ message = <React.Fragment>{_t(
-+            "Or if that doesn't work, please clear your cache by following these steps <a>here</a>.",
++            "Or if that doesn't work, please follow <a>these steps</a>.",
 +            {},
-+            {a: (sub)=><a href="https://aide.tchap.beta.gouv.fr/fr/article/que-faire-si-le-message-dun-interlocuteur-nest-pas-dechiffre-web-1ezes9e" target="_blank">{sub}</a>}
++            {a: (sub)=><a href="https://aide.tchap.beta.gouv.fr/fr/article/je-ne-parviens-pas-a-lire-les-messages-provenant-dune-personne-en-particulier-hgbwun" target="_blank">{sub}</a>}
 +        )}</React.Fragment>;
 +        
 +        // :TCHAP: shrink long banner

--- a/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
+++ b/patches/cross-signing-ui/matrix-react-sdk+3.71.1.patch
@@ -207,7 +207,7 @@ index 2cbfbf8..efe6b26 100644
                          </div>
                      </div>
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
-index 94cf02d..f1d8fbe 100644
+index 94cf02d..2dfec0d 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/rooms/DecryptionFailureBar.tsx
 @@ -193,6 +193,7 @@ export const DecryptionFailureBar: React.FC<IProps> = ({ failures }) => {
@@ -254,7 +254,7 @@ index 94cf02d..f1d8fbe 100644
 +        /* :TCHAP: Add for N bug */ message = <React.Fragment>{_t(
 +            "Or if that doesn't work, please follow <a>these steps</a>.",
 +            {},
-+            {a: (sub)=><a href="https://aide.tchap.beta.gouv.fr/fr/article/je-ne-parviens-pas-a-lire-les-messages-provenant-dune-personne-en-particulier-hgbwun" target="_blank">{sub}</a>}
++            {a: (sub)=><a href="https://beta.tchap.beta.gouv.fr/faq/messages-verrouilles" target="_blank">{sub}</a>}
 +        )}</React.Fragment>;
 +        
 +        // :TCHAP: shrink long banner

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -768,8 +768,12 @@
     "en": "Resend key requests"
   },
   "Open another device to load encrypted messages": {
-    "fr": "Utiliser un autre appareil pour déverrouiller vos messages",
-    "en": "Open another device to unlock messages"
+    "fr": "Utiliser un autre appareil pour déverrouiller vos messages.",
+    "en": "Use another device to unlock your messages."
+  },
+  "Or if that doesn't work, please clear your cache by following these steps <a>here</a>.": {
+    "fr": "Ou si cela ne fonctionne pas, veuillez veuillez vider votre cache en suivant ces étapes <a>ici</a>.",
+    "en": "Or if that doesn't work, please clear your cache by following these steps <a>here</a>."
   },
     "Unable to decrypt message": {
     "fr": "Impossible de déverrouiller le message",

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -771,9 +771,9 @@
     "fr": "Utiliser un autre appareil pour déverrouiller vos messages.",
     "en": "Use another device to unlock your messages."
   },
-  "Or if that doesn't work, please clear your cache by following these steps <a>here</a>.": {
-    "fr": "Ou si cela ne fonctionne pas, veuillez veuillez vider votre cache en suivant ces étapes <a>ici</a>.",
-    "en": "Or if that doesn't work, please clear your cache by following these steps <a>here</a>."
+  "Or if that doesn't work, please follow <a>these steps</a>.": {
+    "fr": "Ou si cela ne fonctionne pas, veuillez suivre <a>ces étapes</a>.",
+    "en": "Or if that doesn't work, please follow <a>these steps</a>."
   },
     "Unable to decrypt message": {
     "fr": "Impossible de déverrouiller le message",


### PR DESCRIPTION
Cf. issue https://github.com/tchapgouv/tchap-web-v4/issues/585

Because this bug is difficult to solve, a temporary solution was found: to change the wording and add a procedure to clear the cache of the user's interlocutor if the message is not decrypted.

Before:
<img width="417" alt="Capture d’écran 2023-05-15 à 17 19 03" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/60fc1ae4-e4e1-4f8a-a79f-1d66d864a32a">

After:
<img width="513" alt="Capture d’écran 2023-05-15 à 18 16 55" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/6051f1be-4c9a-4752-833d-3aca08bdd374">

And "ces étapes" redirects to this FAQ page: 
https://aide.tchap.beta.gouv.fr/fr/article/je-ne-parviens-pas-a-lire-les-messages-provenant-dune-personne-en-particulier-hgbwun/
