### PR TITLE
Fix build validated config from discovery tchap utils

### DIFF
--- a/patches/forgot-password/matrix-react-sdk+3.95.0.patch
+++ b/patches/forgot-password/matrix-react-sdk+3.95.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
-index 9487fc5..0177f0a 100644
+index 9487fc5..f9a0d5e 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/ForgotPassword.tsx
 @@ -42,6 +42,8 @@ import { VerifyEmailModal } from "./forgot-password/VerifyEmailModal";
@@ -75,7 +75,7 @@ index 9487fc5..0177f0a 100644
 +            });
 +            return;
 +        }
-+        const serverConfig = TchapUtils.makeValidatedServerConfig(serverResult);
++        const serverConfig = await TchapUtils.makeValidatedServerConfig(serverResult);
 +        await this.useNewServerConfig(serverConfig);
 +        // end :TCHAP:
 +

--- a/patches/login/matrix-react-sdk+3.95.0.patch
+++ b/patches/login/matrix-react-sdk+3.95.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
-index 5fadde7..82e44bb 100644
+index 5fadde7..0f81d32 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Login.tsx
 @@ -40,6 +40,8 @@ import { ValidatedServerConfig } from "../../../utils/ValidatedServerConfig";
@@ -16,7 +16,7 @@ index 5fadde7..82e44bb 100644
      public isBusy = (): boolean => !!this.state.busy || !!this.props.busy;
  
 +    tchap_setServerInMemory = async (serverConfig) => {
-+        const validatedServerConf = TchapUtils.makeValidatedServerConfig(serverConfig);
++        const validatedServerConf = await TchapUtils.makeValidatedServerConfig(serverConfig);
 +
 +        // Simulate the end of the serverPicker component flow.
 +        this.props.onServerConfigChange(validatedServerConf);

--- a/patches/registration-for-mainlining/matrix-react-sdk+3.95.0.patch
+++ b/patches/registration-for-mainlining/matrix-react-sdk+3.95.0.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx b/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
-index 4da7282..4928a4b 100644
+index 4da7282..751b266 100644
 --- a/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
 +++ b/node_modules/matrix-react-sdk/src/components/structures/auth/Registration.tsx
 @@ -50,11 +50,15 @@ import InteractiveAuth, { InteractiveAuthCallback } from "../InteractiveAuth";
@@ -24,7 +24,7 @@ index 4da7282..4928a4b 100644
      private onFormSubmit = async (formVals: Record<string, string>): Promise<void> => {
 +        // :TCHAP: find the server corresponding to the entered email
 +        const server = await TchapUtils.fetchHomeserverForEmail(formVals.email);
-+        const validatedServerConfig = TchapUtils.makeValidatedServerConfig(server);
++        const validatedServerConfig = await TchapUtils.makeValidatedServerConfig(server);
 +        // Note : onServerConfigChange triggers a state change at the matrixChat level. All the children are rerendered.
 +        this.props.onServerConfigChange(validatedServerConfig);
 +        // end :TCHAP:

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -5,6 +5,7 @@ import { ValidatedServerConfig } from "matrix-react-sdk/src/utils/ValidatedServe
 import { findMapStyleUrl } from "matrix-react-sdk/src/utils/location";
 
 import TchapApi from "./TchapApi";
+import { ClientConfig } from "~tchap-web/yarn-linked-dependencies/matrix-js-sdk/src/autodiscovery";
 
 /**
  * Tchap utils.
@@ -107,8 +108,8 @@ export default class TchapUtils {
      * @param
      * @returns
      */
-    static makeValidatedServerConfig = (serverConfig): ValidatedServerConfig => {
-        const discoveryResult = {
+    static makeValidatedServerConfig = async (serverConfig: Record<string, any>): Promise<ValidatedServerConfig> => {
+        const discoveryResult: ClientConfig = {
             "m.homeserver": {
                 state: "SUCCESS",
                 error: null,
@@ -121,8 +122,8 @@ export default class TchapUtils {
                 base_url: serverConfig.base_url, // On Tchap our Identity server urls and home server urls are the same
                 server_name: serverConfig.server_name,
             },
-        };
-        const validatedServerConf = AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(
+        } as ClientConfig;
+        const validatedServerConf = await AutoDiscoveryUtils.buildValidatedConfigFromDiscovery(
             discoveryResult["m.homeserver"].server_name,
             discoveryResult,
         );


### PR DESCRIPTION
## Description

Because of an update on the OIDC discovery implementation, a function that we used in Tchap went from sync to async. Cf this [PR](https://github.com/element-hq/element-web/pull/27047) in element-web.

That's why in this PR, I update the method and the different patches that use it.

## Checklist

-   [ ] Tests written for new code (and old code if feasible)
-   [x] Linter and other CI checks pass
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md))

<!--
If you would like to specify text for the changelog entry other than your PR title, add the following:

Notes: Add super cool feature

For PRs which *only* affect the desktop version, please use:

Notes: none
element-desktop notes: Add super cool feature
-->
