### PR TITLE
Créer les salons dans un espace

### DIFF
--- a/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -32,7 +32,7 @@ import TchapCreateRoom from "../../../lib/createTchapRoom";
 interface IProps {
     defaultPublic?: boolean; // unused for Tchap version
     defaultName?: string;
-    parentSpace?: Room; // unused for Tchap version
+    parentSpace?: Room; 
     defaultEncrypted?: boolean; // unused for Tchap version
     onFinished(proceed: boolean, opts?: IOpts): void;
 }
@@ -43,13 +43,16 @@ interface IState {
     tchapRoomType: TchapRoomType;
     forumFederationSwitchValue: boolean;
     showFederateSwitch: boolean;
+    createRoomInSpace: boolean;
 }
 
 export default class TchapCreateRoomDialog extends React.Component<IProps, IState> {
     private nameField = createRef<Field>();
+    private readonly createRoomInSpace: boolean;
 
     public constructor(props) {
         super(props);
+        this.createRoomInSpace = !!this.props.parentSpace;
 
         const federationOptions = TchapUtils.getRoomFederationOptions();
 
@@ -59,6 +62,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
             tchapRoomType: TchapRoomType.Private,
             forumFederationSwitchValue: federationOptions.forumFederationSwitchDefaultValue,
             showFederateSwitch: federationOptions.showForumFederationSwitch,
+            createRoomInSpace: createRoomInSpace,
         };
     }
 
@@ -149,7 +153,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
     public render() {
         const shortDomain: string = TchapUtils.getShortDomain();
 
-        const title = _t("Create a room");
+        const title = this.createRoomInSpace ? _t("Create a room in this space") : _t("Create a room");
 
         return (
             <BaseDialog
@@ -176,6 +180,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
                             forumFederationSwitchValue={this.state.forumFederationSwitchValue}
                             setForumFederationSwitchValue={this.onForumFederatedChange}
                             setRoomType={this.onTchapRoomTypeChange}
+                            createRoomInSpace={this.createRoomInSpace}
                         />
                     </div>
                 </form>

--- a/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -62,7 +62,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
             tchapRoomType: TchapRoomType.Private,
             forumFederationSwitchValue: federationOptions.forumFederationSwitchDefaultValue,
             showFederateSwitch: federationOptions.showForumFederationSwitch,
-            createRoomInSpace: createRoomInSpace,
+            createRoomInSpace: this.createRoomInSpace,
         };
     }
 

--- a/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -43,7 +43,6 @@ interface IState {
     tchapRoomType: TchapRoomType;
     forumFederationSwitchValue: boolean;
     showFederateSwitch: boolean;
-    createRoomInSpace: boolean;
 }
 
 export default class TchapCreateRoomDialog extends React.Component<IProps, IState> {
@@ -62,7 +61,6 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
             tchapRoomType: TchapRoomType.Private,
             forumFederationSwitchValue: federationOptions.forumFederationSwitchDefaultValue,
             showFederateSwitch: federationOptions.showForumFederationSwitch,
-            createRoomInSpace: this.createRoomInSpace,
         };
     }
 

--- a/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
+++ b/src/tchap/components/views/dialogs/TchapCreateRoomDialog.tsx
@@ -136,6 +136,7 @@ export default class TchapCreateRoomDialog extends React.Component<IProps, IStat
                     this.state.name,
                     this.state.tchapRoomType,
                     this.isSelectedRoomFederated(),
