### PR TITLE
feat(ff-screenshare): add feature flag screenshare on call

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -116,7 +116,12 @@
             "dev02.tchap.incubateur.net",
             "ext01.tchap.incubateur.net"
         ],
-        "feature_video_call": ["dev01.tchap.incubateur.net", "dev02.tchap.incubateur.net", "ext01.tchap.incubateur.net"]
+        "feature_video_call": [
+            "dev01.tchap.incubateur.net",
+            "dev02.tchap.incubateur.net",
+            "ext01.tchap.incubateur.net"
+        ],
+        "feature_screenshare_call": ["*"]
     },
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
 }

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -107,7 +107,8 @@
         "feature_thread": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
         "feature_space": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
         "feature_audio_call": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
-        "feature_video_call": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"]
+        "feature_video_call": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
+        "feature_screenshare_call": ["*"]
     },
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
 }

--- a/config.prod.json
+++ b/config.prod.json
@@ -194,7 +194,8 @@
         "feature_thread": ["agent.dinum.tchap.gouv.fr"],
         "feature_space": [],
         "feature_audio_call": ["*"],
-        "feature_video_call": []
+        "feature_video_call": [],
+        "feature_screenshare_call": ["*"]
     },
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
 }

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -194,7 +194,8 @@
         "feature_thread": ["agent.dinum.tchap.gouv.fr"],
         "feature_space": ["agent.dinum.tchap.gouv.fr"],
         "feature_audio_call": ["*"],
-        "feature_video_call": ["agent.dinum.tchap.gouv.fr"]
+        "feature_video_call": ["agent.dinum.tchap.gouv.fr"],
+        "feature_screenshare_call": ["*"]
     },
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
 }

--- a/config.prod_rie.json
+++ b/config.prod_rie.json
@@ -194,7 +194,8 @@
         "feature_thread": [],
         "feature_space": [],
         "feature_audio_call": ["*"],
-        "feature_video_call": []
+        "feature_video_call": [],
+        "feature_screenshare_call": ["*"]
     },
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
 }

--- a/linked-dependencies/matrix-react-sdk/src/components/views/voip/LegacyCallView.tsx
+++ b/linked-dependencies/matrix-react-sdk/src/components/views/voip/LegacyCallView.tsx
@@ -360,9 +360,18 @@ export default class LegacyCallView extends React.Component<IProps, IState> {
         // identify it using SDPStreamMetadata or if we can replace the already
         // existing usermedia track by a screensharing track. We also need to be
         // connected to know the state of the other side
-        const screensharingButtonShown =
-            (call.opponentSupportsSDPStreamMetadata() || call.hasLocalUserMediaVideoTrack) &&
-            call.state === CallState.Connected;
+        /** :TCHAP: hide-screensharing-button */ 
+        // const screensharingButtonShown =
+        //     (call.opponentSupportsSDPStreamMetadata() || call.hasLocalUserMediaVideoTrack) &&
+        //     call.state === CallState.Connected;
+        // const vidMuteButtonShown = call.opponentSupportsSDPStreamMetadata() || call.hasLocalUserMediaVideoTrack;
+        let screensharingButtonShown = false // hide by default
+        if (TchapUIFeature.isFeatureActiveForHomeserver("feature_screenshare_call")) {
+            screensharingButtonShown = 
+                (call.opponentSupportsSDPStreamMetadata() || call.hasLocalUserMediaVideoTrack) &&
+                call.state === CallState.Connected;
+        };
+        /** end :TCHAP: */
         // Show the sidebar button only if there is something to hide/show
         const sidebarButtonShown = (secondaryFeed && !secondaryFeed.isVideoMuted()) || sidebarFeeds.length > 0;
         // The dial pad & 'more' button actions are only relevant in a connected call

--- a/patches/subtree-modifications.json
+++ b/patches/subtree-modifications.json
@@ -31,5 +31,11 @@
         "files": [
             "src/components/views/spaces/SpacePanel.tsx"
         ]
+    },
+    "hide-screensharing-button": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1042",
+        "files": [
+            "src/components/views/voip/LegacyCallView.tsx"
+        ]
     }
 }

--- a/test/unit-tests/tchap/components/views/voip/LegacyCallView-test.tsx
+++ b/test/unit-tests/tchap/components/views/voip/LegacyCallView-test.tsx
@@ -56,6 +56,7 @@ describe("LegacyCallView", () => {
         // mock SdkConfig.get("tchap_features")
         const config: ConfigOptions = { tchap_features: {} };
         config.tchap_features[featureName] = homeservers;
+        config.tchap_features["feature_screenshare_call"] = homeservers;
         SdkConfig.put(config);
     };
 
@@ -138,5 +139,31 @@ describe("LegacyCallView", () => {
         waitFor(() => container.getElementsByClassName("mx_LegacyCallViewButtons").length);
 
         expect(container.getElementsByClassName("mx_LegacyCallViewButtons_button_vid").length).toBe(1);
+    });
+
+    it("should display screenshare button when the the homeserver include feature_screenshare_call feature", () => {
+        jest.spyOn(fakeCall, "opponentSupportsSDPStreamMetadata").mockReturnValue(true);
+
+        mockFeatureConfig([homeserverName]);
+        const { container } = renderCallView();
+
+        // needs to hover on the component to make the control button appears
+        fireEvent.mouseEnter(container);
+        waitFor(() => container.getElementsByClassName("mx_LegacyCallViewButtons").length);
+
+        expect(container.getElementsByClassName("mx_LegacyCallViewButtons_button_screensharing").length).toBe(1);
+    });
+
+    it("should not display screenshare button when the the homeserver doesnt include feature_screenshare_call feature", async () => {
+        jest.spyOn(fakeCall, "opponentSupportsSDPStreamMetadata").mockReturnValue(true);
+
+        mockFeatureConfig(["other.homeserver"]);
+        const { container } = renderCallView();
+
+        // needs to hover on the component to make the control button appears
+        fireEvent.mouseEnter(container);
+        waitFor(() => container.getElementsByClassName("mx_LegacyCallViewButtons").length);
+
+        expect(container.getElementsByClassName("mx_LegacyCallViewButtons_button_screensharing").length).toBe(0);
     });
 });


### PR DESCRIPTION
issue https://github.com/tchapgouv/tchap-web-v4/issues/1042

## Description
A screenshare feature flag was added in order to have more granularity on the deployment.
When this feature flag is activated, we can see the sharescreen button during a call, otherwise it won't appear. It can be used even if the video feature flag is not activated.

## Checklist
-   [x] Tests written for new code (and old code if feasible).
-   [x] Linter and other CI checks pass.
