### PR TITLE
Add mobile builds

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -85,6 +85,11 @@
     "desktopBuilds": {
         "available": false
     },
+    "mobile_builds": {
+        "ios": "https://apps.apple.com/us/app/tchap/id1446253779",
+        "android": "https://play.google.com/store/apps/details?id=fr.gouv.tchap.a",
+        "fdroid": null
+    },
     "permalink_prefix": "https://www.tchap.incubateur.net",
     "custom_translations_url_comments": "To add translations, edit /src/i18n/strings/tchap_translations.json. It gets copied over to webapp/i18n for serving.",
     "custom_translations_url": "/i18n/tchap_translations.json",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -79,6 +79,11 @@
     "desktop_builds": {
         "available": false
     },
+    "mobile_builds": {
+        "ios": "https://apps.apple.com/us/app/tchap/id1446253779",
+        "android": "https://play.google.com/store/apps/details?id=fr.gouv.tchap.a",
+        "fdroid": null
+    },
     "permalink_prefix": "https://www.beta.tchap.gouv.fr",
     "custom_translations_url_comments": "To add translations, edit /src/i18n/strings/tchap_translations.json. It gets copied over to webapp/i18n for serving.",
     "custom_translations_url": "/i18n/tchap_translations.json",

--- a/config.prod.json
+++ b/config.prod.json
@@ -187,6 +187,11 @@
     "desktop_builds": {
         "available": false
     },
+    "mobile_builds": {
+        "ios": "https://apps.apple.com/us/app/tchap/id1446253779",
+        "android": "https://play.google.com/store/apps/details?id=fr.gouv.tchap.a",
+        "fdroid": null
+    },
     "permalink_prefix": "https://tchap.gouv.fr",
     "custom_translations_url_comments": "To add translations, edit /src/i18n/strings/tchap_translations.json. It gets copied over to webapp/i18n for serving.",
     "custom_translations_url": "/i18n/tchap_translations.json",

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -187,6 +187,11 @@
     "desktop_builds": {
         "available": false
     },
+    "mobile_builds": {
+        "ios": "https://apps.apple.com/us/app/tchap/id1446253779",
+        "android": "https://play.google.com/store/apps/details?id=fr.gouv.tchap.a",
+        "fdroid": null
+    },
     "permalink_prefix": "https://tchap.gouv.fr",
     "custom_translations_url_comments": "To add translations, edit /src/i18n/strings/tchap_translations.json. It gets copied over to webapp/i18n for serving.",
     "custom_translations_url": "/i18n/tchap_translations.json",

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -208,5 +208,12 @@
             "src/IConfigOptions.ts",
             "src/components/views/settings/Notifications.tsx"
         ]
+    },
+    "remove-fdroid": {
+        "comments" : "remove when issue is fixed in element-web : https://github.com/vector-im/element-web/issues/26309",
+        "package": "matrix-react-sdk",
+        "files": [
+            "src/components/views/dialogs/AppDownloadDialog.tsx"
+        ]
     }
 }

--- a/patches/remove-fdroid/matrix-react-sdk+3.79.0.patch
+++ b/patches/remove-fdroid/matrix-react-sdk+3.79.0.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/AppDownloadDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/AppDownloadDialog.tsx
+index 586a10c..eed46b5 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/dialogs/AppDownloadDialog.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/AppDownloadDialog.tsx
+@@ -107,6 +107,8 @@ export const AppDownloadDialog: FC<Props> = ({ onFinished }) => {
+                         >
+                             <GooglePlayBadge />
+                         </AccessibleButton>
++                        { /** :TCHAP: remove fdroid button.
++                         * Issue filed to element-web : https://github.com/vector-im/element-web/issues/26309
+                         <AccessibleButton
+                             element="a"
+                             href={urlFDroid}
+@@ -116,6 +118,7 @@ export const AppDownloadDialog: FC<Props> = ({ onFinished }) => {
+                         >
+                             <FDroidBadge />
+                         </AccessibleButton>
++                        */}
+                     </div>
+                 </div>
+             </div>


### PR DESCRIPTION
Fixes one task in https://github.com/tchapgouv/tchap-web-v4/issues/744

When you create an account, on first login you get a series of tasks in the main panel, to help you get started. 
One of them is "Download mobile apps".

 - configure `mobile_builds` so that tchap's apps are linked instead of element's
 - hide fdroid download button using a patch (tchap has no fdroid build) until element fixes the issue : https://github.com/vector-im/element-web/issues/26309
 

Before : 


<img width="705" alt="Screen Shot 2023-10-05 at 11 14 36 AM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/f21f9fb6-8394-489a-8ba5-a0d925f5260b">



After : 


<img width="700" alt="Screen Shot 2023-10-05 at 11 16 15 AM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/bdf31835-b48d-4d7c-ad47-bf8a53c53d02">

