### PR TITLE
Translate/modify session lock text

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -1140,5 +1140,13 @@
         "en": "%(brand)s is open in another window. Click \"%(label)s\" to use %(brand)s here and disconnect the other window.",
         "fr": "%(brand)s est ouvert dans une autre fenêtre. Cliquez \"%(label)s\" pour utiliser %(brand)s ici et déconnecter l'autre fenêtre.",
         "comment": "2023-11-08: remove once the string is translated in element"
+    },
+    "%(brand)s has been connected in another tab": {
+        "en": "%(brand)s has been connected in another tab",
+        "fr": "%(brand)s a été connecté dans un autre onglet"
+    },
+    "You can close this disconnected tab, and go to the other %(brand)s tab.": {
+        "en": "You can close this disconnected tab, and go to the other %(brand)s tab.",
+        "fr": "Vous pouvez fermer cet onglet déconnecté, et aller à l'autre onglet %(brand)s."
     }
 }

--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -1135,5 +1135,10 @@
     "onboarding_free_e2ee_messaging_tchap_limited_voip": {
         "en": "With free end-to-end encrypted messaging, %(brand)s is a great way to stay in touch.",
         "fr": "Grâce à la messagerie chiffrée de bout en bout gratuite, %(brand)s est un excellent moyen de rester en contact."
+    },
+    "%(brand)s is open in another window. Click \"%(label)s\" to use %(brand)s here and disconnect the other window.": {
+        "en": "%(brand)s is open in another window. Click \"%(label)s\" to use %(brand)s here and disconnect the other window.",
+        "fr": "%(brand)s est ouvert dans une autre fenêtre. Cliquez \"%(label)s\" pour utiliser %(brand)s ici et déconnecter l'autre fenêtre.",
+        "comment": "2023-11-08: remove once the string is translated in element"
     }
 }

--- a/patches/better-text-for-tab-switch/matrix-react-sdk+3.81.0.patch
+++ b/patches/better-text-for-tab-switch/matrix-react-sdk+3.81.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/SessionLockStolenView.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/SessionLockStolenView.tsx
+index 0c0bc01..1a5ef24 100644
+--- a/node_modules/matrix-react-sdk/src/components/structures/auth/SessionLockStolenView.tsx
++++ b/node_modules/matrix-react-sdk/src/components/structures/auth/SessionLockStolenView.tsx
+@@ -28,8 +28,13 @@ export function SessionLockStolenView(): JSX.Element {
+ 
+     return (
+         <SplashPage className="mx_SessionLockStolenView">
++            {/** :TCHAP: better messaging
+             <h1>{_t("common|error")}</h1>
+             <h2>{_t("%(brand)s has been opened in another tab.", { brand })}</h2>
++            */}
++            <h1>{_t("%(brand)s has been connected in another tab", { brand })}</h1>
++            <h2>{_t("You can close this disconnected tab, and go to the other %(brand)s tab.", { brand })}</h2>
++            {/** end :TCHAP: */}
+         </SplashPage>
+     );
+ }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -233,5 +233,12 @@
         "files": [
             "src/components/views/user-onboarding/UserOnboardingHeader.tsx"
         ]
+    },
+    "better-text-for-tab-switch": {
+        "comments": "Remove when solved in element-web : https://github.com/vector-im/element-web/issues/26537",
+        "package": "matrix-react-sdk",
+        "files": [
+            "src/components/structures/auth/SessionLockStolenView.tsx"
+        ]
     }
 }


### PR DESCRIPTION
Fix https://github.com/tchapgouv/tchap-web-v4/issues/817
Adding string in tchap_translations, until element's strings catch up.
Also modify some text that is too scary (filed at : https://github.com/vector-im/element-web/issues/26537)


Before : 
![image](https://github.com/tchapgouv/tchap-web-v4/assets/911434/24dc9ec6-2183-4b02-aadf-f30b207e41ba)

<img width="633" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/bdb36c75-870c-4859-b7ef-7551cd22cfa2">

---
After : 
<img width="499" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/918717b9-d7ee-438b-b25d-d5e8bb85cfc5">

<img width="879" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/d8ce9aaa-f4de-4fd0-86c3-888dfeb84dae">

