### PR TITLE
Chore:Remove SonarCloud from Tchap workflows

### DIFF
--- a/.github/workflows/tchap_tests.yaml
+++ b/.github/workflows/tchap_tests.yaml
@@ -37,27 +37,3 @@ jobs:
 
             - name: Run tests with coverage
               run: "yarn coverage --ci"
-
-            - name: Upload Artifact
-              uses: actions/upload-artifact@v4
-              with:
-                  name: coverage
-                  path: |
-                      coverage
-                      !coverage/lcov-report
-
-    skip_sonar:
-        name: Skip SonarCloud in merge queue
-        if: github.event_name == 'merge_group'
-        runs-on: ubuntu-latest
-        needs: jest
-        steps:
-            - name: Skip SonarCloud
-              uses: Sibz/github-status-action@071b5370da85afbb16637d6eed8524a06bc2053e # v1
-              with:
-                  authToken: ${{ secrets.GITHUB_TOKEN }}
-                  state: success
-                  description: SonarCloud skipped
-                  context: SonarCloud Code Analysis
-                  sha: ${{ github.sha }}
-                  target_url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
Also removed uploading the artifact : it makes the job slower and we don't use it.

It got added through an upgrade by mistake.