### PR TITLE
Masquer les changements de nom et d'avatar par défaut

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -70,7 +70,9 @@
         "layout": "bubble",
         "custom_themes": [],
         "FTUE.useCaseSelection": "WorkMessaging",
-        "RustCrypto.staged_rollout_percent": 100
+        "RustCrypto.staged_rollout_percent": 100,
+        "hideDisplaynameChanges": true,
+        "hideAvatarChanges": true
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo-dev.svg",

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -64,7 +64,9 @@
         "layout": "bubble",
         "custom_themes": [],
         "FTUE.useCaseSelection": "WorkMessaging",
-        "RustCrypto.staged_rollout_percent": 100
+        "RustCrypto.staged_rollout_percent": 100,
+        "hideDisplaynameChanges": true,
+        "hideAvatarChanges": true
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo-preprod.svg",

--- a/config.prod.json
+++ b/config.prod.json
@@ -157,7 +157,9 @@
         "layout": "bubble",
         "custom_themes": [],
         "FTUE.useCaseSelection": "WorkMessaging",
-        "RustCrypto.staged_rollout_percent": 0
+        "RustCrypto.staged_rollout_percent": 100,
+        "hideDisplaynameChanges": true,
+        "hideAvatarChanges": true
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -157,7 +157,9 @@
         "layout": "bubble",
         "custom_themes": [],
         "FTUE.useCaseSelection": "WorkMessaging",
-        "RustCrypto.staged_rollout_percent": 100
+        "RustCrypto.staged_rollout_percent": 100,
+        "hideDisplaynameChanges": true,
+        "hideAvatarChanges": true
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",

--- a/config.prod_rie.json
+++ b/config.prod_rie.json
@@ -91,7 +91,7 @@
         "feature_video_rooms": false,
         "feature_notification_settings2": false,
         "feature_new_room_decoration_ui": true,
-        "feature_rust_crypto": false
+        "feature_rust_crypto": true
     },
     "feedback": {
         "existing_issues_url": "https://github.com/tchapgouv/tchap-web-v4/issues?q=is%3Aopen+is%3Aissue+sort%3Areactions-%2B1-desc",
@@ -157,7 +157,9 @@
         "layout": "bubble",
         "custom_themes": [],
         "FTUE.useCaseSelection": "WorkMessaging",
-        "RustCrypto.staged_rollout_percent": 0
+        "RustCrypto.staged_rollout_percent": 100,
+        "hideDisplaynameChanges": true,
+        "hideAvatarChanges": true
     },
     "branding": {
         "auth_header_logo_url": "themes/tchap/img/logos/tchap-logo.svg",

--- a/config.sample.json
+++ b/config.sample.json
@@ -65,7 +65,9 @@
         "MessageComposerInput.showPollsButton": true,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,
-        "custom_themes": []
+        "custom_themes": [],
+        "hideDisplaynameChanges": true,
+        "hideAvatarChanges": true
     },
     "branding": {
         "authHeaderLogoUrl": "themes/tchap/img/logos/tchap-logo.svg",


### PR DESCRIPTION
Les options masquant les changement de nom et d'avatar sont désactivé par défaut : 
<img width="691" alt="image" src="https://github.com/user-attachments/assets/490cee6d-f1cc-445b-beb2-6b975155c231">

Cette demande revient réguliérement par les utilisateurs, cela allège l'affichage.