### PR TITLE
[experiment] Reusable build job

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -57,10 +57,10 @@ jobs:
             - name: Get build from cache
               uses: actions/cache@v3
               with:
-              path: |
-                  ./webapp
-                  ./node_modules
-              key: $CACHE_KEY
+                  path: |
+                      ./webapp
+                      ./node_modules
+                  key: $CACHE_KEY
 
             - name: Check presence of cache
               run: ls ./webapp && ls ./node_modules

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -57,7 +57,9 @@ jobs:
             - name: Get build from cache
               uses: actions/cache@v3
               with:
-                  path: ./webapp
+                  path: |
+                      ./webapp
+                      ./node_modules
                   key: "$CACHE_KEY"
 
             - name: Check presence of cache

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,12 +1,13 @@
 # This is a tchap-specific file, inspired from the one in matrix-react-sdk
 name: Cypress End to End Tests
 
-# Run this job when the "Build" job completes
 on:
-    workflow_run:
-        workflows: ["Build"]
-        types:
-            - completed
+    # Run this job when the "Build" job completes
+    #workflow_run:
+    #    workflows: ["Build"]
+    #    types:
+    #        - completed
+    pull_request: {} # run for commits in PRs
     workflow_dispatch: # for running action manually
 
 env:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -21,7 +21,7 @@ jobs:
         name: Build
         uses: ./.github/workflows/reusable-build.yaml
         with:
-            CACHE_KEY: $CACHE_KEY
+            CACHE_KEY: ${{ env.CACHE_KEY }}
 
     cypress:
         name: Cypress
@@ -57,13 +57,14 @@ jobs:
             - name: Get build from cache
               uses: actions/cache@v3
               with:
-                  path: |
-                      ./webapp
-                      ./node_modules
-                  key: $CACHE_KEY
+                  path: ./webapp
+                  key: ${{ env.CACHE_KEY }}
 
             - name: Check presence of cache
-              run: ls ./webapp && ls ./node_modules
+              run: ls ./webapp
+
+            - name: Install cypress
+              run: yarn add cypress --dev --ignore-scripts # ignore-scripts to avoid running postinstall
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -14,13 +14,14 @@ env:
     # Removing this makes the job break.
     REPOSITORY: ${{ github.repository }}
     PR_NUMBER: ${{ github.event.pull_request.number }}
+    CACHE_KEY: $(git rev-parse --short=12 HEAD)-${{ github.event.pull_request.number }}-${{ hashFiles('**/package-lock.json') }}
 
 jobs:
     call-build-job:
         name: Build
         uses: ./.github/workflows/reusable-build.yaml
         with:
-            CACHE_KEY: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+            CACHE_KEY: $CACHE_KEY
 
     cypress:
         name: Cypress
@@ -59,7 +60,7 @@ jobs:
               path: |
                   ./webapp
                   ./node_modules
-              key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+              key: $CACHE_KEY
 
             - name: Check presence of cache
               run: ls ./webapp && ls ./node_modules

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -21,7 +21,7 @@ jobs:
         name: Build
         uses: ./.github/workflows/reusable-build.yaml
         with:
-            CACHE_KEY: ${{ env.CACHE_KEY }}
+            CACHE_KEY: "$CACHE_KEY"
 
     cypress:
         name: Cypress
@@ -58,7 +58,7 @@ jobs:
               uses: actions/cache@v3
               with:
                   path: ./webapp
-                  key: ${{ env.CACHE_KEY }}
+                  key: "$CACHE_KEY"
 
             - name: Check presence of cache
               run: ls ./webapp

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -25,7 +25,7 @@ jobs:
 
     cypress:
         name: Cypress
-        needs: call-build-job # run after call-build-job has succeeded
+        #needs: call-build-job # run after call-build-job has succeeded
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -64,7 +64,7 @@ jobs:
               run: ls ./webapp
 
             - name: Install cypress
-              run: yarn add cypress --dev --ignore-scripts # ignore-scripts to avoid running postinstall
+              run: yarn add cypress --dev #--ignore-scripts # ignore-scripts to avoid running postinstall
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -15,6 +15,9 @@ env:
     PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
