### PR TITLE
Fix cypress tests after new RoomHeader

### DIFF
--- a/cypress/e2e/create-room.spec.ts
+++ b/cypress/e2e/create-room.spec.ts
@@ -54,7 +54,7 @@ describe("Create Room", () => {
         // http://localhost:8080/#/room/!kshfkshfkKSHJ:dev01.tchap.incubateur.net
         const roomUrlRegex = new RegExp("/#/room/![A-z0-9]+:" + homeserverShortname);
         cy.url().should("match", roomUrlRegex);
-        cy.get(".mx_LegacyRoomHeader_nametext").contains(name);
+        cy.get(".mx_RoomHeader_heading").contains(name);
         cy.get(".tc_RoomHeader_external").should("not.exist");
     });
 
@@ -76,7 +76,7 @@ describe("Create Room", () => {
         // http://localhost:8080/#/room/!kshfkshfkKSHJ:dev01.tchap.incubateur.net
         const roomUrlRegex = new RegExp("/#/room/![A-z0-9]+:" + homeserverShortname);
         cy.url().should("match", roomUrlRegex);
-        cy.get(".mx_LegacyRoomHeader_nametext").contains(name);
+        cy.get(".mx_RoomHeader_heading").contains(name);
         cy.get(".tc_RoomHeader_external").should("exist");
     });
 
@@ -97,7 +97,7 @@ describe("Create Room", () => {
         // http://localhost:8080/#/room/!kshfkshfkKSHJ:dev01.tchap.incubateur.net
         const roomUrlRegex = new RegExp("/#/room/![A-z0-9]+:" + homeserverShortname);
         cy.url().should("match", roomUrlRegex);
-        cy.get(".mx_LegacyRoomHeader_nametext").contains(name);
+        cy.get(".mx_RoomHeader_heading").contains(name);
     });
 
     // Note : DM creation is not tested here, because Tchap has no custom implementation for DMs. (2023-01-30)

