### PR TITLE
add metrics on call event

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -107,6 +107,11 @@
             "text": "Read the Privacy Policy"
         }
     ],
+    "posthog": {
+        "project_api_key": "phc_eQOeaQiaIxdX9kaQmqYTD7RJLyFubYmGYKUI9czqqQD",
+        "api_host": "https://us.i.posthog.com"
+    },
+    "privacy_policy_url": "https://tchap.beta.gouv.fr/politique-de-confidentialite",
     "tchap_features": {
         "feature_email_notification": ["*"],
         "feature_space": ["*"],

--- a/patches/metrics-call/matrix-js-sdk+33.1.0.patch
+++ b/patches/metrics-call/matrix-js-sdk+33.1.0.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/matrix-js-sdk/src/webrtc/call.ts b/node_modules/matrix-js-sdk/src/webrtc/call.ts
+index 3f5c61a..a223f4a 100644
+--- a/node_modules/matrix-js-sdk/src/webrtc/call.ts
++++ b/node_modules/matrix-js-sdk/src/webrtc/call.ts
+@@ -1572,6 +1572,12 @@ export class MatrixCall extends TypedEventEmitter<CallEvent, CallEventHandlerMap
+         return callOnHold;
+     }
+     
++    // :TCHAP: metrics-call-js-sdk
++    public getCallStartTime(): number| undefined {
++        return this.callStartTime!;
++    }
++    // end :TCHAP:
++
+     /**
+      * Sends a DTMF digit to the other party
+      * @param digit - The digit (nb. string - '#' and '*' are dtmf too)

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -6,5 +6,11 @@
             "src/http-api/fetch.ts",
             "src/sync.ts"
         ]
+    },
+    "metrics-call": {
+        "package": "matrix-js-sdk",
+        "files": [
+            "src/webrtc/call.ts"
+        ]
     }
 }

--- a/patches/subtree-modifications.json
+++ b/patches/subtree-modifications.json
@@ -72,5 +72,12 @@
             "src/hooks/useUserOnboardingContext.ts"
 
         ]
+    },
+    "metrics-call": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1088",
+        "files": [
+            "src/LegacyCallHandler.tsx"
+
+        ]
     }
 }


### PR DESCRIPTION
## Cas d'usage
- [x] Scenario 1 : appel de user A vers user B - user A doit envoyer un event `CallStarted` lors de l'emission d'un appel (au démarrage de l'appel)
- [x] Scenario 2 : appel de user A vers user B - user B doit envoyer un event `CallStarted` lors de la réception et acceptation d'un appel (au démarrage de l'appel)
- [x] Scenario 3 : appel de user A vers user B - user A doit envoyer un event `CallEnded` lors de la fin d'appel lorsque user A termine l'appel
- [x] Scenario 4 : appel de user A vers user B - user B doit envoyer un event `CallEnded` lors de la fin d'appel lorsque user A termine l'appel

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
