### PR TITLE
fix(build): needs to reset the dist folder before starting a new one

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "i18n:sort": "jq --sort-keys '.' src/i18n/strings/en_EN.json > src/i18n/strings/en_EN.json.tmp && mv src/i18n/strings/en_EN.json.tmp src/i18n/strings/en_EN.json",
         "i18n:lint": "prettier --log-level=silent  --write src/i18n/strings/ --ignore-path /dev/null",
         "i18n:diff": "cp src/i18n/strings/en_EN.json src/i18n/strings/en_EN_orig.json && yarn i18n && matrix-compare-i18n-files src/i18n/strings/en_EN_orig.json src/i18n/strings/en_EN.json",
-        "clean": "rimraf lib webapp",
+        "clean": "rimraf lib webapp dist",
         "build": "yarn clean && yarn build:genfiles && yarn build:bundle",
         "build-stats": "yarn clean && yarn build:genfiles && yarn build:bundle-stats",
         "build:res": "ts-node scripts/copy-res.ts",


### PR DESCRIPTION
issue :  https://github.com/tchapgouv/tchap-web-v4/issues/991

## Description 
Since 4.4.2 the build archive for preprod and prod are 10mb bigger than the dev. We still don't know what introduced this change of behavior  :man_shrugging: 

## Changes 
- Adding the removal of the dist folder in the clean command fix the issue.