### PR TITLE
Only run Cypress on non-draft PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,8 @@
 #Build the application
 name: Build without E2E tests
 on:
-    pull_request: {} # only on draft PRs, see "if:" below
+    pull_request:
+        types: [converted_to_draft]
     push:
         branches: [master]
     workflow_dispatch: # for running action manually

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,13 +3,16 @@ name: Build + E2E Tests
 
 on:
     workflow_dispatch: # for running action manually
-    pull_request:
-        types: [ready_for_review]
+    pull_request: {}
 
 jobs:
     cypress:
         name: Cypress
         runs-on: macos-latest
+
+        # Only run on non-draft PRs. On draft PRs, we already have the Build job
+        if: github.event.pull_request.draft == false
+
         steps:
             - name: Checkout code
               uses: actions/checkout@v4

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,7 +3,8 @@ name: Build + E2E Tests
 
 on:
     workflow_dispatch: # for running action manually
-    pull_request: {}
+    pull_request:
+        types: [ready_for_review]
 
 jobs:
     cypress:


### PR DESCRIPTION
The previous version of the file ran the cypress job when the PR changed state from draft to "ready to review". So it didn't run when the PR was created directly "ready for review".

This version should run when the state is "ready for review", regardless of how the PR got to that state !