### PR TITLE
fix(content-scanning): use devicePixelRatio in thumbnails dimensions

### DIFF
--- a/src/tchap/customisations/ContentScanningMedia.ts
+++ b/src/tchap/customisations/ContentScanningMedia.ts
@@ -88,6 +88,9 @@ export class Media {
      */
     public getThumbnailHttp(width: number, height: number, mode: ResizeMethod = "scale"): string | null | undefined {
         if (!this.hasThumbnail) return null;
+        // scale using the device pixel ratio to keep images clear
+        width = Math.floor(width * window.devicePixelRatio);
+        height = Math.floor(height * window.devicePixelRatio);
         return ContentScanner.instance.urlForMxc(this.thumbnailMxc, width, height, mode);
     }
 
@@ -99,6 +102,9 @@ export class Media {
      * @returns {string} The HTTP URL which points to the thumbnail.
      */
     public getThumbnailOfSourceHttp(width: number, height: number, mode: ResizeMethod = "scale"): string {
+        // scale using the device pixel ratio to keep images clear
+        width = Math.floor(width * window.devicePixelRatio);
+        height = Math.floor(height * window.devicePixelRatio);
         return ContentScanner.instance.urlForMxc(this.srcMxc, width, height, mode);
     }
 
@@ -109,6 +115,7 @@ export class Media {
      * @returns {string} An HTTP URL for the thumbnail.
      */
     public getSquareThumbnailHttp(dim: number): string {
+        dim = Math.floor(dim * window.devicePixelRatio); // scale using the device pixel ratio to keep images clear
         if (this.hasThumbnail) {
             return this.getThumbnailHttp(dim, dim, "crop");
         }


### PR DESCRIPTION
use `devicePixelRatio` as in https://github.com/matrix-org/matrix-react-sdk/blob/develop/src/customisations/Media.ts

fix #250