### PR TITLE
patch useRoomCall to display call button even without the right permission

### DIFF
--- a/patches/display-call-button-anyway/matrix-react-sdk+3.81.0.patch
+++ b/patches/display-call-button-anyway/matrix-react-sdk+3.81.0.patch
@@ -1,0 +1,19 @@
+diff --git a/node_modules/matrix-react-sdk/src/hooks/room/useRoomCall.ts b/node_modules/matrix-react-sdk/src/hooks/room/useRoomCall.ts
+index c369f5a..78b0781 100644
+--- a/node_modules/matrix-react-sdk/src/hooks/room/useRoomCall.ts
++++ b/node_modules/matrix-react-sdk/src/hooks/room/useRoomCall.ts
+@@ -190,8 +190,12 @@ export const useRoomCall = (
+     let videoCallDisabledReason: string | null;
+     switch (state) {
+         case State.NoPermission:
+-            voiceCallDisabledReason = _t("You do not have permission to start voice calls");
+-            videoCallDisabledReason = _t("You do not have permission to start video calls");
++            //:tchap: disable noPermission
++            //voiceCallDisabledReason = _t("You do not have permission to start voice calls");
++            //ideoCallDisabledReason = _t("You do not have permission to start video calls");
++            voiceCallDisabledReason = null;
++            videoCallDisabledReason = null;
++            //:tchap end
+             break;
+         case State.Ongoing:
+             voiceCallDisabledReason = _t("Ongoing call");

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -256,6 +256,7 @@
             "src/hooks/room/useRoomCall.ts"
         ],
         "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/868",
-        "comments": "display call button regardless of widget and room permission"
+        "comments": "display call button regardless of widget and room permission",
+        "remove_when" : "https://github.com/tchapgouv/tchap-backend/issues/18"
     }
 }

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -249,5 +249,13 @@
         ],
         "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/844",
         "comments": "audio feature flag, external room header, hide some icons"
+    },
+    "display-call-button-anyway": {
+        "package": "matrix-react-sdk",
+        "files": [
+            "src/hooks/room/useRoomCall.ts"
+        ],
+        "github-issue": "https://github.com/tchapgouv/tchap-web-v4/issues/868",
+        "comments": "display call button regardless of widget and room permission"
     }
 }


### PR DESCRIPTION
In a default DM, even if not admin, the call button is displayed
<img width="624" alt="Capture d’écran 2024-01-17 à 17 59 30" src="https://github.com/tchapgouv/tchap-web-v4/assets/4077729/cb21e8df-cbbe-4d9a-b531-e5d999f02f0c">

----

<img width="635" alt="image" src="https://github.com/tchapgouv/tchap-web-v4/assets/4077729/bdf4f7a5-1698-4b8d-9637-4b1df02d1f14">


----

Tested : 
- [x] je suis invité dans une DM par un user A, je ne suis pas adminisrtateur de la DM, le bouton appel est activé, je peux lancer un appel, il est visible par le user A qui peut décrocher., l'appel s'établit, les users peuvent raccrocher.
