### PR TITLE
fix visibility parameter for forum created in space

### DIFF
--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -39,7 +39,7 @@ export default class TchapCreateRoom {
             case TchapRoomType.Forum: {
                 // Space "Forum" only for space members and not encrypted
                 if (parentSpace) {
-                    createRoomOpts.visibility = Visibility.PrivateChat;
+                    createRoomOpts.visibility = Visibility.Private;
                 } else {      //"Forum" only for tchap members and not encrypted
                     createRoomOpts.visibility = Visibility.Public;
                 }


### PR DESCRIPTION
- When creating a forum in a space, it should not be visible in the forum list of the homeserver

## Create a forum in a space:  
<img width="578" alt="Capture d’écran 2023-09-19 à 19 19 55" src="https://github.com/tchapgouv/tchap-web-v4/assets/4077729/6a3dddc3-a667-45ed-92c5-04aba81f5a13">



## It must not be visible in the forum list
![Uploading Capture d’écran 2023-09-19 à 19.20.12.png…]()

- [x] https://github.com/tchapgouv/tchap-web-v4/issues/705
