### PR TITLE
E2E : move tchap functions out of element files

### DIFF
--- a/cypress/e2e/content-scanner.spec.ts
+++ b/cypress/e2e/content-scanner.spec.ts
@@ -23,22 +23,7 @@ describe("Content Scanner", () => {
     });
 
     afterEach(() => {
-        // We find the roomId to clean up from the current URL.
-        // Note : This is simple and works, so good enough for now. But if we want to store the roomId at the end of the test instead, we could use “as”
-        // for passing the value around : https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Sharing-Context
-        // Do NOT use a describe-level variable (like "let roomIdToCleanup") like we do in unit tests, cypress does not work like that.
-        cy.url().then((urlString) => {
-            console.log("roomId url string", urlString);
-            console.log("roomId url string split", urlString.split("/#/room/"));
-            console.log("roomIdToCleanup", urlString.split("/#/room/")[1]);
-            const roomId = urlString.split("/#/room/")[1];
-            if (roomId) {
-                cy.leaveRoom(roomId);
-                // todo also forgetRoom to save resources.
-            } else {
-                console.error("Did not find roomId in url. Not cleaning up.");
-            }
-        });
+        cy.leaveCurrentRoom();
     });
 
     const uploadFile = (file: string) => {

--- a/cypress/e2e/content-scanner.spec.ts
+++ b/cypress/e2e/content-scanner.spec.ts
@@ -1,7 +1,6 @@
 /// <reference types="cypress" />
 /// <reference types="@testing-library/cypress" />
 
-import RoomUtils from "../utils/room-utils";
 import RandomUtils from "../utils/random-utils";
 
 describe("Content Scanner", () => {
@@ -16,7 +15,7 @@ describe("Content Scanner", () => {
 
         const roomName = "test/" + today + "/content_scanner_" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPrivateRoom(roomName).then(() => {
+        cy.createPrivateRoom(roomName).then(() => {
             //open room
             cy.get('[aria-label="' + roomName + '"]').click();
         });

--- a/cypress/e2e/create-room.spec.ts
+++ b/cypress/e2e/create-room.spec.ts
@@ -36,22 +36,7 @@ describe("Create Room", () => {
     });
 
     afterEach(() => {
-        // We find the roomId to clean up from the current URL.
-        // Note : This is simple and works, so good enough for now. But if we want to store the roomId at the end of the test instead, we could use “as”
-        // for passing the value around : https://docs.cypress.io/guides/core-concepts/variables-and-aliases#Sharing-Context
-        // Do NOT use a describe-level variable (like "let roomIdToCleanup") like we do in unit tests, cypress does not work like that.
-        cy.url().then((urlString) => {
-            console.log("roomId url string", urlString);
-            console.log("roomId url string split", urlString.split("/#/room/"));
-            console.log("roomIdToCleanup", urlString.split("/#/room/")[1]);
-            const roomId = urlString.split("/#/room/")[1];
-            if (roomId) {
-                cy.leaveRoomWithSilentFail(roomId);
-                // todo also forgetRoom to save resources.
-            } else {
-                console.error("Did not find roomId in url. Not cleaning up.");
-            }
-        });
+        cy.leaveCurrentRoomWithSilentFail();
     });
 
     it("should allow us to create a private room with name", () => {

--- a/cypress/e2e/export-room-members.spec.ts
+++ b/cypress/e2e/export-room-members.spec.ts
@@ -19,7 +19,7 @@ describe("Export room members feature", () => {
 
     it("should display the tooltip on button hover", () => {
         const roomName = "test/" + today + "/export_room_members/" + RandomUtils.generateRandom(4);
-        RoomUtils.createPublicRoom(roomName).then((roomId) => {
+        cy.createPublicRoom(roomName).then((roomId) => {
             RoomUtils.openPeopleMenu(roomName);
             cy.get('[data-testid="tc_exportRoomMembersButton"]')
                 .trigger("mouseover")
@@ -43,7 +43,7 @@ describe("Export room members feature", () => {
             "$";
         const userIdRegex = new RegExp(userIdRegexString);
 
-        RoomUtils.createPublicRoom(roomName).then((roomId) => {
+        cy.createPublicRoom(roomName).then((roomId) => {
             RoomUtils.openPeopleMenu(roomName);
             cy.get('[data-testid="tc_exportRoomMembersButton"]')
                 .click()

--- a/cypress/e2e/location.spec.ts
+++ b/cypress/e2e/location.spec.ts
@@ -1,6 +1,5 @@
 /// <reference types="cypress" />
 
-import RoomUtils from "../utils/room-utils";
 import RandomUtils from "../utils/random-utils";
 
 describe("Location", () => {
@@ -16,7 +15,7 @@ describe("Location", () => {
     it("does not show Location button in message composer", () => {
         // Create a room
         const roomName = "test/" + today + "/no_location_button/" + RandomUtils.generateRandom(4);
-        RoomUtils.createPublicRoom(roomName).then((roomId) => {
+        cy.createPublicRoom(roomName).then((roomId) => {
             //open room
             cy.get('[aria-label="' + roomName + '"]').click();
             // Open menu in message composer

--- a/cypress/e2e/room-access-settings.spec.ts
+++ b/cypress/e2e/room-access-settings.spec.ts
@@ -20,7 +20,7 @@ describe("Check room access settings", () => {
     it("creates a public room and check access settings", () => {
         const roomName = "test/" + today + "/public_room_check_access_settings" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPublicRoom(roomName).then((roomId) => {
+        cy.createPublicRoom(roomName).then((roomId) => {
             RoomUtils.openRoomAccessSettings(roomName);
 
             //assert
@@ -45,7 +45,7 @@ describe("Check room access settings", () => {
     it("creates a private room and check access settings", () => {
         const roomName = "test/" + today + "/private_room_check_access_settings" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPrivateRoom(roomName).then((roomId) => {
+        cy.createPrivateRoom(roomName).then((roomId) => {
             RoomUtils.openRoomAccessSettings(roomName);
 
             //assert
@@ -72,7 +72,7 @@ describe("Check room access settings", () => {
     it("creates a private room with external and check access settings", () => {
         const roomName = "test/" + today + "/external_room_check_access_settings" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPrivateWithExternalRoom(roomName).then((roomId) => {
+        cy.createPrivateWithExternalRoom(roomName).then((roomId) => {
             RoomUtils.openRoomAccessSettings(roomName);
 
             //assert
@@ -100,7 +100,7 @@ describe("Check room access settings", () => {
         const roomName =
             "test/" + today + "/private_room_change_external_access_settings" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPrivateRoom(roomName).then((roomId) => {
+        cy.createPrivateRoom(roomName).then((roomId) => {
             RoomUtils.openRoomAccessSettings(roomName);
 
             // click on 'Allow the externals to join' this room

--- a/cypress/e2e/tchap-external-room-style.spec.ts
+++ b/cypress/e2e/tchap-external-room-style.spec.ts
@@ -16,7 +16,7 @@ describe("Style of external rooms", () => {
     it("displays special header in external private room", () => {
         const roomName = "test/" + today + "/external_room_header_" + RandomUtils.generateRandom(4);
 
-        RoomUtils.createPrivateWithExternalRoom(roomName).then((roomId) => {
+        cy.createPrivateWithExternalRoom(roomName).then((roomId) => {
             //open room
             cy.get('[aria-label="' + roomName + '"]').click();
 

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -20,3 +20,4 @@ import "cypress-real-events";
 
 import "./loginByEmail";
 import "./client";
+import "./rooms";

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -1,17 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright DINUM 2023
 */
 
 /// <reference types="cypress" />

--- a/cypress/support/loginByEmail.ts
+++ b/cypress/support/loginByEmail.ts
@@ -1,17 +1,5 @@
 /*
-Copyright 2022 The Matrix.org Foundation C.I.C.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Copyright DINUM 2023
 */
 
 /// <reference types="cypress" />

--- a/cypress/support/rooms.ts
+++ b/cypress/support/rooms.ts
@@ -49,3 +49,6 @@ Cypress.Commands.add("leaveCurrentRoomWithSilentFail", (): Chainable<{}> => {
         }
     });
 });
+
+// Needed to make this file a module
+export {};

--- a/cypress/support/rooms.ts
+++ b/cypress/support/rooms.ts
@@ -5,7 +5,9 @@
 /// <reference types="cypress" />
 /// <reference types="@testing-library/cypress" />
 
+import TchapCreateRoom from "../../src/tchap/lib/createTchapRoom";
 import Chainable = Cypress.Chainable;
+import { TchapRoomType } from "../../src/tchap/@types/tchap";
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -20,6 +22,12 @@ declare global {
              * Leave the room that we are currently in. If the leaving fails, log and carry on without crashing the test.
              */
             leaveCurrentRoomWithSilentFail(): Chainable<{}>;
+
+            createPublicRoom(roomName: string): Chainable<string>;
+
+            createPrivateRoom(roomName: string): Chainable<string>;
+
+            createPrivateWithExternalRoom(roomName: string): Chainable<string>;
         }
     }
 }
@@ -48,6 +56,18 @@ Cypress.Commands.add("leaveCurrentRoomWithSilentFail", (): Chainable<{}> => {
             return {};
         }
     });
+});
+
+Cypress.Commands.add("createPublicRoom", (roomName: string): Chainable<string> => {
+    return cy.createRoom(TchapCreateRoom.roomCreateOptions(roomName, TchapRoomType.Forum, false).createOpts);
+});
+
+Cypress.Commands.add("createPrivateRoom", (roomName: string): Chainable<string> => {
+    return cy.createRoom(TchapCreateRoom.roomCreateOptions(roomName, TchapRoomType.Private, false).createOpts);
+});
+
+Cypress.Commands.add("createPrivateWithExternalRoom", (roomName: string): Chainable<string> => {
+    return cy.createRoom(TchapCreateRoom.roomCreateOptions(roomName, TchapRoomType.External, false).createOpts);
 });
 
 // Needed to make this file a module

--- a/cypress/support/rooms.ts
+++ b/cypress/support/rooms.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright DINUM 2023
+ */
+
+/// <reference types="cypress" />
+/// <reference types="@testing-library/cypress" />
+
+import Chainable = Cypress.Chainable;
+
+declare global {
+    // eslint-disable-next-line @typescript-eslint/no-namespace
+    namespace Cypress {
+        interface Chainable {
+            /**
+             * Leave the room that we are currently in.
+             */
+            leaveCurrentRoom(): Chainable<{}>;
+
+            /**
+             * Leave the room that we are currently in. If the leaving fails, log and carry on without crashing the test.
+             */
+            leaveCurrentRoomWithSilentFail(): Chainable<{}>;
+        }
+    }
+}
+
+Cypress.Commands.add("leaveCurrentRoom", (): Chainable<{}> => {
+    // We find the roomId to clean up from the current URL.
+    return cy.url().then((urlString) => {
+        const roomId = urlString.split("/#/room/")[1];
+        if (roomId) {
+            return cy.leaveRoom(roomId);
+        } else {
+            console.error("Did not find roomId in url. Not cleaning up.");
+            return {};
+        }
+    });
+});
+
+Cypress.Commands.add("leaveCurrentRoomWithSilentFail", (): Chainable<{}> => {
+    // We find the roomId to clean up from the current URL.
+    return cy.url().then((urlString) => {
+        const roomId = urlString.split("/#/room/")[1];
+        if (roomId) {
+            return cy.leaveRoomWithSilentFail(roomId);
+        } else {
+            console.error("Did not find roomId in url. Not cleaning up.");
+            return {};
+        }
+    });
+});

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -3,7 +3,7 @@
         "target": "es2016",
         "jsx": "react",
         "lib": ["es2020", "dom", "dom.iterable"],
-        "types": ["cypress", "cypress-axe", "@percy/cypress"],
+        "types": ["cypress", "cypress-axe", "@percy/cypress", "@testing-library/cypress"],
         "resolveJsonModule": true,
         "esModuleInterop": true,
         "moduleResolution": "node",

--- a/cypress/utils/room-utils.ts
+++ b/cypress/utils/room-utils.ts
@@ -3,15 +3,6 @@ import TchapCreateRoom from "../../src/tchap/lib/createTchapRoom";
 import { TchapRoomType } from "../../src/tchap/@types/tchap";
 
 export default class RoomUtils {
-    public static createPublicRoom(roomName: string): Chainable<string> {
-        return cy.createRoom(TchapCreateRoom.roomCreateOptions(roomName, TchapRoomType.Forum, false).createOpts);
-    }
-    public static createPrivateRoom(roomName: string): Chainable<string> {
-        return cy.createRoom(TchapCreateRoom.roomCreateOptions(roomName, TchapRoomType.Private, false).createOpts);
-    }
-    public static createPrivateWithExternalRoom(roomName: string): Chainable<string> {
-        return cy.createRoom(TchapCreateRoom.roomCreateOptions(roomName, TchapRoomType.External, false).createOpts);
-    }
     public static openRoom(roomName: string): Chainable<JQuery<HTMLElement>> {
         return cy.get('[aria-label="' + roomName + '"]').click();
     }

--- a/cypress/utils/room-utils.ts
+++ b/cypress/utils/room-utils.ts
@@ -1,7 +1,8 @@
-import Chainable = Cypress.Chainable;
-import TchapCreateRoom from "../../src/tchap/lib/createTchapRoom";
-import { TchapRoomType } from "../../src/tchap/@types/tchap";
+/**
+ * Copyright DINUM 2023
+ */
 
+import Chainable = Cypress.Chainable;
 export default class RoomUtils {
     public static openRoom(roomName: string): Chainable<JQuery<HTMLElement>> {
         return cy.get('[aria-label="' + roomName + '"]').click();


### PR DESCRIPTION
Tests still pass locally.

Created support/rooms.ts, and started moving tchap funcs into it.

Moving tchap funcs out of support/client.ts, which is copied from element and out of date. Then we can simply import the element version of client.ts and remove the copy (in future PR)

Moving tchap funcs out of room-utils.ts which isn't a cypress file. Cypress files have more boilerplate, but I'd rather have proper cypress funcs than home-made TS utils. It's more cleanly organized, but also it makes clear what functions contain cypress magic. (cypress calls are queued and executed later, which is not the standard js code execution)