### PR TITLE
Change bad wording reinit cross-signing

### DIFF
--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -936,11 +936,11 @@
     "en": "Please only proceed if you're sure you've lost all of your other devices and your Recovery Code."
   },
   "Destroy cross-signing keys?": {
-    "fr": "Détruire votre Code de Récupération ?",
-    "en": "Destroy your Recovery Code ?"
+    "fr": "Réinitialiser les clés de signature croisée ?",
+    "en": "Reset cross-signing keys?"
   },
   "Deleting cross-signing keys is permanent. Anyone you have verified with will see security alerts. You almost certainly don't want to do this, unless you've lost every device you can cross-sign from.": {
-    "fr": "La suppression du Code de Récupération est permanent. Tous les appareils que vous avez vérifiés vont voir des alertes de sécurité. Il est peu probable que ce soit ce que vous voulez faire, sauf si vous avez perdu tous les appareils vous permettant d’effectuer une signature croisée.",
-    "en": "Deleting your Recovery Code is permanent. Anyone you have verified with will see security alerts. You almost certainly don't want to do this, unless you've lost every device you can cross-sign from."
+    "fr": "Réinitialiser les clés de signature croisée est permanent. Utiliser cette procédure uniquement si vous avez perdu tous les appareils vous permettant d’effectuer une signature croisée.",
+    "en": "Resetting your Recovery Code is permanent. Please use this procedure only if you have lost all devices that allow you to perform cross-signing."
   }
 }

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -934,5 +934,13 @@
   "Please only proceed if you're sure you've lost all of your other devices and your Security Key.": {
     "fr": "Veuillez ne continuer que si vous êtes certain d’avoir perdu tous vos autres appareils et votre Code de Récupération.",
     "en": "Please only proceed if you're sure you've lost all of your other devices and your Recovery Code."
+  },
+  "Destroy cross-signing keys?": {
+    "fr": "Détruire votre Code de Récupération ?",
+    "en": "Destroy your Recovery Code ?"
+  },
+  "Deleting cross-signing keys is permanent. Anyone you have verified with will see security alerts. You almost certainly don't want to do this, unless you've lost every device you can cross-sign from.": {
+    "fr": "La suppression du Code de Récupération est permanent. Tous les appareils que vous avez vérifiés vont voir des alertes de sécurité. Il est peu probable que ce soit ce que vous voulez faire, sauf si vous avez perdu tous les appareils vous permettant d’effectuer une signature croisée.",
+    "en": "Deleting your Recovery Code is permanent. Anyone you have verified with will see security alerts. You almost certainly don't want to do this, unless you've lost every device you can cross-sign from."
   }
 }

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -942,5 +942,9 @@
   "Deleting cross-signing keys is permanent. Anyone you have verified with will see security alerts. You almost certainly don't want to do this, unless you've lost every device you can cross-sign from.": {
     "fr": "Réinitialiser les clés de signature croisée est permanent. Utiliser cette procédure uniquement si vous avez perdu tous les appareils vous permettant d’effectuer une signature croisée.",
     "en": "Resetting your Recovery Code is permanent. Please use this procedure only if you have lost all devices that allow you to perform cross-signing."
+  },
+  "Clear cross-signing keys": {
+    "fr": "Réinitialiser les clés de signature croisée",
+    "en": "Reset Recovery Code"
   }
 }


### PR DESCRIPTION
Cf. https://github.com/tchapgouv/tchap-web-v4/issues/609

Avant :
<img width="602" alt="Capture d’écran 2023-06-06 à 12 04 57" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/7c55140c-3558-49f0-919b-331fe3740843">

Après :
<img width="747" alt="Capture d’écran 2023-06-07 à 11 25 58" src="https://github.com/tchapgouv/tchap-web-v4/assets/6305268/41cdb449-4735-460d-8c02-3a43b91d1932">

