### PR TITLE
Improve traduction for Spaces

### DIFF
--- a/src/tchap/i18n/strings/tchap_translations.json
+++ b/src/tchap/i18n/strings/tchap_translations.json
@@ -395,15 +395,15 @@
     "fr": "Discussion"
   },
   "Join public room": {
-    "en": "Join a room",
+    "en": "Join a public room",
     "fr": "Rejoindre un forum"
   },
   "Explore rooms": {
-    "en": "Explore rooms",
-    "fr": "Rejoindre un forum"
+    "en": "Explore space rooms",
+    "fr": "Explorer les salons"
   },
   "Explore public rooms": {
-    "en": "Join a room",
+    "en": "Explore public rooms",
     "fr": "Rejoindre un forum"
   },
   "Start chat": {


### PR DESCRIPTION
# Before 
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/75ce171c-bbd5-4c28-842f-231a7c7b7eae)
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/728b628b-9ac6-4265-93b3-432b399d5684)
# After
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/0f4bfed5-f448-435b-a02d-ddd2e06e76a5)
![image](https://github.com/tchapgouv/tchap-web-v4/assets/1238254/00fe8a2c-0608-456c-8aba-ed0c7b661435)

j'aurais pu mettre "Explorer les salons de l'espace" mais je me disais que c'était un peu trop long.