### PR TITLE
Bump to 4.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "element-web",
     "productName": "Tchap",
-    "version": "4.5.8",
+    "version": "4.5.9",
     "version-element-web": "1.11.67",
     "description": "A feature-rich client for Matrix.org",
     "author": "DINUM",


### PR DESCRIPTION
## Changes 
- Update version to 4.5.9, which is only build fix for version 4.5.8. So we don't update yarn lock and minor dependencies