### PR TITLE
e2e : Use cy.leaveRoomSilently for rooms with externs (temporarily)

### DIFF
--- a/cypress/e2e/content-scanner.spec.ts
+++ b/cypress/e2e/content-scanner.spec.ts
@@ -16,7 +16,7 @@ describe("Content Scanner", () => {
 
         const roomName = "test/" + today + "/content_scanner_" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPrivateWithExternalRoom(roomName).then(() => {
+        RoomUtils.createPrivateRoom(roomName).then(() => {
             //open room
             cy.get('[aria-label="' + roomName + '"]').click();
         });

--- a/cypress/e2e/create-room/create-room.spec.ts
+++ b/cypress/e2e/create-room/create-room.spec.ts
@@ -46,7 +46,7 @@ describe("Create Room", () => {
             console.log("roomIdToCleanup", urlString.split("/#/room/")[1]);
             const roomId = urlString.split("/#/room/")[1];
             if (roomId) {
-                cy.leaveRoom(roomId);
+                cy.leaveRoomWithSilentFail(roomId);
                 // todo also forgetRoom to save resources.
             } else {
                 console.error("Did not find roomId in url. Not cleaning up.");

--- a/cypress/e2e/room-access-settings/room-access-settings.spec.ts
+++ b/cypress/e2e/room-access-settings/room-access-settings.spec.ts
@@ -92,7 +92,7 @@ describe("Check room access settings", () => {
                 cy.get(".mx_AccessibleButton").should("have.attr", "aria-disabled", "true");
             });
 
-            cy.leaveRoom(roomId);
+            cy.leaveRoomWithSilentFail(roomId);
         });
     });
 
@@ -116,7 +116,7 @@ describe("Check room access settings", () => {
             //assert room header is updated
             cy.get(".tc_RoomHeader_external").should("exist");
 
-            cy.leaveRoom(roomId);
+            cy.leaveRoomWithSilentFail(roomId);
         });
     });
 });

--- a/cypress/e2e/tchap-external-room-style.spec.ts
+++ b/cypress/e2e/tchap-external-room-style.spec.ts
@@ -25,7 +25,7 @@ describe("Style of external rooms", () => {
                 cy.get(".mx_DecoratedRoomAvatar_icon_external"); // lock icon on room avatar
             });
 
-            cy.leaveRoom(roomId);
+            cy.leaveRoomWithSilentFail(roomId);
         });
     });
 });

--- a/cypress/support/client.ts
+++ b/cypress/support/client.ts
@@ -246,6 +246,7 @@ Cypress.Commands.add("leaveRoom", (roomId: string): Chainable<{}> => {
     return cy.getClient().then((cli) => cli.leave(roomId));
 });
 
+// Needed until this is fixed : https://github.com/tchapgouv/synapse-manage-last-admin/issues/11
 Cypress.Commands.add("leaveRoomWithSilentFail", (roomId: string): Chainable<{}> => {
     return cy.getClient().then((cli) => {
         return cli.leave(roomId).catch((err) => {

--- a/cypress/support/client.ts
+++ b/cypress/support/client.ts
@@ -135,6 +135,12 @@ declare global {
              * @param roomId the id of the room to invite to
              */
             leaveRoom(roomId: string): Chainable<{}>;
+            /**
+             * :TCHAP: added this function
+             * Leave a room. If the leaving fails, log and carry on without crashing the test.
+             * @param roomId the id of the room to invite to
+             */
+            leaveRoomWithSilentFail(roomId: string): Chainable<{}>;
         }
     }
 }
@@ -238,4 +244,13 @@ Cypress.Commands.add("joinRoom", (roomIdOrAlias: string): Chainable<Room> => {
 
 Cypress.Commands.add("leaveRoom", (roomId: string): Chainable<{}> => {
     return cy.getClient().then((cli) => cli.leave(roomId));
+});
+
+Cypress.Commands.add("leaveRoomWithSilentFail", (roomId: string): Chainable<{}> => {
+    return cy.getClient().then((cli) => {
+        return cli.leave(roomId).catch((err) => {
+            cy.log("COULD NOT LEAVE ROOM ! Continuing silently.", err);
+            return {};
+        });
+    });
 });


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/812

Because of bug : https://github.com/tchapgouv/synapse-manage-last-admin/issues/11
We can remove the function when it is solved.

e2e tests run locally. (still broken in github action)
 - [x] in prod
 - [x] in preprod (except content scanner because uploads are broken)