### PR TITLE
Dev/Preprod - set "Tchap" as brand name

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -26,7 +26,7 @@
     "disable_guests": true,
     "disable_login_language_selector": false,
     "disable_3pid_login": false,
-    "brand": "TCHAP DEV",
+    "brand": "Tchap",
     "bug_report_endpoint_url": "/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "default_country_code": "FR",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -22,7 +22,7 @@
     "disable_guests": true,
     "disable_login_language_selector": false,
     "disable_3pid_login": false,
-    "brand": "TCHAP PREPROD",
+    "brand": "Tchap",
     "bug_report_endpoint_url": "https://matrix.i.tchap.gouv.fr/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "default_country_code": "FR",


### PR DESCRIPTION
### Contexte
Le css utilisé dans les templates mail/html sont dépendants du « brand » de Tchap Web.
Ces css ne marchent plus en dev et en preprod lors de la génération des mails.

Ce « brand » est défini dans les config.json de Tchap Web :
- en [Prod](https://github.com/tchapgouv/tchap-web-v4/blob/17c686fd370b0454b58860c5425290313693a955/config.prod.json#L85) : brand = Tchap
- en [Preprod](https://github.com/tchapgouv/tchap-web-v4/blob/17c686fd370b0454b58860c5425290313693a955/config.preprod.json#L25) : brand = TCHAP PREPROD
- en [Dev](https://github.com/tchapgouv/tchap-web-v4/blob/17c686fd370b0454b58860c5425290313693a955/config.dev.json#L29) : brand = TCHAP DEV

Ticket impacté : https://github.com/tchapgouv/tchap-infra/pull/2483

### Objectif
Changer les configurations de Tchap Web afin de fixer l'utilisation des css dans les templates mails pour dev et preprod et d'être iso avec la prod.
