### PR TITLE
add base url to make rageshake on preprod working

### DIFF
--- a/config.preprod.json
+++ b/config.preprod.json
@@ -25,7 +25,7 @@
     "disable_login_language_selector": false,
     "disable_3pid_login": false,
     "brand": "Tchap",
-    "bug_report_endpoint_url": "/bugreports/submit",
+    "bug_report_endpoint_url": "https://matrix.i.tchap.gouv.fr/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "defaultCountryCode": "FR",
     "showLabsSettings": false,


### PR DESCRIPTION
This PR is to make rageshake working on preprod.
The base url is missing in the config.json for preprod.
