### PR TITLE
Add "Enable Secure Backup" in onboarding steps

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -1148,5 +1148,17 @@
     "You can close this disconnected tab, and go to the other %(brand)s tab.": {
         "en": "You can close this disconnected tab, and go to the other %(brand)s tab.",
         "fr": "Vous pouvez fermer cet onglet déconnecté, et aller à l'autre onglet %(brand)s."
+    },
+    "Sauvegardez vos messages automatiquement": {
+        "en": "Back up your messages automatically",
+        "fr": "Sauvegardez vos messages automatiquement"
+    },
+    "Activer la sauvegarde automatique": {
+        "en": "Setup Secure Backup",
+        "fr": "Activer la sauvegarde automatique"
+    },
+    "Vous pourrez les récupérez sur n'importe quel appareil à l'aide du Code de Récupération.": {
+        "en": "You will be able to retrieve them on any device using the Recovery Code.",
+        "fr": "Vous pourrez les récupérez sur n'importe quel appareil à l'aide du Code de Récupération."
     }
 }

--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -1149,9 +1149,9 @@
         "en": "You can close this disconnected tab, and go to the other %(brand)s tab.",
         "fr": "Vous pouvez fermer cet onglet déconnecté, et aller à l'autre onglet %(brand)s."
     },
-    "Sauvegardez vos messages automatiquement": {
+    "Sauvegarder vos messages automatiquement": {
         "en": "Back up your messages automatically",
-        "fr": "Sauvegardez vos messages automatiquement"
+        "fr": "Sauvegarder vos messages automatiquement"
     },
     "Activer la sauvegarde automatique": {
         "en": "Setup Secure Backup",

--- a/patches/add-enable-secure-backup-in-onboarding-steps/matrix-react-sdk+3.81.0.patch
+++ b/patches/add-enable-secure-backup-in-onboarding-steps/matrix-react-sdk+3.81.0.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts b/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts
+index 43e819c..82ec3e5 100644
+--- a/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts
++++ b/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts
+@@ -29,6 +29,7 @@ import SdkConfig from "../SdkConfig";
+ import { UseCase } from "../settings/enums/UseCase";
+ import { useSettingValue } from "./useSettings";
+ import { UserOnboardingContext } from "./useUserOnboardingContext";
++import { accessSecretStorage } from "../SecurityManager";
+ 
+ interface UserOnboardingTask {
+     id: string;
+@@ -93,6 +94,20 @@ const tasks: UserOnboardingTask[] = [
+             onClick: onClickStartDm,
+         },
+     },
++    { // :TCHAP:
++        id: "setup-secure-backup",
++        title: _t("Sauvegardez vos messages automatiquement"),
++        description: _t("Vous pourrez les récupérez sur n'importe quel appareil à l'aide du Code de Récupération."),
++        completed: (ctx: UserOnboardingContext) => {
++
++        }, // todo
++        action: {
++            label: _t("Activer la sauvegarde automatique"),
++            onClick: (ev: ButtonEvent) => {
++                accessSecretStorage();
++            },
++        },
++    }, // end :TCHAP:
+     {
+         id: "download-apps",
+         title: () =>

--- a/patches/add-enable-secure-backup-in-onboarding-steps/matrix-react-sdk+3.81.0.patch
+++ b/patches/add-enable-secure-backup-in-onboarding-steps/matrix-react-sdk+3.81.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts b/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts
-index 43e819c..82ec3e5 100644
+index 43e819c..aa75cef 100644
 --- a/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts
 +++ b/node_modules/matrix-react-sdk/src/hooks/useUserOnboardingTasks.ts
 @@ -29,6 +29,7 @@ import SdkConfig from "../SdkConfig";
@@ -10,13 +10,21 @@ index 43e819c..82ec3e5 100644
  
  interface UserOnboardingTask {
      id: string;
-@@ -93,6 +94,20 @@ const tasks: UserOnboardingTask[] = [
-             onClick: onClickStartDm,
-         },
+@@ -54,12 +55,28 @@ const onClickStartDm = (ev: ButtonEvent): void => {
+ };
+ 
+ const tasks: UserOnboardingTask[] = [
++    /** :TCHAP: delete the first task, we have too many
+     {
+         id: "create-account",
+         title: _t("Create account"),
+         description: _t("onboarding|you_made_it"),
+         completed: () => true,
      },
++    */
 +    { // :TCHAP:
 +        id: "setup-secure-backup",
-+        title: _t("Sauvegardez vos messages automatiquement"),
++        title: _t("Sauvegarder vos messages automatiquement"),
 +        description: _t("Vous pourrez les récupérez sur n'importe quel appareil à l'aide du Code de Récupération."),
 +        completed: (ctx: UserOnboardingContext) => {
 +
@@ -29,5 +37,5 @@ index 43e819c..82ec3e5 100644
 +        },
 +    }, // end :TCHAP:
      {
-         id: "download-apps",
-         title: () =>
+         id: "find-friends",
+         title: _t("onboarding|find_friends"),

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -240,5 +240,13 @@
         "files": [
             "src/components/structures/auth/SessionLockStolenView.tsx"
         ]
+    },
+    "add-enable-secure-backup-in-onboarding-steps": {
+        "comments": "Filed in element-web : https://github.com/vector-im/element-web/issues/26540",
+        "package": "matrix-react-sdk",
+        "files": [
+            "src/hooks/useUserOnboardingTasks.ts",
+            "src/hooks/useUserOnboardingContext.ts"
+        ]
     }
 }


### PR DESCRIPTION
Fix https://github.com/tchapgouv/tchap-web-v4/issues/795

- [x] add button and task
- [x] review text with design and product
- [ ] Notifications task : useful or not ? Check with bizdev
- [ ] open the dialog when button is clicked
- [ ] set task as complete when backup is enabled
- [ ] test ! unit, e2e, both ?
