### PR TITLE
Add bug report button after voip calls

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -713,5 +713,9 @@
     "widget|error_need_kick_permission": {
         "en": "You need to be able to kick users to do that.",
         "fr": "Vous devez avoir l’autorisation de retirer des utilisateurs pour faire ceci."
+    },
+    "Report a problem": {
+        "en": "Report a problem",
+        "fr": "Signaler un problème"
     }
 }

--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -719,7 +719,7 @@
         "fr": "Signaler un problème"
     },
     "tchap_voip_bug_report_prefill": {
-        "en": "Congratulations, your account has been renewed",
-        "fr": "Sujet: problème sur appel Tchap. \nPouver-vous donner des détails?\n\nJe suis connecté en : WIFI / VPN / sur la 4G d'un portable / AUTRE\nJe suis sur : AU TRAVAIL / AILLEURS\nDétails du problème : ..."
+        "en": "I had a problem during a Tchap call.\nDetails: ...",
+        "fr": "J'ai eu un problème pendant un appel Tchap.\nDétails : ..."
     }
 }

--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -717,5 +717,9 @@
     "Report a problem": {
         "en": "Report a problem",
         "fr": "Signaler un problème"
+    },
+    "tchap_voip_bug_report_prefill": {
+        "en": "Congratulations, your account has been renewed",
+        "fr": "Sujet: problème sur appel Tchap. \nPouver-vous donner des détails?\n\nJe suis connecté en : WIFI / VPN / sur la 4G d'un portable / AUTRE\nJe suis sur : AU TRAVAIL / AILLEURS\nDétails du problème : ..."
     }
 }

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
-index 5d826f2..e3ec671 100644
+index 5d826f2..c0008ea 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
 @@ -32,6 +32,7 @@ import DialogButtons from "../elements/DialogButtons";
@@ -49,8 +49,8 @@ index 5d826f2..e3ec671 100644
 +                return customFields[threepid.medium] = threepid.address;
 +            });
 +            // is this a voip report ? Add it in "context" field
