### PR TITLE
Migrate translations to module remove the yarn add to fix scalingo

### DIFF
--- a/build_config.yaml
+++ b/build_config.yaml
@@ -1,4 +1,5 @@
 # copied from build_config.sample.yaml
+# Make sure that the modules added here are ALSO ADDED IN OPTIONALDEPENDENCIES in package.json.
 modules:
     # An example of pulling a module from NPM
     #- "@vector-im/element-web-ilag-module@^0.0.4"
@@ -6,5 +7,5 @@ modules:
     # An example of pulling a module from github
     #- "github:vector-im/element-web-ilag-module#main"
 
-    # Pulling from filesystem
+    # Pulling from filesystem.
     - "file:./modules/tchap-translations"

--- a/module_system/installer.ts
+++ b/module_system/installer.ts
@@ -57,16 +57,15 @@ export function installer(config: BuildConfig): void {
     const currentOptDeps = getOptionalDepNames(packageDeps.packageJson);
 
     try {
-        // :TCHAP: don't call yarn add if the module is already installed in optionalDependencies.
-        // This is for scalingo : when yarn add runs during the build, it crashes.
-        // https://github.com/tchapgouv/tchap-web-v4/assets/911434/621fda92-311a-429c-8eee-1d9f191625e1
-        const modulesToInstall = config.modules.filter((d) => !currentOptDeps.includes(d));
-        const yarnAddRef = modulesToInstall.join(" ");
         // Install the modules with yarn
-        //const yarnAddRef = config.modules.join(" ");
+        const yarnAddRef = config.modules.join(" ");
+        // :TCHAP: don't run the yarn install, scalingo does not like it.
+        console.log("The following modules are in build_config: ", config.modules);
+        if (false) {
+            callYarnAdd(yarnAddRef); // install them all at once
+        }
+        // todo check that the modules in build_config are already present in optionalDependencies, to avoid breaks.
         // end :TCHAP:
-
-        callYarnAdd(yarnAddRef); // install them all at once
 
         // Grab the optional dependencies again and exclude what was there already. Everything
         // else must be a module, we assume.

--- a/module_system/installer.ts
+++ b/module_system/installer.ts
@@ -61,6 +61,7 @@ export function installer(config: BuildConfig): void {
         const yarnAddRef = config.modules.join(" ");
         // :TCHAP: don't run the yarn install, scalingo does not like it.
         console.log("The following modules are in build_config: ", config.modules);
+        // eslint-disable-next-line no-constant-condition
         if (false) {
             callYarnAdd(yarnAddRef); // install them all at once
         }

--- a/module_system/installer.ts
+++ b/module_system/installer.ts
@@ -60,12 +60,34 @@ export function installer(config: BuildConfig): void {
         // Install the modules with yarn
         const yarnAddRef = config.modules.join(" ");
         // :TCHAP: don't run the yarn install, scalingo does not like it.
-        console.log("The following modules are in build_config: ", config.modules);
         // eslint-disable-next-line no-constant-condition
         if (false) {
             callYarnAdd(yarnAddRef); // install them all at once
         }
-        // todo check that the modules in build_config are already present in optionalDependencies, to avoid breaks.
+        console.log("The following modules are in build_config: ", config.modules);
+        // To make sure the build will work without the yarn add, check that the modules in build_config are present in optionalDependencies.
+        const currentOptDepsValues = Object.values(JSON.parse(packageDeps.packageJson)?.["optionalDependencies"] ?? {});
+        const isAllGood = config.modules.every((configLine) => {
+            // Check only the "file:" modules, it's too complicated to check all yarn allowed formats.
+            // Our modules should be "file:"
+            if (configLine.includes("file:")) {
+                if (!currentOptDepsValues.includes(configLine)) {
+                    console.error(
+                        "build_config.yml contains",
+                        configLine,
+                        "but it is not present in optionalDependencies in package.json.",
+                        "\nYou should run : yarn add -O",
+                        configLine,
+                    );
+                    return false;
+                }
+            }
+            return true;
+        });
+        if (!isAllGood) {
+            exitCode = 1;
+            return;
+        }
         // end :TCHAP:
 
         // Grab the optional dependencies again and exclude what was there already. Everything

--- a/module_system/installer.ts
+++ b/module_system/installer.ts
@@ -57,8 +57,15 @@ export function installer(config: BuildConfig): void {
     const currentOptDeps = getOptionalDepNames(packageDeps.packageJson);
 
     try {
+        // :TCHAP: don't call yarn add if the module is already installed in optionalDependencies.
+        // This is for scalingo : when yarn add runs during the build, it crashes.
+        // https://github.com/tchapgouv/tchap-web-v4/assets/911434/621fda92-311a-429c-8eee-1d9f191625e1
+        const modulesToInstall = config.modules.filter((d) => !currentOptDeps.includes(d));
+        const yarnAddRef = modulesToInstall.join(" ");
         // Install the modules with yarn
-        const yarnAddRef = config.modules.join(" ");
+        //const yarnAddRef = config.modules.join(" ");
+        // end :TCHAP:
+
         callYarnAdd(yarnAddRef); // install them all at once
 
         // Grab the optional dependencies again and exclude what was there already. Everything

--- a/package.json
+++ b/package.json
@@ -200,9 +200,9 @@
         "postcss-simple-vars": "^5.0.2",
         "prettier": "2.8.8",
         "proxy-agent": "^6.3.0",
+        "raw-loader": "^4.0.2",
         "rimraf": "^5.0.0",
         "semver": "^7.5.2",
-        "raw-loader": "^4.0.2",
         "string-replace-loader": "3",
         "style-loader": "2",
         "stylelint": "^15.10.1",
@@ -231,5 +231,8 @@
     "engines-comment": {
         "2022-11-07": "matrix-js-sdk requires >=16.0.0. SSL librairies do not work with 18 and 19. 17 has incompatibilities with some deps.",
         "2023-08-29": "matrix-js-sdk requires >=18.0.0"
+    },
+    "optionalDependencies": {
+        "tchap-translations": "file:./modules/tchap-translations"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1701,6 +1701,13 @@
   version "3.2.14"
   resolved "https://gitlab.matrix.org/api/v4/projects/27/packages/npm/@matrix-org/olm/-/@matrix-org/olm-3.2.14.tgz#acd96c00a881d0f462e1f97a56c73742c8dbc984"
 
+"@matrix-org/react-sdk-module-api@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-1.0.0.tgz#de73e163a439fe330f6971a6a0cef2ccb090d616"
+  integrity sha512-drhPkoPWitAv9bXS2q8cyaqPta/KGF+Ph3aZSmaYiOPyY5S84e4Ju3JI6/HExqF8+HyBsajlCKtyvTZsMsTIFA==
+  dependencies:
+    "@babel/runtime" "^7.17.9"
+
 "@matrix-org/react-sdk-module-api@^2.0.0", "@matrix-org/react-sdk-module-api@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-2.1.0.tgz#ca9d67853512fda1df2786810b90be31dd8dc7b1"
@@ -13771,6 +13778,11 @@ tar@^6.0.2:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+"tchap-translations@file:./modules/tchap-translations":
+  version "0.0.0"
+  dependencies:
+    "@matrix-org/react-sdk-module-api" "^1.0.0"
 
 terser-webpack-plugin@^1.4.3:
   version "1.4.5"


### PR DESCRIPTION
```
Error: Command failed: yarn add -O file:./modules/tchap-translations
    at checkExecSyncError (node:child_process:890:11)
    at Object.execSync (node:child_process:962:15)
    at callYarnAdd (/build/975b16bf-c724-4d9b-9a86-9bfa30e6894f/lib/module_system/installer.js:137:18)
```

Removed the yarn add which broke scalingo build, and yarn add our modules by hand instead.