### PR TITLE
Bump version to 4.3.12 and add user_notice

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -1,26 +1,26 @@
 {
     "default_server_config": {
         "m.homeserver": {
-            "base_url": "https://matrix.agent1.tchap.incubateur.net",
+            "base_url": "https://matrix.dev01.tchap.incubateur.net",
             "server_name": "Agents 1"
         },
         "m.identity_server": {
-            "base_url": "https://matrix.agent1.tchap.incubateur.net"
+            "base_url": "https://matrix.dev01.tchap.incubateur.net"
         }
     },
     "homeserver_list": [
         {
-            "base_url": "https://matrix.agent1.tchap.incubateur.net",
+            "base_url": "https://matrix.dev01.tchap.incubateur.net",
             "server_name": "Agents 1",
             "email_examples": "? ..."
         },
         {
-            "base_url": "https://matrix.agent2.tchap.incubateur.net",
+            "base_url": "https://matrix.dev02.tchap.incubateur.net",
             "server_name": "Agents 2",
             "email_examples": "? ..."
         },
         {
-            "base_url": "https://matrix.externe.tchap.incubateur.net",
+            "base_url": "https://matrix.ext01.tchap.incubateur.net",
             "server_name": "Externes",
             "email_examples": "? ..."
         }
@@ -45,12 +45,12 @@
     "default_federate": true,
     "default_theme": "light",
     "room_directory": {
-        "servers": ["agent1.tchap.incubateur.net", "agent2.tchap.incubateur.net", "externe.tchap.incubateur.net"]
+        "servers": ["dev01.tchap.incubateur.net", "dev02.tchap.incubateur.net", "ext01.tchap.incubateur.net"]
     },
     "enable_presence_by_hs_url": {
-        "https://matrix.agent1.tchap.incubateur.net": false,
-        "https://matrix.agent2.tchap.incubateur.net": false,
-        "https://matrix.externe.tchap.incubateur.net": false
+        "https://matrix.dev01.tchap.incubateur.net": false,
+        "https://matrix.dev02.tchap.incubateur.net": false,
+        "https://matrix.ext01.tchap.incubateur.net": false
     },
     "setting_defaults": {
         "breadcrumbs": true,
@@ -96,11 +96,15 @@
     "custom_translations_url": "/i18n/tchap_translations.json",
     "tchap_features": {
         "feature_email_notification": [
-            "agent1.tchap.incubateur.net",
-            "agent2.tchap.incubateur.net",
-            "externe.tchap.incubateur.net"
+            "dev01.tchap.incubateur.net",
+            "dev02.tchap.incubateur.net",
+            "ext01.tchap.incubateur.net"
         ],
-        "feature_space": ["agent1.tchap.incubateur.net", "agent2.tchap.incubateur.net", "externe.tchap.incubateur.net"],
-        "feature_thread": ["agent1.tchap.incubateur.net", "agent2.tchap.incubateur.net", "externe.tchap.incubateur.net"]
+        "feature_space": ["dev01.tchap.incubateur.net", "dev02.tchap.incubateur.net", "ext01.tchap.incubateur.net"],
+        "feature_thread": ["dev01.tchap.incubateur.net", "dev02.tchap.incubateur.net", "ext01.tchap.incubateur.net"]
+    },
+    "user_notice": {
+        "title": "Tchap sera indisponible le 30 nov de 7h30 à 10h30 CET",
+        "description": "Plus d'infos : https://aide.tchap.beta.gouv.fr"
     }
 }

--- a/config.dev.json
+++ b/config.dev.json
@@ -104,7 +104,7 @@
         "feature_thread": ["dev01.tchap.incubateur.net", "dev02.tchap.incubateur.net", "ext01.tchap.incubateur.net"]
     },
     "user_notice": {
-        "title": "Tchap sera indisponible le 30 nov de 7h30 à 10h30 CET",
-        "description": "Plus d'infos : https://aide.tchap.beta.gouv.fr"
+        "title": "Tchap sera indisponible le 30 nov, de 7h30 à 10h30 CET (maximum)",
+        "description": "Pour plus d'infos : https://status.tchap.numerique.gouv.fr"
     }
 }

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -92,5 +92,9 @@
         "feature_email_notification": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
         "feature_thread": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
         "feature_space": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"]
+    },
+    "user_notice": {
+        "title": "Tchap sera indisponible le 30 nov de 7h30 à 10h30 CET",
+        "description": "Plus d'infos : https://aide.tchap.beta.gouv.fr"
     }
 }

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -94,7 +94,7 @@
         "feature_space": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"]
     },
     "user_notice": {
-        "title": "Tchap sera indisponible le 30 nov de 7h30 à 10h30 CET",
-        "description": "Plus d'infos : https://aide.tchap.beta.gouv.fr"
+        "title": "Tchap sera indisponible le 30 nov, de 7h30 à 10h30 CET (maximum)",
+        "description": "Pour plus d'infos : https://status.tchap.numerique.gouv.fr"
     }
 }

--- a/config.prod.json
+++ b/config.prod.json
@@ -202,7 +202,7 @@
         "feature_space": []
     },
     "user_notice": {
-        "title": "Tchap sera indisponible le 30 nov de 7h30 à 10h30 CET",
-        "description": "Plus d'infos : https://aide.tchap.beta.gouv.fr"
+        "title": "Tchap sera indisponible le 30 nov, de 7h30 à 10h30 CET (maximum)",
+        "description": "Pour plus d'infos : https://status.tchap.numerique.gouv.fr"
     }
 }

--- a/config.prod.json
+++ b/config.prod.json
@@ -200,5 +200,9 @@
         "feature_email_notification": ["agent.dinum.tchap.gouv.fr"],
         "feature_thread": ["agent.dinum.tchap.gouv.fr"],
         "feature_space": []
+    },
+    "user_notice": {
+        "title": "Tchap sera indisponible le 30 nov de 7h30 à 10h30 CET",
+        "description": "Plus d'infos : https://aide.tchap.beta.gouv.fr"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "element-web",
     "productName": "Tchap",
-    "version": "4.3.10",
+    "version": "4.3.12",
     "version-element-web": "1.11.40",
     "description": "A feature-rich client for Matrix.org",
     "author": "DINUM",


### PR DESCRIPTION
This actually shouldn't be merged into develop_tchap. I'm just opening the PR so that we can keep track of history.
4.3.12 is just 4.3.10 with a user_notice.
