### PR TITLE
Test : user_notice

### DIFF
--- a/config.preprod.json
+++ b/config.preprod.json
@@ -76,6 +76,11 @@
         ],
         "welcome_background_url": "themes/tchap/img/backgrounds/tchap-bg.svg"
     },
+    "user_notice": {
+        "title": "PREPROD",
+        "description": "You are on preprod env",
+        "show_once": false
+    },
     "desktop_builds": {
         "available": false
     },

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -76,11 +76,6 @@
         ],
         "welcome_background_url": "themes/tchap/img/backgrounds/tchap-bg.svg"
     },
-    "user_notice": {
-        "title": "PREPROD",
-        "description": "You are on preprod env",
-        "show_once": false
-    },
     "desktop_builds": {
         "available": false
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "element-web",
     "productName": "Tchap",
-    "version": "4.3.11",
+    "version": "4.3.11-interruptionnotice",
     "version-element-web": "1.11.44",
     "description": "A feature-rich client for Matrix.org",
     "author": "DINUM",

--- a/src/vector/platform/WebPlatform.ts
+++ b/src/vector/platform/WebPlatform.ts
@@ -28,7 +28,7 @@ import VectorBasePlatform from "./VectorBasePlatform";
 import { parseQs } from "../url_utils";
 import { _t } from "../../languageHandler";
 
-const POKE_RATE_MS = 10 * 60 * 1000; // 10 min
+const POKE_RATE_MS = 60 * 1000; // 1 min
 
 function getNormalizedAppVersion(version: string): string {
     // if version looks like semver with leading v, strip it (matches scripts/normalize-version.sh)


### PR DESCRIPTION
test to see when the user_notice shows.
It's triggered in matrixchat onShowPostLoginScreen.

Add the user_notice in config
 - does user_notice show up when app deploys ? no.
 - wait for updater : does updater react to change of config without change of version ? no.
 - check for new version (in settings) : is new version found ? no
 - what else could make the page reload ? ...
 
Reload page
 - does user_notice show ? yes
 
Remove user_notice (and reduce version check time). Deploy. -> done.
Bump version to 4.3.11-interruptionnotice and add user_notice. Deploy.
-  does updater detect this as a new version ? yes
 - does user_notice show ? yes after reload caused by clicking update
 
 
What is the simplest way to bump version for our current deployment system on real servers ? 
Does our deployment system accept fancy version names like 4.3.11-interruptionnotice ? Can the tag name be different from the version in package.json, and does that help ?
-> answer : only use normal version numbers to reduce risk. Delete 4.3.11 and deploy the user_notice in 4.3.12. Then make 4.3.13 which is really 4.3.11 relabeled.
 
 
 What happens if versions are released out of order ? 
 If we release 4.3.12 (tagged 4.3.10) and then 4.3.11 ? 
According to code, it should be fine. As long as the version number changes, tchap-web displays a toast for an upgrade. So we can downgrade without problem, I think (didn't test it, too long)