+    call-build-job:
+        uses: ./.github/workflows/reusable-build.yml
+
     cypress:
         name: Cypress
         runs-on: ubuntu-latest

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -38,16 +38,18 @@ jobs:
                   cache: "yarn"
                   node-version: ${{ steps.node_version.outputs.node_version }}
 
-            - name: Download build from artifact
-              # use this action instead of actions/download-artifact because we need the "workflow" param
-              uses: dawidd6/action-download-artifact@v2
-              with:
-                  name: devbuild
-                  path: webapp
-                  run_id: ${{ github.event.workflow_run.id }} # I think this is the run_id of the workflow that triggered this workflow
+            #####
+            # Get build from artifact. Not needed since we called reusable-build.yml in the same workflow, we can reuse the files.
+            #- name: Download build from artifact
+            #  # use this action instead of actions/download-artifact because we need the "workflow" param
+            #  uses: dawidd6/action-download-artifact@v2
+            #  with:
+            #      name: devbuild
+            #      path: webapp
+            #      run_id: ${{ github.event.workflow_run.id }} # I think this is the run_id of the workflow that triggered this workflow
 
-            - name: Install Dependencies
-              run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
+            #- name: Install Dependencies
+            #  run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -54,7 +54,6 @@ jobs:
             #  run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
 
             - name: Get build from cache
-                id: get-build-files
                 uses: actions/cache@v3
                 with:
                 path: |

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -18,7 +18,7 @@ env:
 
 jobs:
     call-build-job:
-        name: Build
+        name: Build app for cypress test
         uses: ./.github/workflows/reusable-build.yaml
         with:
             CACHE_KEY: "$CACHE_KEY"

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
     call-build-job:
-        uses: estellecomment/tchap-web-v4/.github/workflows/reusable-build.yml
+        uses: ./.github/workflows/reusable-build.yaml
 
     cypress:
         name: Cypress

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -54,15 +54,15 @@ jobs:
             #  run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
 
             - name: Get build from cache
-                uses: actions/cache@v3
-                with:
-                path: |
-                    ./webapp
-                    ./node_modules
-                key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+              uses: actions/cache@v3
+              with:
+              path: |
+                  ./webapp
+                  ./node_modules
+              key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Check presence of cache
-                run: ls ./webapp && ls ./node_modules
+              run: ls ./webapp && ls ./node_modules
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -14,7 +14,7 @@ env:
     # Removing this makes the job break.
     REPOSITORY: ${{ github.repository }}
     PR_NUMBER: ${{ github.event.pull_request.number }}
-    CACHE_KEY: $(git rev-parse --short=12 HEAD)-${{ github.event.pull_request.number }}-${{ hashFiles('**/package-lock.json') }}
+    CACHE_KEY: $(git rev-parse --short=12 HEAD)-${{ github.event.pull_request.number }}-${{ github.job }}
 
 jobs:
     call-build-job:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -25,7 +25,7 @@ jobs:
 
     cypress:
         name: Cypress
-        #needs: call-build-job # run after call-build-job has succeeded
+        needs: call-build-job # run after call-build-job has succeeded
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -64,7 +64,7 @@ jobs:
               run: ls ./webapp
 
             - name: Install cypress
-              run: yarn add cypress --dev #--ignore-scripts # ignore-scripts to avoid running postinstall
+              run: yarn add cypress --dev
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -60,7 +60,7 @@ jobs:
                 path: |
                     ./webapp
                     ./node_modules
-                key: ${{ inputs.CACHE_KEY }}
+                key: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
             - name: Check presence of cache
                 run: ls ./webapp && ls ./node_modules

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -19,10 +19,12 @@ jobs:
     call-build-job:
         name: Build
         uses: ./.github/workflows/reusable-build.yaml
