### PR TITLE
Suppression des threads pour les agents DINUM

### DIFF
--- a/config.prod.json
+++ b/config.prod.json
@@ -189,7 +189,7 @@
     ],
     "tchap_features": {
         "feature_email_notification": ["agent.dinum.tchap.gouv.fr"],
-        "feature_thread": ["agent.dinum.tchap.gouv.fr"],
+        "feature_thread": [],
         "feature_space": []
     }
 }


### PR DESCRIPTION
## Problème
Des gens de l'incubateur sont en train de devenir fou avec les problèmes de messages non lu causé par les threads.

## Solution
Suppression de la possibilité de créer des threads jusqu'à ce que ce soit fonctionnel.