-+            if (this.props.label === 'voip') {
-+                customFields.context = 'voip';
++            if (this.props.label === "voip-feedback") {
++                customFields.context = "voip";
 +            }
 +            return customFields;
 +        }).then(customFields => {
@@ -149,7 +149,7 @@ index 1eb0379..90955dd 100644
  
  /**
 diff --git a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
-index 3c8241d..414e7cd 100644
+index 3c8241d..cdd9a83 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 @@ -28,6 +28,10 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
@@ -178,7 +178,7 @@ index 3c8241d..414e7cd 100644
 +    private onReportBugClick = (): void => {
 +        Modal.createDialog(BugReportDialog, {
 +            initialText: _t("tchap_voip_bug_report_prefill"),
-+            label: "voip",
++            label: "voip-feedback",
 +        });
 +    };
 +

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -1,16 +1,17 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
-index 5d826f2..c0008ea 100644
+index 5d826f2..51baf28 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
-@@ -32,6 +32,7 @@ import DialogButtons from "../elements/DialogButtons";
+@@ -32,6 +32,8 @@ import DialogButtons from "../elements/DialogButtons";
  import { sendSentryReport } from "../../../sentry";
  import defaultDispatcher from "../../../dispatcher/dispatcher";
  import { Action } from "../../../dispatcher/actions";
 +import { MatrixClientPeg } from '../../../MatrixClientPeg';  // :TCHAP:
++import TchapUtils from "../../../../../../src/tchap/util/TchapUtils"; // :TCHAP:
  
  interface IProps {
      onFinished: (success: boolean) => void;
-@@ -96,12 +97,21 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -96,12 +98,21 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
      };
  
      private onSubmit = (): void => {
@@ -32,7 +33,7 @@ index 5d826f2..c0008ea 100644
  
          const userText =
              (this.state.text.length > 0 ? this.state.text + "\n\n" : "") +
-@@ -111,11 +121,28 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -111,11 +122,34 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
          this.setState({ busy: true, progress: null, err: null });
          this.sendProgressCallback(_t("bug_reporting|preparing_logs"));
  
@@ -43,16 +44,22 @@ index 5d826f2..c0008ea 100644
 -            labels: this.props.label ? [this.props.label] : [],
 +        // :TCHAP: customise report : add email, prefix with "tchap-web"
 +        const client = MatrixClientPeg.get();
++        const customFields = {};
 +        client.getThreePids().then(result => {
-+            const customFields = {};
 +            result.threepids.forEach(threepid => {
 +                return customFields[threepid.medium] = threepid.address;
 +            });
++            return customFields;
++        }).then(customFields => {
 +            // is this a voip report ? Add it in "context" field
 +            if (this.props.label === "voip-feedback") {
 +                customFields.context = "voip";
 +            }
-+            return customFields;
++
++            return TchapUtils.isCurrentlyUsingBluetooth().then(isCurrentlyUsingBluetooth => {
++                customFields.audio_input = isCurrentlyUsingBluetooth ? "headset_bluetooth" : "device";
++                return customFields;
++            })
 +        }).then(customFields => {
 +            return sendBugReport(SdkConfig.get().bug_report_endpoint_url, {
 +                userText,
@@ -66,7 +73,7 @@ index 5d826f2..c0008ea 100644
          }).then(
              () => {
                  if (!this.unmounted) {
-@@ -150,6 +177,7 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -150,6 +184,7 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
                  sendLogs: true,
                  progressCallback: this.downloadProgressCallback,
                  labels: this.props.label ? [this.props.label] : [],
@@ -74,7 +81,7 @@ index 5d826f2..c0008ea 100644
              });
  
              this.setState({
-@@ -214,6 +242,53 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -214,6 +249,53 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
              );
          }
  
@@ -128,7 +135,7 @@ index 5d826f2..c0008ea 100644
          return (
              <BaseDialog
                  className="mx_BugReportDialog"
-@@ -281,5 +356,6 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -281,5 +363,6 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
                  />
              </BaseDialog>
          );

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -145,7 +145,7 @@ index 1eb0379..90955dd 100644
  
  /**
 diff --git a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
-index 3c8241d..a8fb0fd 100644
+index 3c8241d..e947b3b 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 @@ -28,6 +28,9 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
@@ -158,13 +158,14 @@ index 3c8241d..a8fb0fd 100644
  const MAX_NON_NARROW_WIDTH = (450 / 70) * 100;
  
  interface IProps {
-@@ -264,6 +267,24 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+@@ -264,6 +267,25 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
          );
      }
  
 +    private onReportBugClick = (): void => {
 +        Modal.createDialog(BugReportDialog, {
 +            initialText: _t("tchap_voip_bug_report_prefill"),
++            label: "voip",
 +        });
 +    };
 +
@@ -183,7 +184,7 @@ index 3c8241d..a8fb0fd 100644
      public render(): React.ReactNode {
          const event = this.props.mxEvent;
          const sender = event.sender ? event.sender.name : event.getSender();
-@@ -300,6 +321,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+@@ -300,6 +322,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                          </div>
                      </div>
                      {content}

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -144,6 +144,51 @@ index 1eb0379..90955dd 100644
  };
  
  /**
+diff --git a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
+index 3c8241d..6405217 100644
+--- a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
++++ b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
+@@ -28,6 +28,9 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
+ import { formatPreciseDuration } from "../../../DateUtils";
+ import Clock from "../audio_messages/Clock";
+ 
++import Modal from "matrix-react-sdk/src/Modal"; // :TCHAP:
++import BugReportDialog from "matrix-react-sdk/src/components/views/dialogs/BugReportDialog"; // :TCHAP:
++
+ const MAX_NON_NARROW_WIDTH = (450 / 70) * 100;
+ 
+ interface IProps {
+@@ -264,6 +267,22 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+         );
+     }
+ 
++    private onReportBugClick = (): void => {
++        Modal.createDialog(BugReportDialog, {});
++    };
++
++    private renderBugReportButton(): JSX.Element {
++        return (
++            <AccessibleButton
++                className="mx_LegacyCallEvent_content_button mx_LegacyCallEvent_content_button_callBack"
++                onClick={this.onReportBugClick}
++                kind="primary"
++            >
++                <span> {_t("Report a problem")} </span>
++            </AccessibleButton>
++        );
++    }
++
+     public render(): React.ReactNode {
+         const event = this.props.mxEvent;
+         const sender = event.sender ? event.sender.name : event.getSender();
+@@ -300,6 +319,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+                         </div>
+                     </div>
+                     {content}
++                    {this.renderBugReportButton()}
+                 </div>
+             </div>
+         );
 diff --git a/node_modules/matrix-react-sdk/src/rageshake/submit-rageshake.ts b/node_modules/matrix-react-sdk/src/rageshake/submit-rageshake.ts
 index d15f3d9..7c7f6d8 100644
 --- a/node_modules/matrix-react-sdk/src/rageshake/submit-rageshake.ts

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx b/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
-index 5d826f2..5163137 100644
+index 5d826f2..e3ec671 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/dialogs/BugReportDialog.tsx
 @@ -32,6 +32,7 @@ import DialogButtons from "../elements/DialogButtons";
@@ -32,7 +32,7 @@ index 5d826f2..5163137 100644
  
          const userText =
              (this.state.text.length > 0 ? this.state.text + "\n\n" : "") +
-@@ -111,11 +121,24 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -111,11 +121,28 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
          this.setState({ busy: true, progress: null, err: null });
          this.sendProgressCallback(_t("bug_reporting|preparing_logs"));
  
@@ -48,6 +48,10 @@ index 5d826f2..5163137 100644
 +            result.threepids.forEach(threepid => {
 +                return customFields[threepid.medium] = threepid.address;
 +            });
++            // is this a voip report ? Add it in "context" field
++            if (this.props.label === 'voip') {
++                customFields.context = 'voip';
++            }
 +            return customFields;
 +        }).then(customFields => {
 +            return sendBugReport(SdkConfig.get().bug_report_endpoint_url, {
@@ -62,7 +66,7 @@ index 5d826f2..5163137 100644
          }).then(
              () => {
                  if (!this.unmounted) {
-@@ -150,6 +173,7 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -150,6 +177,7 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
                  sendLogs: true,
                  progressCallback: this.downloadProgressCallback,
                  labels: this.props.label ? [this.props.label] : [],
@@ -70,7 +74,7 @@ index 5d826f2..5163137 100644
              });
  
              this.setState({
-@@ -214,6 +238,53 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -214,6 +242,53 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
              );
          }
  
@@ -124,7 +128,7 @@ index 5d826f2..5163137 100644
          return (
              <BaseDialog
                  className="mx_BugReportDialog"
-@@ -281,5 +352,6 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
+@@ -281,5 +356,6 @@ export default class BugReportDialog extends React.Component<IProps, IState> {
                  />
              </BaseDialog>
          );

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -145,20 +145,29 @@ index 1eb0379..90955dd 100644
  
  /**
 diff --git a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
-index 3c8241d..e947b3b 100644
+index 3c8241d..414e7cd 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
-@@ -28,6 +28,9 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
+@@ -28,6 +28,10 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
  import { formatPreciseDuration } from "../../../DateUtils";
  import Clock from "../audio_messages/Clock";
  
 +import Modal from "matrix-react-sdk/src/Modal"; // :TCHAP:
 +import BugReportDialog from "matrix-react-sdk/src/components/views/dialogs/BugReportDialog"; // :TCHAP:
++import "../../../../../../res/css/views/messages/TchapLegacyCallEvent.pcss"; // :TCHAP:
 +
  const MAX_NON_NARROW_WIDTH = (450 / 70) * 100;
  
  interface IProps {
-@@ -264,6 +267,25 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+@@ -192,6 +196,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+                 return (
+                     <div className="mx_LegacyCallEvent_content">
+                         {text}
++                        {this.renderBugReportButton()}
+                         {this.props.timestamp}
+                     </div>
+                 );
+@@ -264,6 +269,25 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
          );
      }
  
@@ -172,7 +181,7 @@ index 3c8241d..e947b3b 100644
 +    private renderBugReportButton(): JSX.Element {
 +        return (
 +            <AccessibleButton
-+                className="mx_LegacyCallEvent_content_button mx_LegacyCallEvent_content_button_callBack"
++                className="mx_LegacyCallEvent_content_button mx_LegacyCallEvent_content_button_reportBug"
 +                onClick={this.onReportBugClick}
 +                kind="primary"
 +            >
@@ -184,14 +193,6 @@ index 3c8241d..e947b3b 100644
      public render(): React.ReactNode {
          const event = this.props.mxEvent;
          const sender = event.sender ? event.sender.name : event.getSender();
-@@ -300,6 +322,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
-                         </div>
-                     </div>
-                     {content}
-+                    {this.renderBugReportButton()}
-                 </div>
-             </div>
-         );
 diff --git a/node_modules/matrix-react-sdk/src/rageshake/submit-rageshake.ts b/node_modules/matrix-react-sdk/src/rageshake/submit-rageshake.ts
 index d15f3d9..7c7f6d8 100644
 --- a/node_modules/matrix-react-sdk/src/rageshake/submit-rageshake.ts

--- a/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
+++ b/patches/bug-reporting/matrix-react-sdk+3.92.0.patch
@@ -145,7 +145,7 @@ index 1eb0379..90955dd 100644
  
  /**
 diff --git a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
-index 3c8241d..6405217 100644
+index 3c8241d..a8fb0fd 100644
 --- a/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/views/messages/LegacyCallEvent.tsx
 @@ -28,6 +28,9 @@ import AccessibleTooltipButton from "../elements/AccessibleTooltipButton";
@@ -158,12 +158,14 @@ index 3c8241d..6405217 100644
  const MAX_NON_NARROW_WIDTH = (450 / 70) * 100;
  
  interface IProps {
-@@ -264,6 +267,22 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+@@ -264,6 +267,24 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
          );
      }
  
 +    private onReportBugClick = (): void => {
-+        Modal.createDialog(BugReportDialog, {});
++        Modal.createDialog(BugReportDialog, {
++            initialText: _t("tchap_voip_bug_report_prefill"),
++        });
 +    };
 +
 +    private renderBugReportButton(): JSX.Element {
@@ -181,7 +183,7 @@ index 3c8241d..6405217 100644
      public render(): React.ReactNode {
          const event = this.props.mxEvent;
          const sender = event.sender ? event.sender.name : event.getSender();
-@@ -300,6 +319,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
+@@ -300,6 +321,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                          </div>
                      </div>
                      {content}

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -17,12 +17,13 @@
     },
     "bug-reporting": {
         "package": "matrix-react-sdk",
-        "github-issue":"https://github.com/tchapgouv/tchap-web-v4/issues/527, https://github.com/tchapgouv/tchap-web-v4/issues/526",
-        "comments" : "add email in rageshake",
+        "github-issue":"https://github.com/tchapgouv/tchap-web-v4/issues/527, https://github.com/tchapgouv/tchap-web-v4/issues/526, https://github.com/tchapgouv/tchap-product/issues/267",
+        "comments" : "add email in rageshake + voip",
         "files": [
             "src/components/views/dialogs/BugReportDialog.tsx",
             "src/rageshake/submit-rageshake.ts",
-            "src/components/views/elements/AccessibleButton.tsx"
+            "src/components/views/elements/AccessibleButton.tsx",
+            "src/components/views/messages/LegacyCallEvent.tsx"
         ]
     },
     "content-scanner": {

--- a/res/css/views/messages/TchapLegacyCallEvent.pcss
+++ b/res/css/views/messages/TchapLegacyCallEvent.pcss
@@ -2,7 +2,7 @@
   .mx_LegacyCallEvent {
     &.mx_LegacyCallEvent_voice {
       .mx_LegacyCallEvent_content_button_reportBug span::before {
-        mask-image: url("~matrix-react-sdk/res/img/feather-customised/bug.svg");
+        mask-image: url("~matrix-react-sdk/res/img/element-icons/warning-badge.svg");
      }
     }
   }

--- a/res/css/views/messages/TchapLegacyCallEvent.pcss
+++ b/res/css/views/messages/TchapLegacyCallEvent.pcss
@@ -1,0 +1,9 @@
+.mx_LegacyCallEvent_wrapper {
+  .mx_LegacyCallEvent {
+    &.mx_LegacyCallEvent_voice {
+      .mx_LegacyCallEvent_content_button_reportBug span::before {
+        mask-image: url("~matrix-react-sdk/res/img/feather-customised/bug.svg");
+     }
+    }
+  }
+}

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -241,7 +241,7 @@ export default class TchapUtils {
 
     /**
      * Whether the user is currently using a bluetooth audio input (bluetooth headset for example).
-     * In Chrome we can get the information, but in Firefox and Edge we don't know.
+     * In Chrome we can get the information sometimes, and in Firefox and Edge we don't know.
      * @returns true if we are sure user is currently using a bluetooth audio input. False if no blutooth, or we don't know.
      */
     static async isCurrentlyUsingBluetooth(): Promise<boolean> {

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -238,4 +238,35 @@ export default class TchapUtils {
         }
         return false;
     }
+
+    /**
+     * @returns true if we are sure user is currently using a bluetooth audio input. In many cases we don't know, and return false.
+     */
+    static async isCurrentlyUsingBluetooth(): Promise<boolean> {
+        if (!navigator.mediaDevices?.enumerateDevices) {
+            console.log("enumerateDevices() not supported. Cannot know if there is a bluetooth device.");
+            return false;
+        } else {
+            // List cameras and microphones.
+            return navigator.mediaDevices
+                .enumerateDevices()
+                .then((devices) => {
+                    let hasBluetooth = false;
+                    devices.forEach((device) => {
+                        console.log(`${device.kind}: ${device.label} id = ${device.deviceId}`);
+                        if (device.kind === "audioinput") {
+                            if (device.label.toLowerCase().includes("bluetooth")) {
+                                hasBluetooth = true;
+                            }
+                        }
+                    });
+                    return hasBluetooth;
+                })
+                .catch((err) => {
+                    console.error(`${err.name}: ${err.message}`);
+                    return false;
+                });
+        }
+    }
+
 }

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -240,7 +240,9 @@ export default class TchapUtils {
     }
 
     /**
-     * @returns true if we are sure user is currently using a bluetooth audio input. In many cases we don't know, and return false.
+     * Whether the user is currently using a bluetooth audio input (bluetooth headset for example).
+     * In Chrome we can get the information, but in Firefox and Edge we don't know.
+     * @returns true if we are sure user is currently using a bluetooth audio input. False if no blutooth, or we don't know.
      */
     static async isCurrentlyUsingBluetooth(): Promise<boolean> {
         if (!navigator.mediaDevices?.enumerateDevices) {


### PR DESCRIPTION
Fix https://github.com/tchapgouv/tchap-web-v4/issues/888

Add "Signaler un probleme" when the call did happen : 

<img width="755" alt="Screen Shot 2024-02-20 at 4 57 26 PM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/5d2f2c8b-5c28-4209-b703-fe0fa713e26e">

Opens the bug report dialog : 

<img width="761" alt="Screen Shot 2024-02-20 at 4 58 34 PM" src="https://github.com/tchapgouv/tchap-web-v4/assets/911434/882b04e1-11cc-4567-b997-743ccf766770">

Editable text in the dialog : 
```
Sujet: problème sur appel Tchap. 
Pouver-vous donner des détails?

Je suis connecté en : WIFI / VPN / sur la 4G d'un portable / AUTRE
Je suis sur : AU TRAVAIL / AILLEURS
Détails du problème : ...
```

Additional fields in the rageshake : 
`context: voip` (and also `label:voip`)
Demo of rageshake : https://app.crisp.chat/website/6dacc68e-de3a-4511-8177-1339616098de/inbox/session_b196c891-7640-4afc-a165-9f88458d4abe/
