### PR TITLE
Run build.yml and cypress.yml on all PR commits

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,7 @@
 #Build the application
 name: Build without E2E tests
 on:
-    pull_request:
-        types: [converted_to_draft]
+    pull_request: {}
     push:
         branches: [master]
     workflow_dispatch: # for running action manually

--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -3,8 +3,7 @@ name: Build + E2E Tests
 
 on:
     workflow_dispatch: # for running action manually
-    pull_request:
-        types: [ready_for_review]
+    pull_request: {}
 
 jobs:
     cypress:


### PR DESCRIPTION
This looks like the less shitty option. 
Run the two jobs for all commits, and then add "if: github.event.pull_request.draft == false/true" to filter which of the two should run. 
When you change the status of the PR from draft to non-draft (or non-draft to draft), just close and reopen the PR to have the other job run.
Hopefully this is the last PR I do on this.

The previous trigger  "pull_request: types: [ready_for_review]" didn't work because it ran ONLY when the status changed to ready for review.