+                    this.props.parentSpace
                 ),
             );
         } else {

--- a/src/tchap/components/views/elements/TchapRoomTypeSelector.tsx
+++ b/src/tchap/components/views/elements/TchapRoomTypeSelector.tsx
@@ -98,7 +98,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                             {_t("Private room open to external users")}
                         </div>
                         <div>
-                            {this.props.createRoomInSpace ? _t("Accessible to all users of this space and to external guests by invitation of an administrator.") : _t("Accessible to all users and to external guests by invitation of an administrator.")}
+                            {this.props.createRoomInSpace ? _t("Private discussions accessible to all users of this space and to external guests by invitation of an administrator.") : _t("Accessible to all users and to external guests by invitation of an administrator.")}
                         </div>
                     </StyledRadioButton>
                 </label>

--- a/src/tchap/components/views/elements/TchapRoomTypeSelector.tsx
+++ b/src/tchap/components/views/elements/TchapRoomTypeSelector.tsx
@@ -84,7 +84,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                         onChange={this.onRoomTypeChange}
                     >
                         <div className="tc_TchapRoomTypeSelector_RadioButton_title">{_t("Private room")}</div>
-                        <div>{this.createRoomInSpace ? _t("Private discussions accessible to all users of this space.")  : _t("Accessible to all users by invitation from an administrator.")}</div>
+                        <div>{this.props.createRoomInSpace ? _t("Private discussions accessible to all users of this space.")  : _t("Accessible to all users by invitation from an administrator.")}</div>
                     </StyledRadioButton>
                 </label>
                 <label className={externalClasses}>
@@ -98,7 +98,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                             {_t("Private room open to external users")}
                         </div>
                         <div>
-                            {this.createRoomInSpace ? _t("Accessible to all users of this space and to external guests by invitation of an administrator.") : _t("Accessible to all users and to external guests by invitation of an administrator.")}
+                            {this.props.createRoomInSpace ? _t("Accessible to all users of this space and to external guests by invitation of an administrator.") : _t("Accessible to all users and to external guests by invitation of an administrator.")}
                         </div>
                     </StyledRadioButton>
                 </label>
@@ -110,7 +110,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                         onChange={this.onRoomTypeChange}
                     >
                         <div className="tc_TchapRoomTypeSelector_RadioButton_title">{_t("Forum room")}</div>
-                        <div>{this.createRoomInSpace ? _t("Public discussion accessible to all users of this space or from a shared link.") : _t("Accessible to all users from the forum directory or from a shared link.")}</div>
+                        <div>{this.props.createRoomInSpace ? _t("Public discussion accessible to all users of this space or from a shared link.") : _t("Accessible to all users from the forum directory or from a shared link.")}</div>
                         {roomFederateOpt}
                     </StyledRadioButton>
                 </label>

--- a/src/tchap/components/views/elements/TchapRoomTypeSelector.tsx
+++ b/src/tchap/components/views/elements/TchapRoomTypeSelector.tsx
@@ -21,6 +21,7 @@ interface IProps {
     forumFederationSwitchValue?: boolean;
     setRoomType(value: TchapRoomType): void;
     setForumFederationSwitchValue(forumFederationSwitchValue: boolean): void;
+    createRoomInSpace: boolean;
 }
 
 interface IState {
@@ -83,7 +84,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                         onChange={this.onRoomTypeChange}
                     >
                         <div className="tc_TchapRoomTypeSelector_RadioButton_title">{_t("Private room")}</div>
-                        <div>{_t("Accessible to all users by invitation from an administrator.")}</div>
+                        <div>{this.createRoomInSpace ? _t("Private discussions accessible to all users of this space.")  : _t("Accessible to all users by invitation from an administrator.")}</div>
                     </StyledRadioButton>
                 </label>
                 <label className={externalClasses}>
@@ -97,7 +98,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                             {_t("Private room open to external users")}
                         </div>
                         <div>
-                            {_t("Accessible to all users and to external guests by invitation of an administrator.")}
+                            {this.createRoomInSpace ? _t("Accessible to all users of this space and to external guests by invitation of an administrator.") : _t("Accessible to all users and to external guests by invitation of an administrator.")}
                         </div>
                     </StyledRadioButton>
                 </label>
@@ -109,7 +110,7 @@ export default class TchapRoomTypeSelector extends React.Component<IProps, IStat
                         onChange={this.onRoomTypeChange}
                     >
                         <div className="tc_TchapRoomTypeSelector_RadioButton_title">{_t("Forum room")}</div>
-                        <div>{_t("Accessible to all users from the forum directory or from a shared link.")}</div>
+                        <div>{this.createRoomInSpace ? _t("Public discussion accessible to all users of this space or from a shared link.") : _t("Accessible to all users from the forum directory or from a shared link.")}</div>
                         {roomFederateOpt}
                     </StyledRadioButton>
                 </label>

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -57,6 +57,22 @@
     "en":"Allow access to this room to all users, even outside \"%(domain)s\" domain",
     "fr":"Autoriser l'accès à tous les utilisateurs, même ceux qui ne sont pas membres du domaine \"%(domain)s\""
   },
+  "Create a room in this space": {
+    "en": "Create a room in this space",
+    "fr": "Créer un salon dans cette espace"
+  },
+  "Private discussions accessible to all users of this space.": {
+    "en": "Private discussions accessible to all users of this space.",
+    "fr": "Discussions privés accessible à tous les membres de cette espace"
+  },
+  "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.": {
+    "en": "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.",
+    "fr": "Discussions privés accessible à tous les membres de cette espace et aux utilisateurs externes sur invitation d'un administrateur."
+  },
+  "Public discussion accessible to all users of this space or from a shared link.": {
+    "en": "Public discussion accessible to all users of this space or from a shared link.",
+    "fr": "Discussions publiques accessible à tous les membres de cette espace ou depuis un lien de partage."
+  },
   "Scanning": {
     "en": "Scanning",
     "fr": "Scanning"

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -59,7 +59,7 @@
   },
   "Create a room in this space": {
     "en": "Create a room in this space",
-    "fr": "Créer un salon dans cette espace"
+    "fr": "Créer un salon dans cet espace"
   },
   "Private discussions accessible to all users of this space.": {
     "en": "Private discussions accessible to all users of this space.",

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -63,7 +63,7 @@
   },
   "Private discussions accessible to all users of this space.": {
     "en": "Private discussions accessible to all users of this space.",
-    "fr": "Discussions privés accessible à tous les membres de cet espace"
+    "fr": "Discussions privées accessibles à tous les membres de cet espace"
   },
   "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.": {
     "en": "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.",

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -67,7 +67,7 @@
   },
   "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.": {
     "en": "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.",
-    "fr": "Discussions privés accessible à tous les membres de cet espace et aux utilisateurs externes sur invitation d'un administrateur."
+    "fr": "Discussions privées accessibles à tous les membres de cet espace et aux utilisateurs externes sur invitation d'un administrateur."
   },
   "Public discussion accessible to all users of this space or from a shared link.": {
     "en": "Public discussion accessible to all users of this space or from a shared link.",

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -71,7 +71,7 @@
   },
   "Public discussion accessible to all users of this space or from a shared link.": {
     "en": "Public discussion accessible to all users of this space or from a shared link.",
-    "fr": "Discussions publiques accessible à tous les membres de cet espace ou depuis un lien de partage."
+    "fr": "Discussions publiques accessibles à tous les membres de cet espace ou depuis un lien de partage."
   },
   "Scanning": {
     "en": "Scanning",

--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -63,15 +63,15 @@
   },
   "Private discussions accessible to all users of this space.": {
     "en": "Private discussions accessible to all users of this space.",
-    "fr": "Discussions privés accessible à tous les membres de cette espace"
+    "fr": "Discussions privés accessible à tous les membres de cet espace"
   },
   "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.": {
     "en": "Private discussions accessible to all users of this space and to external guests by invitation of an administrator.",
-    "fr": "Discussions privés accessible à tous les membres de cette espace et aux utilisateurs externes sur invitation d'un administrateur."
+    "fr": "Discussions privés accessible à tous les membres de cet espace et aux utilisateurs externes sur invitation d'un administrateur."
   },
   "Public discussion accessible to all users of this space or from a shared link.": {
     "en": "Public discussion accessible to all users of this space or from a shared link.",
-    "fr": "Discussions publiques accessible à tous les membres de cette espace ou depuis un lien de partage."
+    "fr": "Discussions publiques accessible à tous les membres de cet espace ou depuis un lien de partage."
   },
   "Scanning": {
     "en": "Scanning",

--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -30,10 +30,16 @@ export default class TchapCreateRoom {
         createRoomOpts.creation_content = { "m.federate": federate };
         createRoomOpts.initial_state = createRoomOpts.initial_state || [];
 
+        opts.parentSpace = this.props.parentSpace;
+
         switch (tchapRoomType) {
             case TchapRoomType.Forum: {
-                //"Forum" only for tchap members and not encrypted
-                createRoomOpts.visibility = Visibility.Public;
+                // Space "Forum" only for  members and not encrypted
+                if (this.props.parentSpace) {
+                    createRoomOpts.visibility = Visibility.PrivateChat;
+                } else {      //"Forum" only for tchap members and not encrypted
+                    createRoomOpts.visibility = Visibility.Public;
+                }
                 createRoomOpts.preset = Preset.PublicChat;
                 // Here we could have used createRoomOpts.accessRule directly,
                 // but since accessRules are a custom Tchap event, it is ignored by later code.
@@ -46,7 +52,12 @@ export default class TchapCreateRoom {
                     state_key: "",
                 });
 
-                opts.joinRule = JoinRule.Public;
+                //Open to space by default
+                if (this.props.parentSpace) {
+                    opts.joinRule = JoinRule.Restricted;
+                } else {
+                    opts.joinRule = JoinRule.Public;
+                }
                 opts.encryption = false;
                 opts.historyVisibility = HistoryVisibility.Shared;
                 break;
@@ -62,7 +73,12 @@ export default class TchapCreateRoom {
                     type: TchapRoomAccessRulesEventId,
                     state_key: "",
                 });
-                opts.joinRule = JoinRule.Invite;
+                //Open to space by default
+                if (this.props.parentSpace) {
+                    opts.joinRule = JoinRule.Restricted;
+                } else {
+                    opts.joinRule = JoinRule.Invite;
+                }
                 opts.encryption = true;
                 opts.historyVisibility = HistoryVisibility.Invited;
                 break;
@@ -78,12 +94,20 @@ export default class TchapCreateRoom {
                     type: TchapRoomAccessRulesEventId,
                     state_key: "",
                 });
-                opts.joinRule = JoinRule.Invite;
+                //Open to space by default
+                if (this.props.parentSpace) {
+                    opts.joinRule = JoinRule.Restricted;
+                } else {
+                    opts.joinRule = JoinRule.Invite;
+                }
                 opts.encryption = true;
                 opts.historyVisibility = HistoryVisibility.Invited;
                 break;
             }
         }
