### PR TITLE
fix(icon): use new compound icon for help in leftpanel

### DIFF
--- a/res/css/common/_TchapLeftPanel.pcss
+++ b/res/css/common/_TchapLeftPanel.pcss
@@ -14,7 +14,9 @@
 
 .tc_sidebar_quick_faq {
     color: var(--sidebar-button-color); 
+    
     &::before {
+        mask-image: url("@vector-im/compound-design-tokens/icons/help-solid.svg") !important;
         background: var(--sidebar-button-color);
     }
 }

--- a/src/tchap/components/views/common/QuickFaq.tsx
+++ b/src/tchap/components/views/common/QuickFaq.tsx
@@ -54,7 +54,7 @@ const QuickFaqButton: React.FC<{
     return (
         <>
             <AccessibleButton
-                className={classNames(["mx_QuickSettingsButton", { expanded: !isPanelCollapsed }, "mx_UserSettingsDialog_helpIcon", "tc_sidebar_quick_faq"])}
+                className={classNames(["mx_QuickSettingsButton", { expanded: !isPanelCollapsed }, "tc_sidebar_quick_faq"])}
                 onClick={openMenu}
                 aria-label={_t("common|help")}
                 title={isPanelCollapsed ? _t("common|help") : undefined}


### PR DESCRIPTION
Fixes https://github.com/tchapgouv/tchap-web-v4/issues/1112

## Change back to help icon
![image](https://github.com/user-attachments/assets/2e73e313-f70b-439b-8b36-32432150d553)
