### PR TITLE
E2E test : external private rooms are styled properly

### DIFF
--- a/cypress/e2e/tchap-external-room-style.spec.ts
+++ b/cypress/e2e/tchap-external-room-style.spec.ts
@@ -20,7 +20,7 @@ describe("Style of external rooms", () => {
             //open room
             cy.get('[aria-label="' + roomName + '"]').click();
 
-            cy.get(".mx_LegacyRoomHeader light-panel").within(() => {
+            cy.get(".mx_LegacyRoomHeader").within(() => {
                 cy.get(".tc_RoomHeader_external"); // "ouvert aux externes"
                 cy.get(".mx_DecoratedRoomAvatar_icon_external"); // lock icon on room avatar
             });

--- a/cypress/e2e/tchap-external-room-style.spec.ts
+++ b/cypress/e2e/tchap-external-room-style.spec.ts
@@ -1,0 +1,31 @@
+/// <reference types="cypress" />
+
+import RoomUtils from "../utils/room-utils";
+import RandomUtils from "../utils/random-utils";
+
+describe("Style of external rooms", () => {
+    const homeserverUrl = Cypress.env("E2E_TEST_USER_HOMESERVER_URL");
+    const email = Cypress.env("E2E_TEST_USER_EMAIL");
+    const password = Cypress.env("E2E_TEST_USER_PASSWORD");
+    const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+
+    beforeEach(() => {
+        cy.loginUser(homeserverUrl, email, password);
+    });
+
+    it("displays special header in external private room", () => {
+        const roomName = "test/" + today + "/external_room_header_" + RandomUtils.generateRandom(4);
+
+        RoomUtils.createPrivateWithExternalRoom(roomName).then((roomId) => {
+            //open room
+            cy.get('[aria-label="' + roomName + '"]').click();
+
+            cy.get(".mx_LegacyRoomHeader light-panel").within(() => {
+                cy.get(".tc_RoomHeader_external"); // "ouvert aux externes"
+                cy.get(".mx_DecoratedRoomAvatar_icon_external"); // lock icon on room avatar
+            });
+
+            cy.leaveRoom(roomId);
+        });
+    });
+});


### PR DESCRIPTION
External private rooms should show 'ouvert aux externes' in the header, and display a special icon.