+
+      
+
         return opts;
     }
 }

--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -37,7 +37,7 @@ export default class TchapCreateRoom {
 
         switch (tchapRoomType) {
             case TchapRoomType.Forum: {
-                // Space "Forum" only for  members and not encrypted
+                // Space "Forum" only for space members and not encrypted
                 if (parentSpace) {
                     createRoomOpts.visibility = Visibility.PrivateChat;
                 } else {      //"Forum" only for tchap members and not encrypted

--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -31,7 +31,9 @@ export default class TchapCreateRoom {
         createRoomOpts.creation_content = { "m.federate": federate };
         createRoomOpts.initial_state = createRoomOpts.initial_state || [];
 
-        opts.parentSpace = parentSpace;
+        if(parentSpace) {
+            opts.parentSpace = parentSpace;
+        }
 
         switch (tchapRoomType) {
             case TchapRoomType.Forum: {

--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -18,6 +18,7 @@ export default class TchapCreateRoom {
         name: string,
         tchapRoomType: TchapRoomType,
         federate: boolean = DEFAULT_FEDERATE_VALUE,
+        parentSpace?: Room
     ): IOpts {
         const opts: IOpts = {};
         const createRoomOpts: ICreateRoomOpts = {};
@@ -30,12 +31,12 @@ export default class TchapCreateRoom {
         createRoomOpts.creation_content = { "m.federate": federate };
         createRoomOpts.initial_state = createRoomOpts.initial_state || [];
 
-        opts.parentSpace = this.props.parentSpace;
+        opts.parentSpace = parentSpace;
 
         switch (tchapRoomType) {
             case TchapRoomType.Forum: {
                 // Space "Forum" only for  members and not encrypted
-                if (this.props.parentSpace) {
+                if (parentSpace) {
                     createRoomOpts.visibility = Visibility.PrivateChat;
                 } else {      //"Forum" only for tchap members and not encrypted
                     createRoomOpts.visibility = Visibility.Public;
@@ -53,7 +54,7 @@ export default class TchapCreateRoom {
                 });
 
                 //Open to space by default
-                if (this.props.parentSpace) {
+                if (parentSpace) {
                     opts.joinRule = JoinRule.Restricted;
                 } else {
                     opts.joinRule = JoinRule.Public;
@@ -74,7 +75,7 @@ export default class TchapCreateRoom {
                     state_key: "",
                 });
                 //Open to space by default
-                if (this.props.parentSpace) {
+                if (parentSpace) {
                     opts.joinRule = JoinRule.Restricted;
                 } else {
                     opts.joinRule = JoinRule.Invite;
@@ -95,7 +96,7 @@ export default class TchapCreateRoom {
                     state_key: "",
                 });
                 //Open to space by default
-                if (this.props.parentSpace) {
+                if (parentSpace) {
                     opts.joinRule = JoinRule.Restricted;
                 } else {
                     opts.joinRule = JoinRule.Invite;

--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -106,9 +106,6 @@ export default class TchapCreateRoom {
                 break;
             }
         }
-
-      
-
         return opts;
     }
 }


### PR DESCRIPTION
## Description

Avant : les salons étaient créés en dehors d'un espace si on fait "Créer un salon" depuis l'espace.
Maintenant :  Tous les salons/forums sont créés dans l'espace et ils sont limité à l'espace par défaut, joignable par défault par les membres de l'espace.

## Captures d'écran

### Avant 
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/96488ff2-f63c-471a-a982-eb0c2de55913)


### Après
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/e321c8bc-75f1-4d08-9b3e-8765c74ce814)

### Menu accessible depuis 
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/b130893f-904f-4f6e-8006-915046d82ae1)
et 
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/699a0130-6b77-433a-84db-9aaad040bede)

## Todo 
- [x] Tester
- [x] Captures d'écrans
- [x] Ecrire les traductions
- [ ] ~~Ecrire des tests~~ (abandoné)
   - Pas de tests react, il faudrait créer un objet Room qui est complexe à créer : https://github.com/matrix-org/matrix-js-sdk/blob/33bbd45f1e59f2f0e2bf3f2d98157a5371864d32/src/models/room.ts#L439-L444
   -  Je n'ai pas trouvé de test composant pour la création de room "dans un espace" dans le code d'Element 
       - https://github.com/matrix-org/matrix-react-sdk/blob/develop/test/components/views/dialogs/CreateRoomDialog-test.tsx
       - https://github.com/matrix-org/matrix-react-sdk/blob/develop/test/createRoom-test.ts
       - https://github.com/matrix-org/matrix-react-sdk/blob/develop/cypress/e2e/create-room/create-room.spec.ts
   - Peut-être un test cypress ?

## Evolution possible
- Afficher le nom de l'espace dans la popup
- Ajouter une checkbox pour indiquer si on veut que le salon soit créer dans l'espace ou pas
- Ajouter une checkbox pour indiquer si on veut que le salon soit joignable par les membres de l'espace ou pas

