### PR TITLE
Move tchap unit-tests into single folder, and run jest on that folder only

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -35,7 +35,7 @@ const config: Config = {
     testEnvironmentOptions: {
         url: "http://localhost/",
     },
-    testMatch: ["<rootDir>/test/unit-tests/**/*-test.[tj]s?(x)"],
+    testMatch: ["<rootDir>/test/unit-tests/tchap/**/*-test.[tj]s?(x)"], // :TCHAP: only tchap tests
     setupFiles: ["jest-canvas-mock"],
     setupFilesAfterEnv: ["<rootDir>/test/setupTests.ts", "<rootDir>/node_modules/matrix-react-sdk/test/setupTests.ts"],
     moduleNameMapper: {

--- a/test/unit-tests/tchap/components/views/dialogs/TchapCreateRoomDialog-test.tsx
+++ b/test/unit-tests/tchap/components/views/dialogs/TchapCreateRoomDialog-test.tsx
@@ -6,9 +6,9 @@ import { act } from "react-dom/test-utils";
 import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
 import { EventEmitter } from "events";
 
-import { TchapRoomType } from "../../../../../src/tchap/@types/tchap";
-import TchapUtils from "../../../../../src/tchap/util/TchapUtils";
-import TchapCreateRoomDialog from "../../../../../src/tchap/components/views/dialogs/TchapCreateRoomDialog";
+import { TchapRoomType } from "../../../../../../src/tchap/@types/tchap";
+import TchapUtils from "../../../../../../src/tchap/util/TchapUtils";
+import TchapCreateRoomDialog from "../../../../../../src/tchap/components/views/dialogs/TchapCreateRoomDialog";
 
 //mocking module with jest.mock should be done outside the test. Before any import of the mocked module.
 //I could not make a mock of TchapCreateRoomDialog, the real implementation was taken each time. Then I used jest spyOn

--- a/test/unit-tests/tchap/components/views/settings/TchapJoinRuleSettings-test.tsx
+++ b/test/unit-tests/tchap/components/views/settings/TchapJoinRuleSettings-test.tsx
@@ -9,8 +9,8 @@ import {
 } from "matrix-react-sdk/test/test-utils/test-utils";
 import { JoinRule, MatrixClient, Room } from "matrix-js-sdk/src/matrix";
 
-import TchapJoinRuleSettings from "../../../../../src/tchap/components/views/settings/TchapJoinRuleSettings";
-import { TchapRoomAccessRule, TchapRoomAccessRulesEventId } from "../../../../../src/tchap/@types/tchap";
+import TchapJoinRuleSettings from "../../../../../../src/tchap/components/views/settings/TchapJoinRuleSettings";
+import { TchapRoomAccessRule, TchapRoomAccessRulesEventId } from "../../../../../../src/tchap/@types/tchap";
 
 function mkStubRoomWithInviteRule(roomId: string, name: string, client: MatrixClient, joinRule: JoinRule): Room {
     const stubRoom: Room = mkStubRoom(roomId, name, client);

--- a/test/unit-tests/tchap/lib/createTchapRoom-test.ts
+++ b/test/unit-tests/tchap/lib/createTchapRoom-test.ts
@@ -1,5 +1,5 @@
-import { TchapRoomType } from "../../../src/tchap/@types/tchap";
-import TchapCreateRoom from "../../../src/tchap/lib/createTchapRoom";
+import { TchapRoomType } from "../../../../src/tchap/@types/tchap";
+import TchapCreateRoom from "../../../../src/tchap/lib/createTchapRoom";
 
 // todo(estellecomment) : these tests are redundant with TchapCreateRoomDialog-test. Either remove them or modify TchapCreateRoomDialog
 // to not edit state directly.

--- a/test/unit-tests/tchap/util/TchapRoomUtils-test.ts
+++ b/test/unit-tests/tchap/util/TchapRoomUtils-test.ts
@@ -1,5 +1,5 @@
-import { TchapRoomAccessRule, TchapRoomType } from "../../../src/tchap/@types/tchap";
-import TchapRoomUtils from "../../../src/tchap/util/TchapRoomUtils";
+import { TchapRoomAccessRule, TchapRoomType } from "../../../../src/tchap/@types/tchap";
+import TchapRoomUtils from "../../../../src/tchap/util/TchapRoomUtils";
 
 describe("Provides utils method to get room type and state", () => {
     beforeEach(() => {});


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/737

I just left element's tests, so that we don't waste any time with conflicts on them during upgrades.