### PR TITLE
Simple cypress build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 #Build the application
-name: Build
+name: Build without E2E tests
 on:
     pull_request: {}
     push:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,7 +3,8 @@ name: Build + E2E Tests
 
 on:
     workflow_dispatch: # for running action manually
-    pull_request: {}
+    pull_request:
+        types: [ready_for_review]
 
 env:
 

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -6,6 +6,9 @@ on:
     pull_request: {}
 
 env:
+    # Removing this makes the job break.
+    REPOSITORY: ${{ github.repository }}
+    PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
     cypress:
@@ -58,4 +61,3 @@ jobs:
                   E2E_TEST_USER_SECURITY_KEY: ${{ secrets.E2E_TEST_USER_SECURITY_KEY }}
                   E2E_TEST_USER_HOMESERVER_URL: "https://matrix.agent1.tchap.incubateur.net"
                   E2E_TEST_USER_HOMESERVER_SHORT: "agent1.tchap.incubateur.net"
-                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # don't remember what this is for, can't hurt

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: macos-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: Get Node Version
               id: node_version

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -6,9 +6,6 @@ on:
     pull_request: {}
 
 env:
-    # Removing this makes the job break.
-    REPOSITORY: ${{ github.repository }}
-    PR_NUMBER: ${{ github.event.pull_request.number }}
 
 jobs:
     cypress:

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
     cypress:
         name: Cypress
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         steps:
             - name: Checkout code
               uses: actions/checkout@v2

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -1,13 +1,9 @@
 # This is a tchap-specific file, inspired from the one in matrix-react-sdk
-name: Cypress End to End Tests
+name: Build + E2E Tests
 
-# Run this job when the "Build" job completes
 on:
-    workflow_run:
-        workflows: ["Build"]
-        types:
-            - completed
     workflow_dispatch: # for running action manually
+    pull_request: {}
 
 env:
     # Removing this makes the job break.
@@ -20,35 +16,35 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout code
-              uses: actions/checkout@v4
+              uses: actions/checkout@v2
 
             - name: Get Node Version
               id: node_version
               run: echo ::set-output name=node_version::$(node -e 'console.log(require("./package.json").engines.node)')
 
-            - name: Yarn cache
+            - name: Setup node with yarn cache
               uses: actions/setup-node@v3
               with:
                   cache: "yarn"
                   node-version: ${{ steps.node_version.outputs.node_version }}
 
-            - name: Download build from artifact
-              # use this action instead of actions/download-artifact because we need the "workflow" param
-              uses: dawidd6/action-download-artifact@v2
-              with:
-                  name: devbuild
-                  path: webapp
-                  run_id: ${{ github.event.workflow_run.id }} # I think this is the run_id of the workflow that triggered this workflow
-
             - name: Install Dependencies
-              run: "yarn install" # this is needed otherwise "cypress: not found". Can we do just yarn install cypress to go faster ?
+              run: "yarn install"
+
+            - name: "Copy the dev config file at the right place"
+              run: "cp config.dev.json config.json"
+              # todo we could make the choice of backend configurable.
+              # But then the test user, password, server, should be changed too, see cypress env vars below.
+
+            - name: Build
+              run: "yarn build"
 
             - name: Run Cypress tests
               uses: cypress-io/github-action@v6.5.0
               with:
                   install: false # disable the default install, we already installed and built.
 
-                  # Serve with 'npx serve', a simple static webserver, so that it starts quickly. The dev server is slow and messy to start.
+                  # Serve with 'npx serve', a simple static webserver, so that it starts quickly. The webpack dev server is slow and messy to start.
                   start: "npx serve -p 8080 -L webapp"
                   # Note : 'wait-on' caused issues where localhost was not found by cypress. Be careful if you want to use it.
 

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -6,8 +6,6 @@ on:
     pull_request:
         types: [ready_for_review]
 
-env:
-
 jobs:
     cypress:
         name: Cypress


### PR DESCRIPTION
Revert cypress workflow to something simple : build + cypress.
Only run the workflow when the pr is ready for review.
Run on macos, because the machine is beefier than the ubuntu one : https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

To see the changes in action work, they needs to be merged into default branch. See this PR : https://github.com/estellecomment/tchap-web-v4/pull/6