### PR TITLE
Reuse element's terms_and_conditions_links instead of custom code

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -92,6 +92,16 @@
         "fdroid": null
     },
     "permalink_prefix": "https://www.tchap.incubateur.net",
+    "terms_and_conditions_links": [
+        {
+            "url": "https://www.tchap.beta.gouv.fr/cgu",
+            "text": "Read the CGU"
+        },
+        {
+            "url": "https://tchap.beta.gouv.fr/politique-de-confidentialite",
+            "text": "Read the Privacy Policy"
+        }
+    ],
     "tchap_features": {
         "feature_email_notification": [
             "agent1.tchap.incubateur.net",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -86,6 +86,16 @@
         "fdroid": null
     },
     "permalink_prefix": "https://www.beta.tchap.gouv.fr",
+    "terms_and_conditions_links": [
+        {
+            "url": "https://www.tchap.beta.gouv.fr/cgu",
+            "text": "Read the CGU"
+        },
+        {
+            "url": "https://tchap.beta.gouv.fr/politique-de-confidentialite",
+            "text": "Read the Privacy Policy"
+        }
+    ],
     "tchap_features": {
         "feature_email_notification": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
         "feature_thread": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],

--- a/config.prod.json
+++ b/config.prod.json
@@ -194,6 +194,16 @@
         "fdroid": null
     },
     "permalink_prefix": "https://tchap.gouv.fr",
+    "terms_and_conditions_links": [
+        {
+            "url": "https://www.tchap.beta.gouv.fr/cgu",
+            "text": "Read the CGU"
+        },
+        {
+            "url": "https://tchap.beta.gouv.fr/politique-de-confidentialite",
+            "text": "Read the Privacy Policy"
+        }
+    ],
     "tchap_features": {
         "feature_email_notification": ["agent.dinum.tchap.gouv.fr"],
         "feature_thread": ["agent.dinum.tchap.gouv.fr"],

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -194,6 +194,16 @@
         "fdroid": null
     },
     "permalink_prefix": "https://tchap.gouv.fr",
+    "terms_and_conditions_links": [
+        {
+            "url": "https://www.tchap.beta.gouv.fr/cgu",
+            "text": "Read the CGU"
+        },
+        {
+            "url": "https://tchap.beta.gouv.fr/politique-de-confidentialite",
+            "text": "Read the Privacy Policy"
+        }
+    ],
     "tchap_features": {
         "feature_email_notification": ["agent.dinum.tchap.gouv.fr"],
         "feature_thread": ["agent.dinum.tchap.gouv.fr"],

--- a/src/tchap/components/views/settings/tabs/user/TchapHelpUserSettingsTab.tsx
+++ b/src/tchap/components/views/settings/tabs/user/TchapHelpUserSettingsTab.tsx
@@ -28,6 +28,7 @@ import PlatformPeg from "matrix-react-sdk/src/PlatformPeg";
 import UpdateCheckButton from "matrix-react-sdk/src/components/views/settings/UpdateCheckButton";
 import BugReportDialog from "matrix-react-sdk/src/components/views/dialogs/BugReportDialog";
 import CopyableText from "matrix-react-sdk/src/components/views/elements/CopyableText";
+import ExternalLink from "matrix-react-sdk/src/components/views/elements/ExternalLink";
 
 interface IProps {
     closeSettingsFn: () => void;
@@ -113,16 +114,16 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
         for (const tocEntry of tocLinks) {
             legalLinks.push(
                 <div key={tocEntry.url}>
-                    <a href={tocEntry.url} rel="noreferrer noopener" target="_blank">
-                        {tocEntry.text}
-                    </a>
-                </div>,
+                    <ExternalLink href={tocEntry.url} target="_blank" rel="noreferrer noopener">
+                        {_t(tocEntry.text)}
+                    </ExternalLink>
+                </div>
             );
         }
 
         return (
             <div className="mx_SettingsTab_section">
-                <span className="mx_SettingsTab_subheading">{_t("Legal")}</span>
+                <span className="mx_SettingsTab_subheading">{_t("common|legal")}</span>
                 <div className="mx_SettingsTab_subsectionText">{legalLinks}</div>
             </div>
         );
@@ -354,54 +355,6 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
             </div>
         );
 
-        const cguUrl = "https://www.tchap.beta.gouv.fr/cgu";
-        const cguSection = (
-            <div className='mx_SettingsTab_section'>
-                <span className='mx_SettingsTab_subheading'>{ _t("General Conditions of Use (CGU)") }</span>
-                {/* <div className='mx_SettingsTab_subsectionText'>
-                    {
-                        _t(
-                            "We have compiled a list of the questions our users ask the most frequently. Your question may be answered there."
-                        )
-                    }
-                </div> */}
-                <AccessibleButton
-                    kind="primary"
-                    element="a"
-                    href={ cguUrl }
-                    target="_blank"
-                    rel="noreferrer noopener"
-                >
-                    { _t("Read the CGU") }
-                    <i className='mx_ExternalLink_icon' />
-                </AccessibleButton>
-            </div>
-        );
-
-        const privacyPolicyUrl = "https://tchap.beta.gouv.fr/politique-de-confidentialite";
-        const privacyPolicySection = (
-            <div className='mx_SettingsTab_section'>
-                <span className='mx_SettingsTab_subheading'>{ _t("Privacy Policy") /** TCHAP string */ }</span>
-                {/* <div className='mx_SettingsTab_subsectionText'>
-                    {
-                        _t(
-                            "We have compiled a list of the questions our users ask the most frequently. Your question may be answered there."
-                        )
-                    }
-                </div> */}
-                <AccessibleButton
-                    kind="primary"
-                    element="a"
-                    href={ privacyPolicyUrl }
-                    target="_blank"
-                    rel="noreferrer noopener"
-                >
-                    { _t("Read the Privacy Policy") }
-                    <i className='mx_ExternalLink_icon' />
-                </AccessibleButton>
-            </div>
-        );
-
         const knownIssuesUrl = "https://github.com/tchapgouv/tchap-web-v4/wiki/Nouveau-Tchap-Web";
         const knownIssuesSection = (
             <div className='mx_SettingsTab_section'>
@@ -432,8 +385,6 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
                 <div className="mx_SettingsTab_heading">{_t("setting|help_about|title")}</div>
                 { /* :TCHAP: added */ contactSection }
                 { /* :TCHAP: added */ faqSection }
-                { /* :TCHAP: added */ cguSection }
-                { /* :TCHAP: added */ privacyPolicySection }
                 { /* :TCHAP: moved down the page - bugReportingSection */}
                 { /* :TCHAP: replaced by custom faqSection
                 <div className="mx_SettingsTab_section">


### PR DESCRIPTION
It changes the layout a bit. I don't think many people read this anyway.

Before : big blue buttons for CGU and Politique de Confidentialité :

<img width="1053" alt="Screen Shot 2023-11-02 at 12 00 37 PM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/02102caf-256e-469a-a2b0-cfe91c29ebe8">


After : more discrete section, towards the bottom.

<img width="957" alt="Screen Shot 2023-11-02 at 12 00 18 PM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/6d6e3827-fbed-48cc-9296-66727de3f316">
