### PR TITLE
WIP : translation keys I think are not used in app

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -3,14 +3,6 @@
         "en": "Welcome to Tchap",
         "fr": "Bienvenue sur Tchap"
     },
-    "Examples:": {
-        "en": "Examples:",
-        "fr": "Exemples :"
-    },
-    "Choose a homeserver:": {
-        "en": "Choose a homeserver:",
-        "fr": "Choisissez un serveur d'accueil :"
-    },
     "Private room": {
         "en": "Private room",
         "fr": "Salon"
@@ -200,10 +192,6 @@
         "en": "This file will be protected by a password, which will be asked next time you log in, when you will import the keys to unlock your messages.",
         "fr": "Ce fichier sera protégé par un mot de passe, qui vous sera demandé à votre prochaine connexion, lorsque vous importerez les clés pour déverrouiller vos messages."
     },
-    "<b>Warning:</b> these keys cannot be used to unlock the messages received after backup": {
-        "en": "<b>Warning:</b> these keys cannot be used to unlock the messages received after backup",
-        "fr": "<b>Attention:</b> ces clés ne pourront pas être utilisées pour déverrouiller les messages reçus après la sauvegarde"
-    },
     "Create your Tchap Key password (minimum 8 characters)": {
         "en": "Create your Tchap Key password (minimum 8 characters)",
         "fr": "Créez votre mot de passe Clé Tchap (minimum 8 caractères)"
@@ -228,26 +216,6 @@
         "en": "Your Tchap Keys (encryption keys) have been successful saved in the <b>tchap-keys.txt</b> file. You can import them when you login again to unlock your messages (<a>find out more</a>).",
         "fr": "Vos Clés Tchap (clés de chiffrement) ont été sauvegardées avec succès dans le fichier <b>tchap-keys.txt</b>. Vous pourrez les importer à votre prochaine connexion pour déverrouiller vos messages (<a>en savoir plus</a>)."
     },
