### PR TITLE
fix(build): add subtree node_modules during postinstall

### DIFF
--- a/scripts/tchap/postinstall.sh
+++ b/scripts/tchap/postinstall.sh
@@ -7,9 +7,13 @@ set -x
 
 cd linked-dependencies
 pushd matrix-react-sdk
+# Normally when dealing with a subtree and node_modules, it is good practice to merge them in the parent package.json. 
+# However in our case nothing should overlaps since element and matrix-react-sdk are deeply interconnected.
+# Moreover, webpack will apply tree shaking to remove unecessary pacakges
+yarn install --pure-lockfile
 yarn unlink # :TCHAP: for local build, undo previous links if present.
 yarn link
-# yarn install --pure-lockfile
+
 popd
 
 cd ..


### PR DESCRIPTION
fix https://github.com/tchapgouv/tchap-web-v4/issues/1048

- Don't know how it was working previously without this line :shrug: since the dependencies were not/partially included? 
- Moreover the errror thrown in the issue was present only in firefox < 115. 

## To check
- [x] working on firefox 115 and below