### PR TITLE
Build job on draft PRs only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,10 @@ jobs:
     build:
         name: "Build"
         runs-on: ubuntu-latest
+
+        # Only run on draft PRs. On ready_for_review PRs, we already have the Cypress job which runs the build
+        if: github.event.pull_request.draft == true
+
         steps:
             - uses: actions/checkout@v4
             - name: Get Node Version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 #Build the application
 name: Build without E2E tests
 on:
-    pull_request: {}
+    pull_request: {} # only on draft PRs, see "if:" below
     push:
         branches: [master]
     workflow_dispatch: # for running action manually


### PR DESCRIPTION
That way we have build+cypress on ready_for_review PRs, and build on draft PRs.