### PR TITLE
Fix patches-reapply so that it does not remove yarn links

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
         "analyse:unused-exports": "node ./scripts/analyse_unused_exports.js",
         "postinstall": "./scripts/tchap/apply_patches.sh",
         "patch-package": "patch-package",
-        "patches-reapply": "rm -rf node_modules/matrix-react-sdk; rm -rf node_modules/matrix-js-sdk; yarn install --force",
+        "patches-reapply": "rm -rf node_modules/matrix-react-sdk; rm -rf node_modules/matrix-js-sdk; yarn link matrix-js-sdk; yarn link matrix-react-sdk; yarn install --force",
         "patch-make": "node scripts/tchap/makePatch.ts"
     },
     "dependencies": {


### PR DESCRIPTION
Problem : 
When running `yarn patches-reapply`, the `rm -rf node_modules/matrix-react-sdk` removes yarn links. 
So then the patches are applied to node_modules, not to yarn-linked-dependencies.

Fix : 
Add `yarn link matrix-react-sdk` before `yarn install`.