### PR TITLE
fix(rageshake): reallow customapp field

### DIFF
--- a/linked-dependencies/matrix-react-sdk/src/rageshake/submit-rageshake.ts
+++ b/linked-dependencies/matrix-react-sdk/src/rageshake/submit-rageshake.ts
@@ -105,7 +105,7 @@ async function collectBaseInformation(body: FormData, opts: IOpts): Promise<void
     /* :TCHAP: bug-reporting - rename app - for bugreport rageshakes
     body.append("app", opts.customApp || "element-web");
     */
-    body.append("app", "tchap-web");
+    body.append("app", opts.customApp || "tchap-web");
     // end :TCHAP:
     body.append("version", version ?? "UNKNOWN");
     body.append("user_agent", userAgent);

--- a/test/unit-tests/tchap/rageshake/submit-rageshake-test.ts
+++ b/test/unit-tests/tchap/rageshake/submit-rageshake-test.ts
@@ -76,11 +76,18 @@ describe("Rageshakes", () => {
             windowSpy.mockRestore();
         });
 
-        it("should include app name", async () => {
+        it("should include app name default as tchap", async () => {
             const formData = await collectBugReport();
             const appName = formData.get("app");
 
             expect(appName).toBe("tchap-web");
+        });
+
+        it("should include custom app name ", async () => {
+            const formData = await collectBugReport({ customApp: "toto" });
+            const appName = formData.get("app");
+
+            expect(appName).toBe("toto");
         });
 
         // We did not customise the custom fields code, but we test to guard against changes of output if element changes


### PR DESCRIPTION
issue https://github.com/tchapgouv/tchap-web-v4/issues/920 (small addition)

This will unbreak the crisp triage bot, which was using the customApp field (indirectly, taking the value from uisi_autorageshake_app in config.json).

## Check
- [x] modify tests 