### PR TITLE
fix(room-icons #908): remove deprecated function and use event timeline with join rules attributes

### DIFF
--- a/src/tchap/@types/tchap.ts
+++ b/src/tchap/@types/tchap.ts
@@ -9,6 +9,8 @@ export enum TchapRoomType {
 export enum TchapRoomAccessRule {
     Unrestricted = "unrestricted", // accessible to externals
     Restricted = "restricted", // not accessible to externals
+    Public = "public",
+    Invite = "invite",
 }
 
 export interface TchapIAccessRuleEventContent {

--- a/src/tchap/util/TchapRoomUtils.ts
+++ b/src/tchap/util/TchapRoomUtils.ts
@@ -2,16 +2,15 @@
  * Tchap Room utils.
  */
 
-import { Room } from "matrix-js-sdk/src/matrix";
-import { MatrixClientPeg } from "matrix-react-sdk/src/MatrixClientPeg";
+import { EventTimeline, EventType, Room } from "matrix-js-sdk/src/matrix";
 
-import { TchapRoomAccessRule, TchapRoomAccessRulesEventId, TchapRoomType } from "../@types/tchap";
+import { TchapRoomAccessRule, TchapRoomType } from "../@types/tchap";
 
 export default class TchapRoomUtils {
     //inspired by https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/main/java/fr/gouv/tchap/core/utils/RoomUtils.kt#L31
     //direct type is not handled yet
     static getTchapRoomType(room: Room): TchapRoomType {
-        const isEncrypted: boolean = this.isRoomEncrypted(room.roomId);
+        const isEncrypted: boolean = this.isRoomEncrypted(room);
         const tchapRoomAccessRule: TchapRoomAccessRule = this.getTchapRoomAccessRule(room);
         return this.getTchapRoomTypeInternal(isEncrypted, tchapRoomAccessRule);
     }
@@ -23,10 +22,10 @@ export default class TchapRoomUtils {
         if (!tchapRoomAccessRule) {
             return TchapRoomType.Unknown;
         }
-        if (tchapRoomAccessRule === TchapRoomAccessRule.Restricted) {
+        if (tchapRoomAccessRule === TchapRoomAccessRule.Restricted || tchapRoomAccessRule === TchapRoomAccessRule.Invite) {
             return TchapRoomType.Private;
         }
-        if (tchapRoomAccessRule === TchapRoomAccessRule.Unrestricted) {
+        if (tchapRoomAccessRule === TchapRoomAccessRule.Unrestricted || tchapRoomAccessRule === TchapRoomAccessRule.Public) {
             return TchapRoomType.External;
         }
         return TchapRoomType.Unknown;
@@ -38,7 +37,11 @@ export default class TchapRoomUtils {
      * @returns string that matches of one TchapRoomAccessRule //todo or null? or empty?
      */
     static getTchapRoomAccessRule(room: Room): TchapRoomAccessRule {
-        return room.currentState.getStateEvents(TchapRoomAccessRulesEventId, "")?.getContent().rule;
+        // the state event TchapRoomAccessRulesEventId is working only when the rule access is invite -> maybe a change in the backend configuration ? needs to check
+        // That's is why sometimes the last state events is undefined, here we are not directly using getJoinRule because of types compatibility
+        const lastEvent =  room.getLiveTimeline().getState(EventTimeline.FORWARDS)?.getStateEvents(EventType.RoomJoinRules)[0];
+
+        return lastEvent?.getContent().join_rule;
     }
 
     /**
@@ -46,7 +49,7 @@ export default class TchapRoomUtils {
      * @param roomId
      * @returns true if room is encrypted, false if not
      */
-    static isRoomEncrypted(roomId: string): boolean {
-        return MatrixClientPeg.get().isRoomEncrypted(roomId);
+    static isRoomEncrypted(room: Room): boolean {
+        return room.hasEncryptionStateEvent();
     }
 }


### PR DESCRIPTION
Fix #908

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [ ] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))

## Deprecated method from matrix-js-sdk
- room.currentState is deprecated
- isRoomEncrypted is also deprecated because of matrix rust sdk

## What's the problem
- The problem that was causing the icon to no show up sometimes is because the event received from the room where sometimes undefined. I noticed this behavior, only on rooms that have where configured on invite mode
- My guess is that maybe some configuration changed on the backend, so the value returned by state key `im.vector.room.access_rules` are not the same anymore

## What changed
- One solution that was implemented here is to use join_rules instead of `im.vector.room.access_rules` 

## TODO
Still in draft because i think the best solution is to try fix the backend and check why we dont receive the same values anymore 

# UPDATE 
We don't mix join_rule and access_rules in tchap. The identified pb is that the `access_rule` event is not set when the rooms have been upgraded to version 9 