### PR TITLE
Use WorkMessaging UI profile for welcome pages

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -68,7 +68,8 @@
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
-        "custom_themes": []
+        "custom_themes": [],
+        "FTUE.useCaseSelection": "WorkMessaging"
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -62,7 +62,8 @@
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
-        "custom_themes": []
+        "custom_themes": [],
+        "FTUE.useCaseSelection": "WorkMessaging"
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",

--- a/config.prod.json
+++ b/config.prod.json
@@ -170,7 +170,8 @@
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
-        "custom_themes": []
+        "custom_themes": [],
+        "FTUE.useCaseSelection": "WorkMessaging"
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -170,7 +170,8 @@
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
         "layout": "bubble",
-        "custom_themes": []
+        "custom_themes": [],
+        "FTUE.useCaseSelection": "WorkMessaging"
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/744
(two last tasks)

Original welcome page had a useless page for chosing which type of use tchap users need. We set it as WorkMessaging by default in the config, so that this page is not shown any more.

This also changes the second welcome page slightly to use work-related vocabulary.
"Faites votre job" is maybe a bit informal, but overall it's good !


Before : 

![image](https://github.com/tchapgouv/tchap-web-v4/assets/911434/a64485a3-87d3-497f-980f-003abf4817b3)



After : 

<img width="1114" alt="Screen Shot 2023-10-05 at 11 36 09 AM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/5cfcd65f-18bc-475d-be04-3ad4cd35a6fa">