+        with:
+            CACHE_KEY: ${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
 
     cypress:
         name: Cypress
-        needs: call-build-job
+        needs: call-build-job # run after call-build-job has succeeded
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
@@ -50,6 +52,18 @@ jobs:
 
             #- name: Install Dependencies
             #  run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
+
+            - name: Get build from cache
+                id: get-build-files
+                uses: actions/cache@v3
+                with:
+                path: |
+                    ./webapp
+                    ./node_modules
+                key: ${{ inputs.CACHE_KEY }}
+
+            - name: Check presence of cache
+                run: ls ./webapp && ls ./node_modules
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -17,10 +17,12 @@ env:
 
 jobs:
     call-build-job:
+        name: Build
         uses: ./.github/workflows/reusable-build.yaml
 
     cypress:
         name: Cypress
+        needs: call-build-job
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -17,7 +17,7 @@ env:
 
 jobs:
     call-build-job:
-        uses: ./.github/workflows/reusable-build.yml
+        uses: estellecomment/tchap-web-v4/.github/workflows/reusable-build.yml
 
     cypress:
         name: Cypress

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -4,13 +4,7 @@ name: Reusable Build
 on:
   # setup of the reusable job.
   workflow_call:
-    inputs:
-      config-path:
-        required: true
-        type: string
-    secrets:
-      token:
-        required: true
+
   workflow_dispatch: # for running workflow manually. (I don't see why you would but it doesn't hust either)
 
 jobs:

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -4,6 +4,10 @@ name: Reusable Build
 on:
   # setup of the reusable job.
   workflow_call:
+      inputs:
+          CACHE_KEY: # needed to reuse files from cache between jobs (node_modules and build)
+              required: true
+              type: string
 
   workflow_dispatch: # for running workflow manually. (I don't see why you would but it doesn't hust either)
 
@@ -28,6 +32,18 @@ jobs:
 
             - name: Build
               run: "yarn build"
+
+            - name: Echo CACHE_KEY
+              run: echo 'CACHE_KEY' && echo ${{ inputs.CACHE_KEY }}
+
+            - name: Cache build files
+                id: cache-build-files
+                uses: actions/cache@v3
+                with:
+                path: |
+                    ./webapp
+                    ./node_modules
+                key: ${{ inputs.CACHE_KEY }}
 
             - name: Upload build in artifact
               uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -17,6 +17,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v4
+
+            - name: Echo CACHE_KEY
+              run: echo 'CACHE_KEY' && echo ${{ inputs.CACHE_KEY }}
+
             - name: Get Node Version
               id: node_version
               run: echo ::set-output name=node_version::$(node -e 'console.log(require("./package.json").engines.node)')
@@ -29,9 +33,6 @@ jobs:
 
             - name: "Copy the config file at the right place"
               run: "cp config.dev.json config.json" # todo we could make the choice of backend configurable.
-
-            - name: Echo CACHE_KEY
-              run: echo 'CACHE_KEY' && echo ${{ inputs.CACHE_KEY }}
 
             - name: Build
               run: "yarn build"

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -37,7 +37,6 @@ jobs:
               run: echo 'CACHE_KEY' && echo ${{ inputs.CACHE_KEY }}
 
             - name: Cache build files
-                id: cache-build-files
                 uses: actions/cache@v3
                 with:
                 path: |

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -43,10 +43,11 @@ jobs:
                   path: ./webapp
                   key: ${{ inputs.CACHE_KEY }}
 
-            - name: Upload build in artifact
-              uses: actions/upload-artifact@v3
-              with:
-                  name: devbuild # because we used the dev config file
-                  path: webapp
-                  # We'll only use this in a triggered job, then we're done with it
-                  retention-days: 1
+            # We are not using this for now, so remove to make job faster.
+            #- name: Upload build in artifact
+            #  uses: actions/upload-artifact@v3
+            #  with:
+            #      name: devbuild # because we used the dev config file
+            #      path: webapp
+            #      # We'll only use this in a triggered job, then we're done with it
+            #      retention-days: 1

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -30,18 +30,16 @@ jobs:
             - name: "Copy the config file at the right place"
               run: "cp config.dev.json config.json" # todo we could make the choice of backend configurable.
 
-            - name: Build
-              run: "yarn build"
-
             - name: Echo CACHE_KEY
               run: echo 'CACHE_KEY' && echo ${{ inputs.CACHE_KEY }}
+
+            - name: Build
+              run: "yarn build"
 
             - name: Cache build files
               uses: actions/cache@v3
               with:
-                  path: |
-                      ./webapp
-                      ./node_modules
+                  path: ./webapp
                   key: ${{ inputs.CACHE_KEY }}
 
             - name: Upload build in artifact

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -1,0 +1,44 @@
+# Build the application. This job is reusable : it has to be called by another workflow.
+name: Reusable Build
+
+on:
+  # setup of the reusable job.
+  workflow_call:
+    inputs:
+      config-path:
+        required: true
+        type: string
+    secrets:
+      token:
+        required: true
+  workflow_dispatch: # for running workflow manually. (I don't see why you would but it doesn't hust either)
+
+jobs:
+    build:
+        name: "Build"
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - name: Get Node Version
+              id: node_version
+              run: echo ::set-output name=node_version::$(node -e 'console.log(require("./package.json").engines.node)')
+            - uses: actions/setup-node@v3
+              with:
+                  cache: "yarn"
+                  node-version: ${{ steps.node_version.outputs.node_version }}
+            - name: Install Dependencies
+              run: "yarn install"
+
+            - name: "Copy the config file at the right place"
+              run: "cp config.dev.json config.json" # todo we could make the choice of backend configurable.
+
+            - name: Build
+              run: "yarn build"
+
+            - name: Upload build in artifact
+              uses: actions/upload-artifact@v3
+              with:
+                  name: devbuild # because we used the dev config file
+                  path: webapp
+                  # We'll only use this in a triggered job, then we're done with it
+                  retention-days: 1

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -40,7 +40,9 @@ jobs:
             - name: Cache build files
               uses: actions/cache@v3
               with:
-                  path: ./webapp
+                  path: |
+                      ./webapp
+                      ./node_modules
                   key: ${{ inputs.CACHE_KEY }}
 
             # We are not using this for now, so remove to make job faster.

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -37,12 +37,12 @@ jobs:
               run: echo 'CACHE_KEY' && echo ${{ inputs.CACHE_KEY }}
 
             - name: Cache build files
-                uses: actions/cache@v3
-                with:
-                path: |
-                    ./webapp
-                    ./node_modules
-                key: ${{ inputs.CACHE_KEY }}
+              uses: actions/cache@v3
+              with:
+              path: |
+                  ./webapp
+                  ./node_modules
+              key: ${{ inputs.CACHE_KEY }}
 
             - name: Upload build in artifact
               uses: actions/upload-artifact@v3

--- a/.github/workflows/reusable-build.yaml
+++ b/.github/workflows/reusable-build.yaml
@@ -39,10 +39,10 @@ jobs:
             - name: Cache build files
               uses: actions/cache@v3
               with:
-              path: |
-                  ./webapp
-                  ./node_modules
-              key: ${{ inputs.CACHE_KEY }}
+                  path: |
+                      ./webapp
+                      ./node_modules
+                  key: ${{ inputs.CACHE_KEY }}
 
             - name: Upload build in artifact
               uses: actions/upload-artifact@v3

--- a/cypress/e2e/login/login.spec.ts
+++ b/cypress/e2e/login/login.spec.ts
@@ -61,7 +61,9 @@ describe("Login", () => {
             cy.get(".mx_Login_submit").click();
 
             // Enter security key
-            cy.get(".mx_CompleteSecurityBody .mx_AccessibleButton").contains("Vérifier avec un Code de Récupération").click();
+            cy.get(".mx_CompleteSecurityBody .mx_AccessibleButton")
+                .contains("Vérifier avec un Code de Récupération")
+                .click();
             cy.get("#mx_securityKey").type(securityKey);
             cy.get(".mx_AccessSecretStorageDialog .mx_Dialog_primary").click();
 

--- a/cypress/e2e/login/login.spec.ts
+++ b/cypress/e2e/login/login.spec.ts
@@ -41,6 +41,7 @@ describe("Login", () => {
         // Will be replaced by a generated random user when we have a full docker setup
         const username = Cypress.env("E2E_TEST_USER_EMAIL");
         const password = Cypress.env("E2E_TEST_USER_PASSWORD");
+        const securityKey = Cypress.env("E2E_TEST_USER_SECURITY_KEY");
 
         beforeEach(() => {
             // We use a pre-existing user on dev backend. If random user was created each time, we would use :
@@ -57,12 +58,18 @@ describe("Login", () => {
 
             cy.get("#mx_LoginForm_email").type(username);
             cy.get("#mx_LoginForm_password").type(password);
-            cy.startMeasuring("from-submit-to-home");
             cy.get(".mx_Login_submit").click();
 
-            //TODO: does not work if account has cross signing because the screen is /#/login "Vérifier cet appareil"
+            // Enter security key
+            cy.get(".mx_CompleteSecurityBody .mx_AccessibleButton").contains("Vérifier avec un Code de Récupération").click();
+            cy.get("#mx_securityKey").type(securityKey);
+            cy.get(".mx_AccessSecretStorageDialog .mx_Dialog_primary").click();
+
+            // Success page displays. Click to continue.
+            cy.get(".mx_E2EIcon_verified"); // check for presence of success icon
+            cy.get(".mx_CompleteSecurityBody .mx_AccessibleButton_kind_primary").click();
+
             cy.url().should("contain", "/#/home");
-            cy.stopMeasuring("from-submit-to-home");
         });
     });
 });

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
         "concurrently": "^8.0.0",
         "cpx": "^1.5.0",
         "css-loader": "^4",
-        "cypress": "^10.3.0",
+        "cypress": "^13.2.0",
         "cypress-axe": "^1.0.0",
         "cypress-real-events": "^1.7.1",
         "dotenv": "^16.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,10 +1215,10 @@
   resolved "https://registry.yarnpkg.com/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz#798622546b63847e82389e473fd67f2707d82247"
   integrity sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==
 
-"@cypress/request@^2.88.10":
-  version "2.88.12"
-  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-2.88.12.tgz#ba4911431738494a85e93fb04498cb38bc55d590"
-  integrity sha512-tOn+0mDZxASFM+cuAP9szGUGPI1HwWVSvdzm7V4cCsPdFTx6qMj29CwaQmRAMIEhORIUBFBsYROYJcveK4uOjA==
+"@cypress/request@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@cypress/request/-/request-3.0.1.tgz#72d7d5425236a2413bd3d8bb66d02d9dc3168960"
+  integrity sha512-TWivJlJi8ZDx2wGOw1dbLuHJKUYX7bWySw377nlnGOW3hP9/MUKIsEdXT/YngWxVdgNCHRBmFlBipE+5/2ZZlQ==
   dependencies:
     aws-sign2 "~0.7.0"
     aws4 "^1.8.0"
@@ -1233,7 +1233,7 @@
     json-stringify-safe "~5.0.1"
     mime-types "~2.1.19"
     performance-now "^2.1.0"
-    qs "~6.10.3"
+    qs "6.10.4"
     safe-buffer "^5.1.2"
     tough-cookie "^4.1.3"
     tunnel-agent "^0.6.0"
@@ -2699,15 +2699,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.9.tgz#a70ec9d8fa0180a314c3ede0e20ea56ff71aed9a"
   integrity sha512-PcGNd//40kHAS3sTlzKB9C9XL4K0sTup8nbG5lC14kzEteTNuAFh9u5nA0o5TWnSG2r/JNPRXFVcHJIIeRlmqQ==
 
-"@types/node@^14.14.31":
-  version "14.18.58"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.58.tgz#547e64027defb95f34824794574dabf5417bc615"
-  integrity sha512-Y8ETZc8afYf6lQ/mVp096phIVsgD/GmDxtm3YaPcc+71jmi/J6zdwbwaUU4JvS56mq6aSfbpkcKhQ5WugrWFPw==
-
 "@types/node@^16":
   version "16.18.48"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.48.tgz#3bc872236cdb31cb51024d8875d655e25db489a4"
   integrity sha512-mlaecDKQ7rIZrYD7iiKNdzFb6e/qD5I9U1rAhq+Fd+DWvYVs+G2kv74UFHmSOlg5+i/vF3XxuR522V4u8BqO+Q==
+
+"@types/node@^18.17.5":
+  version "18.17.18"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.18.tgz#acae19ad9011a2ab3d792232501c95085ba1838f"
+  integrity sha512-/4QOuy3ZpV7Ya1GTRz5CYSz3DgkKpyUptXuQ5PPce7uuyJAOR7r9FhkmxJfvcNUXyklbC63a+YvB3jxy7s9ngw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -4590,11 +4590,6 @@ commander@^4.1.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-commander@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
-  integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
-
 commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
@@ -5169,14 +5164,14 @@ cypress-real-events@^1.7.1:
   resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.10.1.tgz#289f2cb4a1d452e54a19e1ecd02931016b41b8ff"
   integrity sha512-l4WvEymhup8EAheXVPqEi5gofBTCvhyYL/i3fOcJtL32prfpZ6jhnnXSLJsxOAl/RlmygIEP1ZeRpqrrDPgGIA==
 
-cypress@^10.3.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-10.11.0.tgz#e9fbdd7638bae3d8fb7619fd75a6330d11ebb4e8"
-  integrity sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==
+cypress@^13.2.0:
+  version "13.2.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-13.2.0.tgz#10f73d06a0764764ffbb903a31e96e2118dcfc1d"
+  integrity sha512-AvDQxBydE771GTq0TR4ZUBvv9m9ffXuB/ueEtpDF/6gOcvFR96amgwSJP16Yhqw6VhmwqspT5nAGzoxxB+D89g==
   dependencies:
-    "@cypress/request" "^2.88.10"
+    "@cypress/request" "^3.0.0"
     "@cypress/xvfb" "^1.2.4"
-    "@types/node" "^14.14.31"
+    "@types/node" "^18.17.5"
     "@types/sinonjs__fake-timers" "8.1.1"
     "@types/sizzle" "^2.3.2"
     arch "^2.2.0"
@@ -5188,10 +5183,10 @@ cypress@^10.3.0:
     check-more-types "^2.24.0"
     cli-cursor "^3.1.0"
     cli-table3 "~0.6.1"
-    commander "^5.1.0"
+    commander "^6.2.1"
     common-tags "^1.8.0"
     dayjs "^1.10.4"
-    debug "^4.3.2"
+    debug "^4.3.4"
     enquirer "^2.3.6"
     eventemitter2 "6.4.7"
     execa "4.1.0"
@@ -5206,12 +5201,13 @@ cypress@^10.3.0:
     listr2 "^3.8.3"
     lodash "^4.17.21"
     log-symbols "^4.0.0"
-    minimist "^1.2.6"
+    minimist "^1.2.8"
     ospath "^1.2.2"
     pretty-bytes "^5.6.0"
+    process "^0.11.10"
     proxy-from-env "1.0.0"
     request-progress "^3.0.0"
-    semver "^7.3.2"
+    semver "^7.5.3"
     supports-color "^8.1.1"
     tmp "~0.2.1"
     untildify "^4.0.0"
@@ -9939,7 +9935,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@>=1.2.2, minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@>=1.2.2, minimist@^1.1.0, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -11835,6 +11831,13 @@ qrcode@1.5.3:
     pngjs "^5.0.0"
     yargs "^15.3.1"
 
+qs@6.10.4:
+  version "6.10.4"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.4.tgz#6a3003755add91c0ec9eacdc5f878b034e73f9e7"
+  integrity sha512-OQiU+C+Ds5qiH91qh/mg0w+8nwQuLjM4F4M/PbmhDOoYehPh+Fb0bDjtR1sOvy7YKxvj28Y/M0PhP5uVX0kB+g==
+  dependencies:
+    side-channel "^1.0.4"
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -11846,13 +11849,6 @@ qs@^6.11.0:
   version "6.11.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.2.tgz#64bea51f12c1f5da1bc01496f48ffcff7c69d7d9"
   integrity sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==
-  dependencies:
-    side-channel "^1.0.4"
-
-qs@~6.10.3:
-  version "6.10.5"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.5.tgz#974715920a80ff6a262264acd2c7e6c2a53282b4"
-  integrity sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==
   dependencies:
     side-channel "^1.0.4"
 


### PR DESCRIPTION
Alternative way of running the cypress tests : 
Write a build job in a separate file (reusable job), that is called by the cypress workflow.

I thought that the build and cypress jobs would share env files, but they don't, so we need to use caches to get the results of the build for cypress. And also the files from yarn install. 

Overall it's not clear that the added complication is really solving anything.

(the changes to review are in the .github/workflow dir, the others are from other PRs, ignore them)
