### PR TITLE
Add link to status page in the error message when Tchap is down

### DIFF
--- a/patches/error-tchap-is-down/matrix-react-sdk+3.71.1.patch
+++ b/patches/error-tchap-is-down/matrix-react-sdk+3.71.1.patch
@@ -1,0 +1,46 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx b/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx
+index 00b9284..74a7e23 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx
+@@ -34,6 +34,7 @@ import ResizeNotifier from "../../utils/ResizeNotifier";
+ import MatrixClientContext from "../../contexts/MatrixClientContext";
+ import { RoomPermalinkCreator } from "../../utils/permalinks/Permalinks";
+ import RoomContext from "../../contexts/RoomContext";
++import Tchapi18nUtils from "../../../../../src/tchap/i18n/Tchapi18nUtils";
+ 
+ const DEBUG = false;
+ let debuglog = function (msg: string): void {};
+@@ -129,7 +130,7 @@ export const RoomSearchView = forwardRef<ScrollPanel, Props>(
+                                 title: _t("Search failed"),
+                                 description:
+                                     error?.message ??
+-                                    _t("Server may be unavailable, overloaded, or search timed out :("),
++                                    Tchapi18nUtils.getServerDownMessage("err-02"),
+                             });
+                             return false;
+                         },
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx b/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx
+index 24530d4..9ee7a92 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx
+@@ -30,6 +30,7 @@ import AccessibleButton from "../views/elements/AccessibleButton";
+ import InlineSpinner from "../views/elements/InlineSpinner";
+ import MatrixClientContext from "../../contexts/MatrixClientContext";
+ import { RoomStatusBarUnsentMessages } from "./RoomStatusBarUnsentMessages";
++import Tchapi18nUtils from '../../../../../src/tchap/i18n/Tchapi18nUtils'; // :TCHAP:
+ 
+ const STATUS_BAR_HIDDEN = 0;
+ const STATUS_BAR_EXPANDED = 1;
+@@ -286,10 +287,10 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
+                             />
+                             <div>
+                                 <div className="mx_RoomStatusBar_connectionLostBar_title">
+-                                    {_t("Connectivity to the server has been lost.")}
++                                    {Tchapi18nUtils.getServerDownMessage("err-00")}
+                                 </div>
+                                 <div className="mx_RoomStatusBar_connectionLostBar_desc">
+-                                    {_t("Sent messages will be stored until your connection has returned.")}
++                                    {Tchapi18nUtils.getServerDownMessage("err-00")}
+                                 </div>
+                             </div>
+                         </div>

--- a/patches/error-tchap-is-down/matrix-react-sdk+3.71.1.patch
+++ b/patches/error-tchap-is-down/matrix-react-sdk+3.71.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx b/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx
-index 00b9284..74a7e23 100644
+index 00b9284..e55da17 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/RoomSearchView.tsx
 @@ -34,6 +34,7 @@ import ResizeNotifier from "../../utils/ResizeNotifier";
@@ -15,12 +15,12 @@ index 00b9284..74a7e23 100644
                                  description:
                                      error?.message ??
 -                                    _t("Server may be unavailable, overloaded, or search timed out :("),
-+                                    Tchapi18nUtils.getServerDownMessage("err-02"),
++                                    Tchapi18nUtils.getServerDownMessage(),
                              });
                              return false;
                          },
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx b/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx
-index 24530d4..9ee7a92 100644
+index 24530d4..2f8f555 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/RoomStatusBar.tsx
 @@ -30,6 +30,7 @@ import AccessibleButton from "../views/elements/AccessibleButton";
@@ -31,16 +31,12 @@ index 24530d4..9ee7a92 100644
  
  const STATUS_BAR_HIDDEN = 0;
  const STATUS_BAR_EXPANDED = 1;
