### PR TITLE
Remove engines warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,7 +222,9 @@
         "relativePaths": true
     },
     "engines": {
-        "comment-2022-11-07": "matrix-js-sdk requires >=16.0.0. SSL librairies do not work with 18 and 19. 17 has incompatibilities with some deps.",
         "node": "^16"
+    },
+    "engines-comment": {
+        "2022-11-07": "matrix-js-sdk requires >=16.0.0. SSL librairies do not work with 18 and 19. 17 has incompatibilities with some deps."
     }
 }


### PR DESCRIPTION
This warning shows up everywhere in builds : 
`warning element-web@4.3.6: The engine "comment-2022-11-07" appears to be invalid.`

Move the offending comment to stop the warning.