--- a/cypress/e2e/tchap-external-room-style.spec.ts
+++ b/cypress/e2e/tchap-external-room-style.spec.ts
@@ -20,7 +20,7 @@ describe("Style of external rooms", () => {
             //open room
             cy.get('[aria-label="' + roomName + '"]').click();
 
-            cy.get(".mx_LegacyRoomHeader").within(() => {
+            cy.get(".mx_RoomHeader").within(() => {
                 cy.get(".tc_RoomHeader_external"); // "ouvert aux externes"
                 cy.get(".mx_DecoratedRoomAvatar_icon_external"); // lock icon on room avatar
             });

--- a/cypress/utils/room-utils.ts
+++ b/cypress/utils/room-utils.ts
@@ -8,9 +8,8 @@ export default class RoomUtils {
         return cy.get('.mx_RoomList .mx_RoomSublist [aria-label="' + roomName + '"]').click();
     }
     public static openRoomAccessSettings(roomName: string): Chainable<JQuery<HTMLElement>> {
-        cy.get('[aria-label="' + roomName + '"]').click(); //open room
-        cy.get(".mx_LegacyRoomHeader_chevron").click();
-        cy.get('[aria-label="Paramètres"] > .mx_IconizedContextMenu_label').click();
+        this.openRoomInformation(roomName);
+        cy.get(".mx_RoomSummaryCard_Button.mx_RoomSummaryCard_icon_settings").click();
         return cy.get('[data-testid="settings-tab-ROOM_SECURITY_TAB"] > .mx_TabbedView_tabLabel_text').click();
     }
     public static openRoomInformation(roomName: string): Chainable<JQuery<HTMLElement>> {

--- a/cypress/utils/room-utils.ts
+++ b/cypress/utils/room-utils.ts
@@ -15,7 +15,7 @@ export default class RoomUtils {
     }
     public static openRoomInformation(roomName: string): Chainable<JQuery<HTMLElement>> {
         cy.get('[aria-label="' + roomName + '"]').click(); //open room
-        return cy.get('[aria-label="Information du salon"]').click();
+        return cy.get('.mx_RoomHeader_info [title="' + roomName + '"]').click();
     }
     public static openPeopleMenu(roomName: string): Chainable<JQuery<HTMLElement>> {
         this.openRoomInformation(roomName);

--- a/patches/customize-room-header-bar/matrix-react-sdk+3.81.0.patch
+++ b/patches/customize-room-header-bar/matrix-react-sdk+3.81.0.patch
@@ -21,30 +21,33 @@ index 2614e17..79fe37e 100644
 +    display: -webkit-box;
 +}
 diff --git a/node_modules/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx b/node_modules/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
-index bb8dd49..df46713 100644
+index bb8dd49..13ba615 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
-@@ -48,6 +48,9 @@ import RoomAvatar from "../avatars/RoomAvatar";
+@@ -48,6 +48,10 @@ import RoomAvatar from "../avatars/RoomAvatar";
  import { formatCount } from "../../../utils/FormattingUtils";
  import RightPanelStore from "../../../stores/right-panel/RightPanelStore";
  
 +import TchapUIFeature from "../../../../../../src/tchap/util/TchapUIFeature";
 +import TchapExternalRoomHeader from "../../../../../../src/tchap/components/views/rooms/TchapExternalRoomHeader";
++import DecoratedRoomAvatar from "../avatars/DecoratedRoomAvatar"; // :TCHAP:
 +
  /**
   * A helper to transform a notification color to the what the Compound Icon Button
   * expects
-@@ -111,6 +114,9 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -110,7 +114,10 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+                 RightPanelStore.instance.showOrHidePanel(RightPanelPhases.RoomSummary);
              }}
          >
-             <RoomAvatar room={room} size="40px" />
+-            <RoomAvatar room={room} size="40px" />
++            <DecoratedRoomAvatar room={room} size="40px" />
 +            {/* :tchap: Add external caption when room is open to external */}
 +            <TchapExternalRoomHeader room={room}></TchapExternalRoomHeader>
 +            {/* :tchap: end */}
              <Box flex="1" className="mx_RoomHeader_info">
                  <BodyText
                      as="div"
-@@ -124,7 +130,8 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -124,7 +131,8 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                  >
                      {roomName}
  
@@ -54,7 +57,7 @@ index bb8dd49..df46713 100644
                          <Tooltip label={_t("Public room")}>
                              <PublicIcon
                                  width="16px"
-@@ -135,7 +142,8 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -135,7 +143,8 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                          </Tooltip>
                      )}
  
@@ -64,7 +67,7 @@ index bb8dd49..df46713 100644
                          <Tooltip label={_t("common|verified")}>
                              <VerifiedIcon
                                  width="16px"
-@@ -146,7 +154,8 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -146,7 +155,8 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                          </Tooltip>
                      )}
  
@@ -74,7 +77,7 @@ index bb8dd49..df46713 100644
                          <Tooltip label={_t("Untrusted")}>
                              <ErrorIcon
                                  width="16px"
-@@ -164,7 +173,10 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -164,7 +174,10 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                  )}
              </Box>
              <Flex as="nav" align="center" gap="var(--cpd-space-2x)">
@@ -86,7 +89,7 @@ index bb8dd49..df46713 100644
                      <Tooltip label={!voiceCallDisabledReason ? _t("voip|voice_call") : voiceCallDisabledReason!}>
                          <IconButton
                              disabled={!!voiceCallDisabledReason}
-@@ -175,6 +187,10 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -175,6 +188,10 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                          </IconButton>
                      </Tooltip>
                  )}
@@ -97,7 +100,7 @@ index bb8dd49..df46713 100644
                  <Tooltip label={!videoCallDisabledReason ? _t("voip|video_call") : videoCallDisabledReason!}>
                      <IconButton
                          disabled={!!videoCallDisabledReason}
-@@ -183,7 +199,7 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
+@@ -183,7 +200,7 @@ export default function RoomHeader({ room }: { room: Room }): JSX.Element {
                      >
                          <VideoCallIcon />
                      </IconButton>


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/875

We moved from LegacyRoomHeader to RoomHeader, which broke some tests, and found a regression! Fix it.

The regression was that "Ouvert aux externes" had disappeared in the RoomHeader.

Cypress tests run locally on prod backend.