### PR TITLE
Fix e2e test with matrixId

### DIFF
--- a/cypress/e2e/export-room-members/export-room-members.spec.ts
+++ b/cypress/e2e/export-room-members/export-room-members.spec.ts
@@ -10,8 +10,6 @@ describe("Export room members feature", () => {
     const email = Cypress.env("E2E_TEST_USER_EMAIL");
     const password = Cypress.env("E2E_TEST_USER_PASSWORD");
     const today = new Date().toISOString().slice(0, 10).replace(/-/g, "");
-    // This will fail if email has special characters.
-    const userId = "@" + email.replace("@", "-") + ":" + homeserverShort;
 
     beforeEach(() => {
         cy.loginUser(homeserverUrl, email, password);
@@ -33,12 +31,27 @@ describe("Export room members feature", () => {
     it("downloads the file when button is clicked", () => {
         const roomName = "test/" + today + "/export_room_members/" + RandomUtils.generateRandom(4);
         const normalizedRoomName = normalize(roomName);
+
+        const normalizedEmail = email.replace("@", "-"); // This will fail if email has additional special characters.
+        const userIdRegexString =
+            "^" +
+            "@" +
+            normalizedEmail.replaceAll(".", "\\.") + // escape dots
+            "[0-9]{0,3}" + // if the account has been deleted and recreated, there is an additional number here.
+            ":" +
+            homeserverShort +
+            "$";
+        const userIdRegex = new RegExp(userIdRegexString);
+
         RoomUtils.createPublicRoom(roomName).then((roomId) => {
             RoomUtils.openPeopleMenu(roomName);
             cy.get('[data-testid="tc_exportRoomMembersButton"]')
                 .click()
                 .then(() => {
-                    cy.readFile("cypress/downloads/membres_de_" + normalizedRoomName + ".txt").should("eq", userId);
+                    cy.readFile("cypress/downloads/membres_de_" + normalizedRoomName + ".txt").should(
+                        "match",
+                        userIdRegex,
+                    );
                 });
             cy.leaveRoom(roomId);
         });


### PR DESCRIPTION
Takes into account that for accounts that have been deleted and recreated, the matrixId has a number right after the email.
