### PR TITLE
 CI : download build from uploaded artifact for cypress job (3rd part)

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -40,7 +40,7 @@ jobs:
                   run_id: ${{ github.event.workflow_run.id }} # I think this is the run_id of the workflow that triggered this workflow
 
             - name: Install Dependencies
-              run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
+              run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn add cypress to go faster ?
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0


### PR DESCRIPTION
In order to shorten the super long cypress job, we reuse the build made by the build job. 
The build.yml job uploads the contents of `webapp` in an artifact, that the cypress.yml job downloads.
We save about 2min. 

The cypress job is triggered, but its results are not displayed in the github PR 
See the run results : https://github.com/tchapgouv/tchap-web-v4/actions/runs/6262723807

The full diff to review is this : 
https://github.com/tchapgouv/tchap-web-v4/compare/31d995a1d...cypress-download-build-artifact-3

Continuation of work started in previous PRs : 
https://github.com/tchapgouv/tchap-web-v4/pull/709
https://github.com/tchapgouv/tchap-web-v4/pull/710
https://github.com/tchapgouv/tchap-web-v4/pull/711


Todo in next PRs : 
 - display the results of the cypress run in the PR
 - We could maybe save more time by avoiding the whole `yarn install` + `postinstall`, and installing only cypress...