-@@ -286,10 +287,10 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
+@@ -286,7 +287,7 @@ export default class RoomStatusBar extends React.PureComponent<IProps, IState> {
                              />
                              <div>
                                  <div className="mx_RoomStatusBar_connectionLostBar_title">
 -                                    {_t("Connectivity to the server has been lost.")}
-+                                    {Tchapi18nUtils.getServerDownMessage("err-00")}
++                                    {Tchapi18nUtils.getServerDownMessage()}
                                  </div>
                                  <div className="mx_RoomStatusBar_connectionLostBar_desc">
--                                    {_t("Sent messages will be stored until your connection has returned.")}
-+                                    {Tchapi18nUtils.getServerDownMessage("err-00")}
-                                 </div>
-                             </div>
-                         </div>
+                                     {_t("Sent messages will be stored until your connection has returned.")}

--- a/patches/forgot-password/matrix-react-sdk+3.71.1.patch
+++ b/patches/forgot-password/matrix-react-sdk+3.71.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
-index c4c0834..6486c91 100644
+index c4c0834..880f18e 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 @@ -43,6 +43,8 @@ import { VerifyEmailModal } from "./forgot-password/VerifyEmailModal";
@@ -74,7 +74,7 @@ index c4c0834..6486c91 100644
 +        if (!serverResult) {
 +            this.setState({
 +                serverIsAlive: false,
-+                errorText: Tchapi18nUtils.getServerDownMessage("err-01"),
++                errorText: Tchapi18nUtils.getServerDownMessage(),
 +                phase: Phase.EnterEmail, // return to original phase, to remove the loding spinner from the submit button.
 +            });
 +            return;

--- a/patches/forgot-password/matrix-react-sdk+3.71.1.patch
+++ b/patches/forgot-password/matrix-react-sdk+3.71.1.patch
@@ -1,16 +1,17 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
-index c4c0834..27e9f28 100644
+index c4c0834..6486c91 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
-@@ -43,6 +43,7 @@ import { VerifyEmailModal } from "./forgot-password/VerifyEmailModal";
+@@ -43,6 +43,8 @@ import { VerifyEmailModal } from "./forgot-password/VerifyEmailModal";
  import Spinner from "../../views/elements/Spinner";
  import { formatSeconds } from "../../../DateUtils";
  import AutoDiscoveryUtils from "../../../utils/AutoDiscoveryUtils";
 +import TchapUtils from "../../../../../../src/tchap/util/TchapUtils"; // :TCHAP:
++import Tchapi18nUtils from "../../../../../../src/tchap/i18n/Tchapi18nUtils";
  
  const emailCheckInterval = 2000;
  
-@@ -62,7 +63,7 @@ enum Phase {
+@@ -62,7 +64,7 @@ enum Phase {
  }
  
  interface Props {
@@ -19,7 +20,7 @@ index c4c0834..27e9f28 100644
      onLoginClick: () => void;
      onComplete: () => void;
  }
-@@ -107,14 +108,17 @@ export default class ForgotPassword extends React.Component<Props, State> {
+@@ -107,14 +109,17 @@ export default class ForgotPassword extends React.Component<Props, State> {
              serverSupportsControlOfDevicesLogout: false,
              logoutDevices: false,
          };
@@ -38,7 +39,7 @@ index c4c0834..27e9f28 100644
          if (
              prevProps.serverConfig.hsUrl !== this.props.serverConfig.hsUrl ||
              prevProps.serverConfig.isUrl !== this.props.serverConfig.isUrl
-@@ -125,6 +129,7 @@ export default class ForgotPassword extends React.Component<Props, State> {
+@@ -125,6 +130,7 @@ export default class ForgotPassword extends React.Component<Props, State> {
              // Do capabilities check on new URLs
              this.checkServerCapabilities(this.props.serverConfig);
          }
@@ -46,7 +47,7 @@ index c4c0834..27e9f28 100644
      }
  
      private async checkServerLiveliness(serverConfig: ValidatedServerConfig): Promise<void> {
-@@ -159,9 +164,38 @@ export default class ForgotPassword extends React.Component<Props, State> {
+@@ -159,9 +165,38 @@ export default class ForgotPassword extends React.Component<Props, State> {
          });
      }
  
@@ -73,7 +74,7 @@ index c4c0834..27e9f28 100644
 +        if (!serverResult) {
 +            this.setState({
 +                serverIsAlive: false,
-+                errorText: _t('Server unavailable, overloaded, or something else went wrong.'), // reuse existing string
++                errorText: Tchapi18nUtils.getServerDownMessage("err-01"),
 +                phase: Phase.EnterEmail, // return to original phase, to remove the loding spinner from the submit button.
 +            });
 +            return;
@@ -85,7 +86,7 @@ index c4c0834..27e9f28 100644
          if (await this.sendVerificationMail()) {
              this.phase = Phase.EmailSent;
              return;
-@@ -326,8 +360,10 @@ export default class ForgotPassword extends React.Component<Props, State> {
+@@ -326,8 +361,10 @@ export default class ForgotPassword extends React.Component<Props, State> {
              errorText: "",
          });
  
@@ -96,7 +97,7 @@ index c4c0834..27e9f28 100644
  
          // Server error
          if (!this.state.serverIsAlive) return;
-@@ -358,7 +394,7 @@ export default class ForgotPassword extends React.Component<Props, State> {
+@@ -358,7 +395,7 @@ export default class ForgotPassword extends React.Component<Props, State> {
              <EnterEmail
                  email={this.state.email}
                  errorText={this.state.errorText}
@@ -105,7 +106,7 @@ index c4c0834..27e9f28 100644
                  loading={this.state.phase === Phase.SendingEmail}
                  onInputChanged={this.onInputChanged}
                  onLoginClick={this.props.onLoginClick!} // set by default props
-@@ -449,7 +485,9 @@ export default class ForgotPassword extends React.Component<Props, State> {
+@@ -449,7 +486,9 @@ export default class ForgotPassword extends React.Component<Props, State> {
                                      onChange={() => this.setState({ logoutDevices: !this.state.logoutDevices })}
                                      checked={this.state.logoutDevices}
                                  >

--- a/patches/login/matrix-react-sdk+3.71.1.patch
+++ b/patches/login/matrix-react-sdk+3.71.1.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
-index 4314726..fb1ed2c 100644
+index 4314726..a74c9af 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
 @@ -40,6 +40,8 @@ import AuthHeader from "../../views/auth/AuthHeader";
@@ -88,7 +88,7 @@ index 4314726..fb1ed2c 100644
 +        //     _t("There was a problem communicating with the homeserver, please try again later.") +
 +        //     (errCode ? " (" + errCode + ")" : "");
 +
-+        let errorText: ReactNode = Tchapi18nUtils.getServerDownMessage(errCode);
++        let errorText: ReactNode = Tchapi18nUtils.getServerDownMessage("("+errCode+")");
  
          if (err instanceof ConnectionError) {
              if (

--- a/patches/login/matrix-react-sdk+3.71.1.patch
+++ b/patches/login/matrix-react-sdk+3.71.1.patch
@@ -1,16 +1,17 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
-index 4314726..0a34f0e 100644
+index 4314726..fb1ed2c 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
-@@ -40,6 +40,7 @@ import AuthHeader from "../../views/auth/AuthHeader";
+@@ -40,6 +40,8 @@ import AuthHeader from "../../views/auth/AuthHeader";
  import AccessibleButton, { ButtonEvent } from "../../views/elements/AccessibleButton";
  import { ValidatedServerConfig } from "../../../utils/ValidatedServerConfig";
  import { filterBoolean } from "../../../utils/arrays";
 +import TchapUtils from '../../../../../../src/tchap/util/TchapUtils'; // :TCHAP:
++import Tchapi18nUtils from '../../../../../../src/tchap/i18n/Tchapi18nUtils'; // :TCHAP:
  
  // These are used in several places, and come from the js-sdk's autodiscovery
  // stuff. We define them here so that they'll be picked up by i18n.
-@@ -167,12 +168,22 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -167,12 +169,22 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
  
      public isBusy = (): boolean => !!this.state.busy || !!this.props.busy;
  
@@ -33,7 +34,7 @@ index 4314726..0a34f0e 100644
          if (!this.state.serverIsAlive) {
              this.setState({ busy: true });
              // Do a quick liveliness check on the URLs
-@@ -198,6 +209,7 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -198,6 +210,7 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
                  return;
              }
          }
@@ -41,7 +42,7 @@ index 4314726..0a34f0e 100644
  
          this.setState({
              busy: true,
-@@ -206,6 +218,22 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -206,6 +219,23 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
              loginIncorrect: false,
          });
  
@@ -52,7 +53,8 @@ index 4314726..0a34f0e 100644
 +            this.setState({
 +                busy: false,
 +                busyLoggingIn: false,
-+                errorText: _t('Server unavailable, overloaded, or something else went wrong.'), // reuse existing string
++                //errorText: _t('Server unavailable, overloaded, or something else went wrong.'), // reuse existing string
++                errorText: Tchapi18nUtils.getServerDownMessage("(err-03)"),
 +                loginIncorrect: false,
 +            });
 +            return;
@@ -64,7 +66,7 @@ index 4314726..0a34f0e 100644
          this.loginLogic.loginViaPassword(username, phoneCountry, phoneNumber, password).then(
              (data) => {
                  this.setState({ serverIsAlive: true }); // it must be, we logged in.
-@@ -253,6 +281,10 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -253,6 +283,10 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
                      } else {
                          errorText = _t("Incorrect username and/or password.");
                      }
@@ -75,7 +77,67 @@ index 4314726..0a34f0e 100644
                  } else {
                      // other errors, not specific to doing a password login
                      errorText = this.errorTextFromError(error);
-@@ -629,10 +661,12 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+@@ -454,9 +488,11 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+             errCode = "HTTP " + err.httpStatus;
+         }
+ 
+-        let errorText: ReactNode =
+-            _t("There was a problem communicating with the homeserver, please try again later.") +
+-            (errCode ? " (" + errCode + ")" : "");
++        // let errorText: ReactNode =
++        //     _t("There was a problem communicating with the homeserver, please try again later.") +
++        //     (errCode ? " (" + errCode + ")" : "");
++
++        let errorText: ReactNode = Tchapi18nUtils.getServerDownMessage(errCode);
+ 
+         if (err instanceof ConnectionError) {
+             if (
+@@ -465,42 +501,13 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
+             ) {
+                 errorText = (
+                     <span>
+-                        {_t(
+-                            "Can't connect to homeserver via HTTP when an HTTPS URL is in your browser bar. " +
+-                                "Either use HTTPS or <a>enable unsafe scripts</a>.",
+-                            {},
+-                            {
+-                                a: (sub) => {
+-                                    return (
+-                                        <a
+-                                            target="_blank"
+-                                            rel="noreferrer noopener"
+-                                            href="https://www.google.com/search?&q=enable%20unsafe%20scripts"
+-                                        >
+-                                            {sub}
+-                                        </a>
+-                                    );
+-                                },
+-                            },
+-                        )}
++                        {Tchapi18nUtils.getServerDownMessage("err-01")}
+                     </span>
+                 );
+             } else {
+                 errorText = (
+                     <span>
+-                        {_t(
+-                            "Can't connect to homeserver - please check your connectivity, ensure your " +
+-                                "<a>homeserver's SSL certificate</a> is trusted, and that a browser extension " +
+-                                "is not blocking requests.",
+-                            {},
+-                            {
+-                                a: (sub) => (
+-                                    <a target="_blank" rel="noreferrer noopener" href={this.props.serverConfig.hsUrl}>
+-                                        {sub}
+-                                    </a>
+-                                ),
+-                            },
+-                        )}
++                        {Tchapi18nUtils.getServerDownMessage("err-02")}
+                     </span>
+                 );
+             }
+@@ -629,10 +636,12 @@ export default class LoginComponent extends React.PureComponent<IProps, IState>
                      </h1>
                      {errorTextSection}
                      {serverDeadSection}

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -62,6 +62,7 @@
 
     "login": {
         "package": "matrix-react-sdk",
+        "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/507",
         "files": [
             "src/components/structures/auth/Login.tsx",
             "src/components/views/auth/PasswordLogin.tsx"
@@ -212,6 +213,14 @@
         "files": [
             "src/utils/exportUtils/HtmlExport.tsx",
             "test/utils/exportUtils/HTMLExport-test.ts"
+        ]
+    },
+    "error-tchap-is-down": {
+        "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/507",
+        "package": "matrix-react-sdk",
+        "files": [
+            "src/components/structures/RoomSearchView.tsx",
+            "src/components/structures/RoomStatusBar.tsx"
         ]
     }
 }

--- a/src/tchap/i18n/Tchapi18nUtils.tsx
+++ b/src/tchap/i18n/Tchapi18nUtils.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { _t } from "matrix-react-sdk/src/languageHandler";
+import TchapUrls from "../util/TchapUrls";
+
+
+export default class Tchapi18nUtils {
+
+    public static getServerDownMessage(errCode? : string){
+        return _t(
+            "Review Tchap services status : url",
+            errCode ? {errCode} : {"errCode": ""},
+            {
+                a: (sub) => (
+                    <a target="_blank" rel="noreferrer noopener" href={TchapUrls.statusPage}>
+                        {sub}
+                    </a>
+                ),
+            },
+        )
+    }
+}
+
+

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -962,5 +962,41 @@
   "Read the Privacy Policy": {
     "en": "Read the Privacy Policy",
     "fr": "Consultez la Politique de Confidentialité"
+  },
+  "Your %(brand)s is misconfigured": {
+    "fr": "",
+    "en": ""
+  },
+  "You can also ask your homeserver admin to upgrade the server to change this behaviour.":{
+    "fr" : "",
+    "en" : ""
+  },
+  "Ask your %(brand)s admin to check <a>your config</a> for incorrect or duplicate entries.":{
+    "fr" : "",
+    "en" : ""
+  },
+  "Server may be unavailable, overloaded, or search timed out :(" : {
+    "fr" :  "Tchap n'est pas accessible pour le moment. Merci de consulter l'état des services Tchap: https://status.tchap.numerique.gouv.fr (err:01)",
+    "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr (err:01)"
+  },
+  "Server may be unavailable, overloaded, or you hit a bug." : {
+    "fr" : "Tchap n'est pas accessible pour le moment. Merci de consulter l'état des services Tchap: https://status.tchap.numerique.gouv.fr (err:02) " ,
+    "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr  (err:02)"
+  },
+  "Server unavailable, overloaded, or something else went wrong." : {
+    "fr" : "Tchap n'est pas accessible pour le moment. Merci de consulter l'état des services Tchap: https://status.tchap.numerique.gouv.fr (err:03)",
+    "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr (err:03) "
+  },
+  "Connectivity to the server has been lost.": {
+    "fr": "Tchap n'est pas accessible pour le moment, consulter <a>l'état des services</a>. %(errCode)s",
+    "en" : "Tchap is not available at the moment"
+  },
+  "Review Tchap services status : url": {
+    "fr": "Tchap n'est pas accessible pour le moment, consulter <a>l'état des services</a>. %(errCode)s",
+    "en" : "Review Tchap services status : <a>url</a>"
+  },
+  "Sent messages will be stored until your connection has returned.": {
+    "fr": "Les messages envoyés seront stockés jusqu’à ce que la connexion soit établie.",
+    "en" : "Sent messages will be stored until your connection has returned."
   }
 }

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -975,28 +975,24 @@
     "fr" : "",
     "en" : ""
   },
-  "Server may be unavailable, overloaded, or search timed out :(" : {
-    "fr" : "La connexion à Tchap n'est pas possible pour le moment. Voir l'état du service: https://status.tchap.numerique.gouv.fr (err:01)",
-    "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr (err:01)"
-  },
   "Server may be unavailable, overloaded, or you hit a bug." : {
-    "fr" : "La connexion à Tchap n'est pas possible pour le moment. Voir l'état du service: https://status.tchap.numerique.gouv.fr (err:02)" ,
-    "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr  (err:02)"
+    "fr" : "La connexion à Tchap n'est pas possible pour le moment (err:04). Voir l'état du service: https://status.tchap.numerique.gouv.fr" ,
+    "en" : "Tchap is not available at the moment (err:04). View the status of services: https://status.tchap.numerique.gouv.fr"
   },
   "Server unavailable, overloaded, or something else went wrong." : {
-    "fr" : "La connexion à Tchap n'est pas possible pour le moment. Voir l'état du service: https://status.tchap.numerique.gouv.fr (err:03)",
-    "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr (err:03) "
+    "fr" : "La connexion à Tchap n'est pas possible pour le moment (err:03). Voir l'état du service: https://status.tchap.numerique.gouv.fr",
+    "en" : "Tchap is not available at the moment (err:03). View the status of services: https://status.tchap.numerique.gouv.fr"
   },
   "Connectivity to the server has been lost.": {
-    "fr": "La connexion à Tchap n'est pas possible pour le moment. Voir <a>l'état du service</a>. %(errCode)s",
-    "en" : "Tchap is not available at the moment"
+    "fr": "La connexion à Tchap n'est pas possible pour le moment. <a>Voir l'état du service</a>",
+    "en" : "Tchap is not available at the moment. <a>View the status of services</a>."
   },
   "Review Tchap services status : url": {
-    "fr": "La connexion à Tchap n'est pas possible pour le moment. Voir <a>l'état du service</a>. %(errCode)s",
-    "en": "Review Tchap services status : <a>url</a>"
+    "fr": "La connexion à Tchap n'est pas possible pour le moment %(errCode)s. <a>Voir l'état du service</a>",
+    "en": "Tchap is not available at the moment %(errCode)s. <a>View the status of services</a>."
   },
   "Sent messages will be stored until your connection has returned.": {
     "fr": "Les messages seront envoyés automatiquement dès que la connexion sera rétablie.",
-    "en": "Sent messages will be stored until your connection has returned."
+    "en": "Messages will be sent when your connection returns."
   }
 }

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -976,27 +976,27 @@
     "en" : ""
   },
   "Server may be unavailable, overloaded, or search timed out :(" : {
-    "fr" :  "Tchap n'est pas accessible pour le moment. Merci de consulter l'état des services Tchap: https://status.tchap.numerique.gouv.fr (err:01)",
+    "fr" : "La connexion à Tchap n'est pas possible pour le moment. Voir l'état du service: https://status.tchap.numerique.gouv.fr (err:01)",
     "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr (err:01)"
   },
   "Server may be unavailable, overloaded, or you hit a bug." : {
-    "fr" : "Tchap n'est pas accessible pour le moment. Merci de consulter l'état des services Tchap: https://status.tchap.numerique.gouv.fr (err:02) " ,
+    "fr" : "La connexion à Tchap n'est pas possible pour le moment. Voir l'état du service: https://status.tchap.numerique.gouv.fr (err:02)" ,
     "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr  (err:02)"
   },
   "Server unavailable, overloaded, or something else went wrong." : {
-    "fr" : "Tchap n'est pas accessible pour le moment. Merci de consulter l'état des services Tchap: https://status.tchap.numerique.gouv.fr (err:03)",
+    "fr" : "La connexion à Tchap n'est pas possible pour le moment. Voir l'état du service: https://status.tchap.numerique.gouv.fr (err:03)",
     "en" : "View the status of Tchape services at this url: https://status.tchap.numerique.gouv.fr (err:03) "
   },
   "Connectivity to the server has been lost.": {
-    "fr": "Tchap n'est pas accessible pour le moment, consulter <a>l'état des services</a>. %(errCode)s",
+    "fr": "La connexion à Tchap n'est pas possible pour le moment. Voir <a>l'état du service</a>. %(errCode)s",
     "en" : "Tchap is not available at the moment"
   },
   "Review Tchap services status : url": {
-    "fr": "Tchap n'est pas accessible pour le moment, consulter <a>l'état des services</a>. %(errCode)s",
-    "en" : "Review Tchap services status : <a>url</a>"
+    "fr": "La connexion à Tchap n'est pas possible pour le moment. Voir <a>l'état du service</a>. %(errCode)s",
+    "en": "Review Tchap services status : <a>url</a>"
   },
   "Sent messages will be stored until your connection has returned.": {
-    "fr": "Les messages envoyés seront stockés jusqu’à ce que la connexion soit établie.",
-    "en" : "Sent messages will be stored until your connection has returned."
+    "fr": "Les messages seront envoyés automatiquement dès que la connexion sera rétablie.",
+    "en": "Sent messages will be stored until your connection has returned."
   }
 }

--- a/src/tchap/util/TchapUrls.ts
+++ b/src/tchap/util/TchapUrls.ts
@@ -1,4 +1,8 @@
 export default class TchapUrls {
     //url to request the opening of a new domain on Tchap
     public static requestDomainUrl = "https://www.demarches-simplifiees.fr/commencer/utiliser-tchap";
+
+    //tchap status page
+    public static statusPage =  "https://status.tchap.numerique.gouv.fr"
+
 }


### PR DESCRIPTION
## room status bar (UPDATED)

Before : 
<img width="667" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/4077729/af9ebc7c-3ce8-467e-b560-dd920c185cab">


After : 
![image](https://github.com/tchapgouv/tchap-web-v4/assets/4077729/198a2ee0-c988-49ee-8b80-a7198f181098)



## Login 

Before : 
<img width="721" alt="Capture d’écran 2023-07-27 à 10 26 45" src="https://github.com/tchapgouv/tchap-web-v4/assets/4077729/f2d04cc0-0244-477e-b3bf-6d778eecaea3">


After : 
![Capture d’écran 2023-07-31 à 10 13 30](https://github.com/tchapgouv/tchap-web-v4/assets/4077729/243fe37c-b902-44cd-a1f5-31e7423da630)