-    "Save your Tchap Keys before logging out": {
-        "en": "Save your Tchap Keys before logging out",
-        "fr": "Sauvegardez vos Clés Tchap avant de vous déconnecter"
-    },
-    "<b>Without your Tchap Keys, you won't be able to read your messages</b> at your next login because they will be locked. It's a Tchap safety measure.": {
-        "en": "<b>Without your Tchap Keys, you won't be able to read your messages</b> at your next login because they will be locked. It's a Tchap safety measure.",
-        "fr": "<b>Sans vos Clés Tchap, vous ne pourrez pas lire vos messages</b> à votre prochaine connexion parce qu'ils seront verrouillés. C'est une mesure de sécurité Tchap."
-    },
-    "<b>Can you currently read your messages on another device?</b> You can disconnect. This other device automatically backs up your Tchat Keys and messages.": {
-        "en": "<b>Can you currently read your messages on another device?</b> You can disconnect. This other device automatically backs up your Tchat Keys and messages.",
-        "fr": "<b>Vous pouvez actuellement lire vos messages sur un autre appareil ?</b> Vous pouvez vous déconnecter. Cet autre appareil sauvegarde automatiquement vos Clés Tchap et tous vos messages."
-    },
-    "<b>You don't have another device connected to Tchap?</b> Back up your Tchap Keys. These keys will unlock current messages, but not those received after saving.": {
-        "en": "<b>You don't have another device connected to Tchap?</b> Back up your Tchap Keys. These keys will unlock current messages, but not those received after saving.",
-        "fr": "<b>Vous n'avez pas d'autre appareil connecté à Tchap ?</b> Sauvegardez vos Clés Tchap. Ces clés déverrouilleront les messages actuels, mais pas ceux reçus entre la sauvegarde et votre prochaine connexion."
-    },
-    "Sign me out": {
-        "en": "Sign me out",
-        "fr": "Me déconnecter"
-    },
     "Save my keys": {
         "en": "Save my Tchap keys",
         "fr": "Sauvegarder mes clés Tchap"
@@ -255,10 +223,6 @@
     "One of your devices <b>wants to check your Tchap Keys</b> to unlock your messages.": {
         "en": "One of your devices <b>wants to check your Tchap Keys</b> to unlock your messages.",
         "fr": "L'un de vos appareils <b>demande à partager vos Clés Tchap</b> pour déverrouiller vos messages."
-    },
-    "Please also confirm the emojis on the other device.": {
-        "en": "Please also confirm the emojis on the other device.",
-        "fr": "Confirmez si les objets sont les mêmes sur vos 2 appareils."
     },
     "Incoming Verification Request": {
         "en": "Incoming Verification Request",
@@ -271,10 +235,6 @@
     "Finish": {
         "en": "Finish",
         "fr": "Terminer"
-    },
-    "Please <b>accept the sharing</b> of your Tchap Keys on the other device.": {
-        "en": "Please <b>accept the sharing</b> of your Tchap Keys on the other device.",
-        "fr": "Merci d'<b>accepter la demande</b> de partage de vos Clés Tchap pour déverrouiller vos messages."
     },
     "Confirm the emoji below are displayed on both devices, in the same order:": {
         "en": "Confirm the emoji below are displayed on both devices, in the same order:",
@@ -335,30 +295,6 @@
     "Decryption fail: Please open Tchap on an other connected device to allow key sharing.": {
         "en": "Decryption fail: Please open Tchap on an other connected device to allow key sharing.",
         "fr": "Message verrouillé par sécurité. Récupérez vos clés Tchap pour déverrouiller vos messages."
-    },
-    "<requestLink>Re-send a request to your other devices</requestLink>": {
-        "en": "<requestLink>Re-send a request to your other devices</requestLink>",
-        "fr": "<requestLink>Renvoyer une demande à un autre appareil</requestLink>"
-    },
-    "Request in progress...": {
-        "en": "Request in progress...",
-        "fr": "Demande en cours..."
-    },
-    "Tchap Key share requests are sent to your other devices automatically. If you rejected or dismissed the key share request on your other devices, click here to request the Tchap Keys again.": {
-        "en": "Tchap Key share requests are sent to your other devices automatically. If you rejected or dismissed the key share request on your other devices, click here to request the Tchap Keys again.",
-        "fr": "Les demandes de partage de vos Clés Tchap sont automatiquement envoyées à vos autres appareils. Si vous rejetez ou supprimez la demande de partage de clé sur vos autres appareils, cliquez ici pour redemander vos Clés Tchap."
-    },
-    "If your other devices do not have the key for this message, you will not be able to decrypt them.": {
-        "en": "If your other devices do not have the key for this message, you will not be able to decrypt them.",
-        "fr": "Si vos autres appareils n'ont pas la clé pour ce message, vous ne pourrez pas le déchiffrer."
-    },
-    "Your key share request has been sent - please check your other devices for key share requests.": {
-        "en": "Your key share request has been sent - please check your other devices for key share requests.",
-        "fr": "Votre demande de partage de clé a été envoyée - vérifiez les demandes de partage de clé sur vos autres appareils."
-    },
-    "<requestLink>Import from saved file</requestLink>": {
-        "en": "<requestLink>Import from saved file</requestLink>",
-        "fr": "<requestLink>Importer depuis le fichier sauvegardé</requestLink>"
     },
     "Lock my messages and disconnect me from all my devices (in case your account is hacked or a device loss)": {
         "en": "Lock my messages and disconnect me from all my devices (in case your account is hacked or a device loss)",


### PR DESCRIPTION
I could be wrong for the longer ones, since I'm just doing text searches in code.
We should figure out why they are unused, it could be lost code. 

Conversely, it could be dangerous to delete strings that we are using, by mistake... 

Ideally using a script to do this would be best...
(I had started in https://github.com/tchapgouv/tchap-web-v4/pull/309)