### PR TITLE
Welcome page : better text layout

### DIFF
--- a/res/welcome.html
+++ b/res/welcome.html
@@ -124,6 +124,11 @@
         margin: 8px 0 0;
     }
 
+    .tc_paragraph {
+        margin-bottom: 40px;
+        margin-top: 40px;
+    }
+
     .mx_ButtonSignIn {
         background-color: #000091;
         color: white !important;
@@ -197,8 +202,9 @@ we don't have an account and should hide them. No account == no guest account ei
     </a>
     <h1 class="mx_Header_title">_t("Welcome to Tchap")<br/><span class="mx_Header_title_no_bold">_t("la messagerie instantanée de l'Administration")</span></h1>
     <!-- XXX: Our translations system isn't smart enough to recognize variables in the HTML, so we manually do it -->
-    <h2>_t("Conçue et gérée par l'Administration française")
-    </h2>
+    <div class="tc_paragraph">
+        _t("Conçue et gérée par l'Administration française")
+    </div>
     <div class="mx_ButtonGroup">
         <div class="mx_ButtonRow mx_Center_content">
             <a href="https://tchap.beta.gouv.fr?mtm_campaign=TchapWebConnectLogo" class="mx_ButtonParent mx_SecondaryButton "><div>_t("En savoir plus")</div>


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/685
This page is not viewed very often so I went with "good enough" :)

Before : 
<img width="1146" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/230438b6-bd9b-4360-935a-bca46c6aac1c">

After : 

<img width="723" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/7cde11d1-08f5-45ac-a5e7-135c9e4218ab">
