### PR TITLE
Capitalize locationSharing correctly

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -64,7 +64,7 @@
         "UIFeature.thirdPartyId": true,
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
-        "UIFeature.LocationSharing": false,
+        "UIFeature.locationSharing": false,
         "MessageComposerInput.showPollsButton": false,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -58,7 +58,7 @@
         "UIFeature.thirdPartyId": true,
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
-        "UIFeature.LocationSharing": false,
+        "UIFeature.locationSharing": false,
         "MessageComposerInput.showPollsButton": false,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,

--- a/config.prod.json
+++ b/config.prod.json
@@ -166,7 +166,7 @@
         "UIFeature.thirdPartyId": true,
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
-        "UIFeature.LocationSharing": false,
+        "UIFeature.locationSharing": false,
         "MessageComposerInput.showPollsButton": false,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -166,7 +166,7 @@
         "UIFeature.thirdPartyId": true,
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
-        "UIFeature.LocationSharing": false,
+        "UIFeature.locationSharing": false,
         "MessageComposerInput.showPollsButton": true,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,


### PR DESCRIPTION
We were using LocationSharing instead of locationSharing, which caused our setting to be ignored. 

Fixes https://github.com/tchapgouv/tchap-web-v4/issues/702