### PR TITLE
Lighter version of patches-reapply, which does not reinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
         "analyse:unused-exports": "node ./scripts/analyse_unused_exports.js",
         "postinstall": "./scripts/tchap/apply_patches.sh",
         "patch-package": "patch-package",
-        "patches-reapply-with-reinstall": "rm -rf node_modules/matrix-react-sdk; rm -rf node_modules/matrix-js-sdk; yarn link matrix-js-sdk; yarn link matrix-react-sdk; yarn install --force",
         "patches-reapply": "cd yarn-linked-dependencies/matrix-react-sdk; git checkout .; cd ../matrix-js-sdk; git checkout .; cd ../..; ./scripts/tchap/apply_patches.sh",
         "patch-make": "node scripts/tchap/makePatch.ts"
     },

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
         "analyse:unused-exports": "node ./scripts/analyse_unused_exports.js",
         "postinstall": "./scripts/tchap/apply_patches.sh",
         "patch-package": "patch-package",
-        "patches-reapply": "rm -rf node_modules/matrix-react-sdk; rm -rf node_modules/matrix-js-sdk; yarn link matrix-js-sdk; yarn link matrix-react-sdk; yarn install --force",
+        "patches-reapply-with-reinstall": "rm -rf node_modules/matrix-react-sdk; rm -rf node_modules/matrix-js-sdk; yarn link matrix-js-sdk; yarn link matrix-react-sdk; yarn install --force",
+        "patches-reapply": "cd yarn-linked-dependencies/matrix-react-sdk; git checkout .; cd ../matrix-js-sdk; git checkout .; cd ../..; ./scripts/tchap/apply_patches.sh",
         "patch-make": "node scripts/tchap/makePatch.ts"
     },
     "dependencies": {


### PR DESCRIPTION
This is what I do by hand when I want to reset patches : go to the package's folder, and remove the git changes.
It's a bit lighter than the previous command.
(if the names are not great, suggestions are welcome !)