### PR TITLE
feat(group_call): add new tchap video group call config, differenciate from 1to1 video call

### DIFF
--- a/README_tchap.md
+++ b/README_tchap.md
@@ -1,3 +1,16 @@
+## Config variable
+
+-   tchap_features : Object containing the feature that can be activated by homeserver
+    -   "feature_email_notification": Email notification
+    -   "feature_space": Creation of spaces
+    -   "feature_thread": Activate thread on messages
+    -   "feature_audio_call": Activate 1 to 1 voice call
+    -   "feature_video_call": Activate 1 to 1 video call
+    -   "feature_video_group_call": Activate group call on rooms, for this feature to work, the values of `UIFeature.widgets` and `feature_group_calls` needs to be true
+    -   "feature_screenshare_call": Activate 1 to 1 screenshare
+-   "tchap_sso_flow"
+    -   "isActive": Activate ProConnect SSO flow
+
 ## File structures
 
 -   modules -> used for translation

--- a/config.dev.json
+++ b/config.dev.json
@@ -32,7 +32,7 @@
     "default_country_code": "FR",
     "show_labs_settings": false,
     "features": {
-        "feature_video_rooms": true,
+        "feature_video_rooms": false,
         "feature_notification_settings2": false,
         "feature_new_room_decoration_ui": true,
         "feature_rust_crypto": true,
@@ -58,7 +58,7 @@
         "UIFeature.shareSocial": false,
         "UIFeature.registration": true,
         "UIFeature.urlPreviews": false,
-        "UIFeature.widgets": false,
+        "UIFeature.widgets": true,
         "UIFeature.shareQrCode": false,
         "UIFeature.thirdPartyId": true,
         "UIFeature.identityServer": true,
@@ -112,17 +112,10 @@
     "tchap_features": {
         "feature_email_notification": ["*"],
         "feature_space": ["*"],
-        "feature_thread": ["dev01.tchap.incubateur.net", "dev02.tchap.incubateur.net", "ext01.tchap.incubateur.net"],
-        "feature_audio_call": [
-            "dev01.tchap.incubateur.net",
-            "dev02.tchap.incubateur.net",
-            "ext01.tchap.incubateur.net"
-        ],
-        "feature_video_call": [
-            "dev01.tchap.incubateur.net",
-            "dev02.tchap.incubateur.net",
-            "ext01.tchap.incubateur.net"
-        ],
+        "feature_thread": ["*"],
+        "feature_audio_call": ["*"],
+        "feature_video_call": ["*"],
+        "feature_video_group_call": ["*"],
         "feature_screenshare_call": ["*"]
     },
     "tchap_sso_flow": {

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -109,6 +109,7 @@
         "feature_space": ["*"],
         "feature_audio_call": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
         "feature_video_call": ["i.tchap.gouv.fr", "e.tchap.gouv.fr"],
+        "feature_video_group_call": [],
         "feature_screenshare_call": ["*"]
     },
     "tchap_sso_flow": {

--- a/config.prod.json
+++ b/config.prod.json
@@ -196,6 +196,7 @@
         "feature_space": ["*"],
         "feature_audio_call": ["*"],
         "feature_video_call": ["agent.dinum.tchap.gouv.fr"],
+        "feature_video_group_call": [],
         "feature_screenshare_call": ["*"]
     },
     "tchap_sso_flow": {

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -196,6 +196,7 @@
         "feature_space": ["agent.dinum.tchap.gouv.fr"],
         "feature_audio_call": ["*"],
         "feature_video_call": ["agent.dinum.tchap.gouv.fr", "education.tchap.gouv.fr"],
+        "feature_video_group_call": [],
         "feature_screenshare_call": ["*"]
     },
     "tchap_sso_flow": {

--- a/linked-dependencies/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
+++ b/linked-dependencies/matrix-react-sdk/src/components/views/rooms/RoomHeader.tsx
@@ -349,6 +349,9 @@ export default function RoomHeader({
                             { /* :TCHAP: customize-room-header-bar - activate video call only if directmessage and if feature is activated on homeserver }
                             {!isVideoRoom && videoCallButton}
                             */ }
+                            {!isDirectMessage && TchapUIFeature.isFeatureActiveForHomeserver("feature_video_group_call") &&
+                              !isVideoRoom && videoCallButton}
+
                             {isDirectMessage && TchapUIFeature.isFeatureActiveForHomeserver("feature_video_call") &&
                               !isVideoRoom && videoCallButton}
                             {/* end :TCHAP: */}

--- a/test/setup/setupLanguage.ts
+++ b/test/setup/setupLanguage.ts
@@ -9,9 +9,9 @@ Please see LICENSE files in the repository root for full details.
 import fetchMock from "fetch-mock-jest";
 import _ from "lodash";
 import { setupLanguageMock as reactSetupLanguageMock } from "matrix-react-sdk/test/setup/setupLanguage";
+import reactEn from "matrix-react-sdk/src/i18n/strings/en_EN.json"; // :TCHAP: we want to have the sdk translation and element since we might have test for both repo
 
 import en from "../../src/i18n/strings/en_EN.json";
-import reactEn from "../../src/i18n/strings/en_EN.json";
 
 fetchMock.config.overwriteRoutes = false;
 

--- a/test/setupTests.ts
+++ b/test/setupTests.ts
@@ -1,1 +1,11 @@
 import "@testing-library/jest-dom";
+// :TCHAP:
+// Very carefully enable the mocks for everything else in
+// a specific order. We use this order to ensure we properly
+// establish an application state that actually works.
+//
+// These are also require() calls to make sure they get called
+// synchronously.
+require("matrix-react-sdk/test/setup/setupManualMocks"); // must be first
+require("./setup/setupLanguage");
+require("matrix-react-sdk/test/setup/setupConfig");

--- a/test/unit-tests/tchap/components/structures/UserMenu-test.tsx
+++ b/test/unit-tests/tchap/components/structures/UserMenu-test.tsx
@@ -26,7 +26,7 @@ describe("<UserMenu>", () => {
         // it"s a good indicator to see if this could introduce some regression on our code
         it("should render as expected", async () => {
             // open the user menu
-            screen.getByRole("button", { name: "a11y" }).click();
+            screen.getByRole("button", { name: "User menu" }).click();
 
             const menu = screen.getByRole("menu");
             expect(menu).toMatchSnapshot();
@@ -46,9 +46,9 @@ describe("<UserMenu>", () => {
         it("should open the faq when clicking on the faq button", () => {
             global.open = jest.fn();
             // open the user menu
-            screen.getByRole("button", { name: "a11y" }).click();
+            screen.getByRole("button", { name: "User menu" }).click();
             // click on the faq
-            screen.getByRole("menuitem", { name: "common" }).click();
+            screen.getByRole("menuitem", { name: "Help" }).click();
             expect(global.open).toHaveBeenCalledTimes(1);
             expect(global.open).toHaveBeenCalledWith("https://www.tchap.gouv.fr/faq", "_blank");
         });

--- a/test/unit-tests/tchap/components/structures/__snapshots__/UserMenu-test.tsx.snap
+++ b/test/unit-tests/tchap/components/structures/__snapshots__/UserMenu-test.tsx.snap
@@ -25,7 +25,7 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
         </span>
       </div>
       <div
-        aria-label="user_menu"
+        aria-label="Switch to dark mode"
         class="mx_AccessibleButton mx_UserMenu_contextMenu_themeButton"
         role="button"
         tabindex="-1"
@@ -42,7 +42,7 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
       class="mx_IconizedContextMenu_optionList mx_IconizedContextMenu_optionList_notFirst"
     >
       <li
-        aria-label="notifications"
+        aria-label="Notifications"
         class="mx_AccessibleButton mx_IconizedContextMenu_item"
         role="menuitem"
         tabindex="0"
@@ -53,11 +53,11 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
         <span
           class="mx_IconizedContextMenu_label"
         >
-          notifications
+          Notifications
         </span>
       </li>
       <li
-        aria-label="room_settings"
+        aria-label="Security & Privacy"
         class="mx_AccessibleButton mx_IconizedContextMenu_item"
         role="menuitem"
         tabindex="-1"
@@ -68,11 +68,11 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
         <span
           class="mx_IconizedContextMenu_label"
         >
-          room_settings
+          Security & Privacy
         </span>
       </li>
       <li
-        aria-label="user_menu"
+        aria-label="All settings"
         class="mx_AccessibleButton mx_IconizedContextMenu_item"
         role="menuitem"
         tabindex="-1"
@@ -83,11 +83,11 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
         <span
           class="mx_IconizedContextMenu_label"
         >
-          user_menu
+          All settings
         </span>
       </li>
       <li
-        aria-label="common"
+        aria-label="Help"
         class="mx_AccessibleButton mx_IconizedContextMenu_item"
         role="menuitem"
         tabindex="-1"
@@ -98,11 +98,11 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
         <span
           class="mx_IconizedContextMenu_label"
         >
-          common
+          Help
         </span>
       </li>
       <li
-        aria-label="action"
+        aria-label="Sign out"
         class="mx_AccessibleButton mx_IconizedContextMenu_option_red mx_IconizedContextMenu_item"
         role="menuitem"
         tabindex="-1"
@@ -113,7 +113,7 @@ exports[`<UserMenu> <UserMenu> UI should render as expected 1`] = `
         <span
           class="mx_IconizedContextMenu_label"
         >
-          action
+          Sign out
         </span>
       </li>
     </div>

--- a/test/unit-tests/tchap/components/views/dialogs/__snapshots__/BugReportDialog-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/dialogs/__snapshots__/BugReportDialog-test.tsx.snap
@@ -33,19 +33,19 @@ exports[`<BugReportDialog> should render as expected 1`] = `
         >
           <p>
             <strong>
-              bug_reporting
+              Reminder: Your browser is unsupported, so your experience may be unpredictable.
             </strong>
           </p>
           <p>
-            bug_reporting
+            Debug logs contain application usage data including your username, the IDs or aliases of the rooms you have visited, which UI elements you last interacted with, and the usernames of other users. They do not contain messages.
           </p>
           <div
             class="mx_Field mx_Field_textarea mx_BugReportDialog_field_input"
           >
             <textarea
               id="mx_Field_1"
-              label="bug_reporting"
-              placeholder="bug_reporting"
+              label="Notes"
+              placeholder="If there is additional context that would help in analysing the issue, such as what you were doing at the time, room IDs, user IDs, etc., please include those things here."
               rows="5"
               type="text"
             >
@@ -54,7 +54,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
             <label
               for="mx_Field_1"
             >
-              bug_reporting
+              Notes
             </label>
           </div>
           <div
@@ -71,7 +71,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
                   data-testid="dialog-primary-button"
                   type="button"
                 >
-                  bug_reporting
+                  Send logs
                 </button>
               </span>
             </div>
@@ -93,14 +93,14 @@ exports[`<BugReportDialog> should render as expected 1`] = `
                   data-testid="dialog-primary-button"
                   type="button"
                 >
-                  bug_reporting
+                  Download logs
                 </button>
               </span>
             </div>
           </div>
         </div>
         <div
-          aria-label="dialog_close_label"
+          aria-label="Close dialog"
           class="mx_AccessibleButton mx_Dialog_cancelButton"
           role="button"
           tabindex="0"
@@ -142,19 +142,19 @@ exports[`<BugReportDialog> should render as expected 1`] = `
       >
         <p>
           <strong>
-            bug_reporting
+            Reminder: Your browser is unsupported, so your experience may be unpredictable.
           </strong>
         </p>
         <p>
-          bug_reporting
+          Debug logs contain application usage data including your username, the IDs or aliases of the rooms you have visited, which UI elements you last interacted with, and the usernames of other users. They do not contain messages.
         </p>
         <div
           class="mx_Field mx_Field_textarea mx_BugReportDialog_field_input"
         >
           <textarea
             id="mx_Field_1"
-            label="bug_reporting"
-            placeholder="bug_reporting"
+            label="Notes"
+            placeholder="If there is additional context that would help in analysing the issue, such as what you were doing at the time, room IDs, user IDs, etc., please include those things here."
             rows="5"
             type="text"
           >
@@ -163,7 +163,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
           <label
             for="mx_Field_1"
           >
-            bug_reporting
+            Notes
           </label>
         </div>
         <div
@@ -180,7 +180,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
                 data-testid="dialog-primary-button"
                 type="button"
               >
-                bug_reporting
+                Send logs
               </button>
             </span>
           </div>
@@ -202,14 +202,14 @@ exports[`<BugReportDialog> should render as expected 1`] = `
                 data-testid="dialog-primary-button"
                 type="button"
               >
-                bug_reporting
+                Download logs
               </button>
             </span>
           </div>
         </div>
       </div>
       <div
-        aria-label="dialog_close_label"
+        aria-label="Close dialog"
         class="mx_AccessibleButton mx_Dialog_cancelButton"
         role="button"
         tabindex="0"

--- a/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
+++ b/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
@@ -99,6 +99,11 @@ describe("RoomHeader", () => {
         jest.restoreAllMocks();
     });
 
+    it("should render as expected", async () => {
+        const { container } = getComponent();
+        expect(container).toMatchSnapshot();
+    });
+
     it("renders the room header", () => {
         const { container } = getComponent();
         expect(container).toHaveTextContent(ROOM_ID);

--- a/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
+++ b/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
@@ -1,13 +1,15 @@
 import React from "react";
-import { PendingEventOrdering, Room } from "matrix-js-sdk/src/matrix";
-import { screen, render, RenderOptions } from "@testing-library/react";
+import { KnownMembership, PendingEventOrdering, Room } from "matrix-js-sdk/src/matrix";
+import { screen, render, RenderOptions, getByLabelText, queryByLabelText } from "@testing-library/react";
 
-import { stubClient } from "~matrix-react-sdk/test/test-utils";
+import { mkRoomMember, stubClient } from "~matrix-react-sdk/test/test-utils";
 import RoomHeader from "~matrix-react-sdk/src/components/views/rooms/RoomHeader";
 import DMRoomMap from "~matrix-react-sdk/src/utils/DMRoomMap";
 import { MatrixClientPeg } from "~matrix-react-sdk/src/MatrixClientPeg";
 import MatrixClientContext from "~matrix-react-sdk/src/contexts/MatrixClientContext";
 import SdkConfig from "~matrix-react-sdk/src/SdkConfig";
+import SettingsStore from "~matrix-react-sdk/src/settings/SettingsStore";
+import { UIFeature } from "~matrix-react-sdk/src/settings/UIFeature";
 
 function getWrapper(): RenderOptions {
     return {
@@ -17,10 +19,33 @@ function getWrapper(): RenderOptions {
     };
 }
 
+/**
+ *
+ * @param count the number of users to create
+ */
+function mockRoomMembers(room: Room, count: number) {
+    const members = Array(count)
+        .fill(0)
+        .map((_, index) => ({
+            userId: `@user-${index}:example.org`,
+            name: `Member ${index}`,
+            rawDisplayName: `Member ${index}`,
+            roomId: room.roomId,
+            membership: KnownMembership.Join,
+            getAvatarUrl: () => `mxc://avatar.url/user-${index}.png`,
+            getMxcAvatarUrl: () => `mxc://avatar.url/user-${index}.png`,
+        }));
+
+    room.currentState.setJoinedMemberCount(members.length);
+    room.getJoinedMembers = jest.fn().mockReturnValue(members);
+}
+
 describe("RoomHeader", () => {
     let room: Room;
     const ROOM_ID = "!1:example.org";
     const featurethreadName: string = "feature_thread";
+    const featureVideoName: string = "feature_video_call";
+    const featureVideoGroupName: string = "feature_video_group_call";
     const homeserverName: string = "my.home.server";
 
     const addHomeserverToMockConfig = (homeservers: string[], feature: string) => {
@@ -32,11 +57,38 @@ describe("RoomHeader", () => {
 
     const getComponent = () => render(<RoomHeader room={room} />, getWrapper());
 
+    function mockDMRoom(memberCount: number = 2) {
+        mockRoomMembers(room, memberCount);
+        jest.spyOn(SettingsStore, "getValue").mockImplementation(() => false);
+        jest.spyOn(room.currentState, "mayClientSendStateEvent").mockReturnValue(false);
+        jest.spyOn(room, "getMember").mockReturnValue(mkRoomMember(room.roomId, "@alice:example.org"));
+
+        DMRoomMap.setShared({
+            getUserIdForRoomId: () => {
+                return "@alice:example.org";
+            },
+        } as unknown as DMRoomMap);
+    }
+
     beforeEach(async () => {
-        stubClient();
+        const mockClient = stubClient();
         room = new Room(ROOM_ID, MatrixClientPeg.get()!, "@alice:example.org", {
             pendingEventOrdering: PendingEventOrdering.Detached,
         });
+
+        jest.spyOn(mockClient, "getDomain").mockImplementation(() => homeserverName);
+        jest.spyOn(room, "isElementVideoRoom").mockReturnValue(false);
+        jest.spyOn(room, "isCallRoom").mockReturnValue(false);
+        jest.spyOn(room, "isSpaceRoom").mockReturnValue(false);
+        jest.spyOn(room, "getType").mockReturnValue(undefined);
+
+        // allow element calls
+        jest.spyOn(room.currentState, "mayClientSendStateEvent").mockReturnValue(true);
+        // activate the group and widget features
+        jest.spyOn(SettingsStore, "getValue").mockImplementation(
+            (feature) => feature === "feature_group_calls" || feature == UIFeature.Widgets,
+        );
+
         DMRoomMap.setShared({
             getUserIdForRoomId: jest.fn(),
         } as unknown as DMRoomMap);
@@ -52,19 +104,69 @@ describe("RoomHeader", () => {
         expect(container).toHaveTextContent(ROOM_ID);
     });
 
-    it("display well the thread button when feature is activated", async () => {
-        addHomeserverToMockConfig([homeserverName], featurethreadName);
+    it("display well the thread button when feature is activated", () => {
+        addHomeserverToMockConfig(["*"], featurethreadName);
 
         getComponent();
 
-        expect(screen.queryByTestId("room-header-thread-button")).toBeInTheDocument;
+        expect(screen.queryByRole("button", { name: "Threads" })).toBeInTheDocument();
     });
 
-    it("hides the thread button when feature is deactivated", async () => {
+    it("hides the thread button when feature is deactivated", () => {
         addHomeserverToMockConfig(["other.homeserver"], featurethreadName);
 
         getComponent();
 
-        expect(screen.queryByTestId("room-header-thread-button")).not.toBeInTheDocument;
+        expect(screen.queryByRole("button", { name: "Threads" })).not.toBeInTheDocument();
+    });
+
+    // For 1 to 1 video call
+    it("display well the video button when feature is activated for 1v1 call", () => {
+        addHomeserverToMockConfig([homeserverName], featureVideoName);
+        mockDMRoom();
+
+        const { container } = getComponent();
+
+        expect(queryByLabelText(container, "Video call")).toBeInTheDocument();
+    });
+
+    it("hides the video button when feature is deactivated for 1v1 call", () => {
+        addHomeserverToMockConfig(["other.homeserver"], featureVideoName);
+        mockDMRoom();
+
+        const { container } = getComponent();
+
+        expect(queryByLabelText(container, "Video call")).toBeNull();
+    });
+
+    it("hides the video button when feature is activated but is not a direct message room", () => {
+        addHomeserverToMockConfig([homeserverName], featureVideoName);
+
+        mockDMRoom(4);
+
+        const { container } = getComponent();
+
+        expect(queryByLabelText(container, "Video call")).toBeNull();
+    });
+
+    //  for video group element call button
+    it("display well the video group button when feature is activated", () => {
+        addHomeserverToMockConfig([homeserverName], featureVideoGroupName);
+
+        mockRoomMembers(room, 4);
+
+        const { container } = getComponent();
+
+        expect(getByLabelText(container, "Video call")).toBeInTheDocument();
+    });
+
+    it("hides the video group when feature is deactivated", () => {
+        addHomeserverToMockConfig(["other.homeserver"], featureVideoGroupName);
+
+        mockRoomMembers(room, 4);
+
+        const { container } = getComponent();
+
+        expect(queryByLabelText(container, "Video call")).toBeNull();
     });
 });

--- a/test/unit-tests/tchap/components/views/rooms/__snapshots__/RoomHeaders-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/rooms/__snapshots__/RoomHeaders-test.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RoomHeader should render as expected 1`] = `
+<div>
+  <header
+    class="mx_Flex mx_RoomHeader light-panel"
+    style="--mx-flex-display: flex; --mx-flex-direction: row; --mx-flex-align: center; --mx-flex-justify: start; --mx-flex-gap: var(--cpd-space-3x);"
+  >
+    <div
+      class="mx_DecoratedRoomAvatar mx_DecoratedRoomAvatar_cutout"
+    >
+      <div
+        class="mx_DecoratedRoomAvatar_positionedParent"
+      >
+        <span
+          class="_avatar_mcap2_17 mx_BaseAvatar _avatar-imageless_mcap2_61"
+          data-color="3"
+          data-testid="avatar-img"
+          data-type="round"
+          role="presentation"
+          style="--cpd-avatar-size: 40px;"
+        >
+          !
+        </span>
+        <div
+          class="mx_DecoratedRoomAvatar_icon mx_DecoratedRoomAvatar_icon_forum"
+          tabindex="0"
+        />
+      </div>
+       
+    </div>
+    <button
+      aria-label="Room info"
+      class="mx_RoomHeader_infoWrapper"
+      tabindex="0"
+    >
+      <div
+        class="mx_Box mx_RoomHeader_info mx_Box--flex"
+        style="--mx-box-flex: 1;"
+      >
+        <div
+          aria-level="1"
+          class="_typography_yh5dq_162 _font-body-lg-semibold_yh5dq_83 mx_RoomHeader_heading"
+          dir="auto"
+          role="heading"
+        >
+          <span
+            class="mx_RoomHeader_truncated mx_lineClamp"
+          >
+            !1:example.org
+          </span>
+        </div>
+      </div>
+    </button>
+    <div
+      class="mx_Flex"
+      style="--mx-flex-display: flex; --mx-flex-direction: row; --mx-flex-align: center; --mx-flex-justify: start; --mx-flex-gap: var(--cpd-space-2x);"
+    >
+      <button
+        aria-label="Room info"
+        class="_icon-button_bh2qc_17"
+        role="button"
+        style="--cpd-icon-button-size: 32px;"
+        tabindex="0"
+      >
+        <div
+          class="_indicator-icon_133tf_26"
+          style="--cpd-icon-button-size: 100%;"
+        >
+          <div />
+        </div>
+      </button>
+    </div>
+    <div
+      class="_typography_yh5dq_162 _font-body-sm-medium_yh5dq_50"
+    >
+      <div
+        aria-label="0 members"
+        class="mx_AccessibleButton mx_FacePile"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="_stacked-avatars_mcap2_111"
+        />
+        0
+      </div>
+    </div>
+  </header>
+</div>
+`;

--- a/test/unit-tests/tchap/components/views/spaces/SpacePanel-test.tsx
+++ b/test/unit-tests/tchap/components/views/spaces/SpacePanel-test.tsx
@@ -8,12 +8,16 @@ import { SdkContextClass } from "~matrix-react-sdk/src/contexts/SDKContext";
 import UnwrappedSpacePanel from "~matrix-react-sdk/src/components/views/spaces/SpacePanel";
 import SdkConfig, { ConfigOptions } from "~tchap-web/linked-dependencies/matrix-react-sdk/src/SdkConfig";
 
+jest.mock("~tchap-web/src/tchap/components/views/common/Gaufre.tsx", () => {
+    return jest.fn((props: { isPanelCollapsed: boolean }) => <div>Mocked ChildComponent with text: </div>);
+});
+
 describe("<SpacePanel />", () => {
     const SpacePanel = wrapInSdkContext(wrapInMatrixClientContext(UnwrappedSpacePanel), SdkContextClass.instance);
-    const featureName: string = "feature_thread";
+    const featureThreadName: string = "feature_thread";
     const homeserverName: string = "my.home.server";
 
-    const addHomeserverToMockConfig = (homeservers: string[]) => {
+    const addHomeserverToMockConfig = (homeservers: string[], featureName: string) => {
         // mock SdkConfig.get("tchap_features")
         const config: ConfigOptions = { tchap_features: {} };
         config.tchap_features[featureName] = homeservers;
@@ -29,17 +33,25 @@ describe("<SpacePanel />", () => {
 
     afterEach(() => {
         cleanup();
+        SdkConfig.reset();
+        jest.restoreAllMocks();
+    });
+
+    it("should render as expected", async () => {
+        const { container } = renderSpacePanel();
+
+        expect(container).toMatchSnapshot();
     });
 
     it("returns true when the the homeserver include thread feature", () => {
-        addHomeserverToMockConfig([homeserverName]);
+        addHomeserverToMockConfig([homeserverName], featureThreadName);
         const { container } = renderSpacePanel();
 
         expect(container.getElementsByClassName("mx_ThreadsActivityCentre_container").length).toBe(1);
     });
 
     it("returns false when the the homeserver doesnt include thread feature", async () => {
-        addHomeserverToMockConfig(["other.homeserver"]);
+        addHomeserverToMockConfig(["other.homeserver"], featureThreadName);
         const { container } = renderSpacePanel();
 
         expect(container.getElementsByClassName("mx_ThreadsActivityCentre_container").length).toBe(0);

--- a/test/unit-tests/tchap/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/spaces/__snapshots__/SpacePanel-test.tsx.snap
@@ -1,0 +1,92 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SpacePanel /> should render as expected 1`] = `
+<div>
+  <nav
+    aria-label="Spaces"
+    class="mx_SpacePanel collapsed"
+  >
+    <div
+      class="mx_UserMenu"
+    >
+      <div
+        aria-expanded="false"
+        aria-haspopup="true"
+        aria-label="User menu"
+        class="mx_AccessibleButton mx_UserMenu_contextMenuButton"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="mx_UserMenu_userAvatar"
+        >
+          <span
+            class="_avatar_mcap2_17 mx_BaseAvatar mx_UserMenu_userAvatar_BaseAvatar _avatar-imageless_mcap2_61"
+            data-color="2"
+            data-testid="avatar-img"
+            data-type="round"
+            role="presentation"
+            style="--cpd-avatar-size: 32px;"
+          >
+            u
+          </span>
+        </div>
+      </div>
+      <div
+        aria-label="Expand"
+        class="mx_AccessibleButton mx_SpacePanel_toggleCollapse"
+        role="button"
+        tabindex="0"
+      />
+    </div>
+    <ul
+      aria-label="Spaces"
+      class="mx_AutoHideScrollbar mx_SpaceTreeLevel"
+      data-rbd-droppable-context-id="0"
+      data-rbd-droppable-id="top-level-spaces"
+      role="tree"
+      tabindex="-1"
+    >
+      <li
+        aria-selected="false"
+        class="mx_SpaceItem mx_SpaceItem_new collapsed"
+        role="treeitem"
+      >
+        <div
+          aria-label="Create a space"
+          class="mx_AccessibleButton mx_SpaceButton mx_SpaceButton_new mx_SpaceButton_narrow"
+          data-testid="create-space-button"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="mx_SpaceButton_selectionWrapper"
+          >
+            <div
+              class="mx_SpaceButton_avatarWrapper"
+            >
+              <div
+                class="mx_SpaceButton_avatarPlaceholder"
+              >
+                <div
+                  class="mx_SpaceButton_icon"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </li>
+    </ul>
+    <div
+      aria-expanded="false"
+      aria-label="Help"
+      class="mx_AccessibleButton mx_QuickSettingsButton tc_sidebar_quick_faq"
+      role="button"
+      tabindex="0"
+    />
+    <div>
+      Mocked ChildComponent with text: 
+    </div>
+  </nav>
+</div>
+`;


### PR DESCRIPTION
https://github.com/tchapgouv/tchap-web-v4/issues/1087

## Changes 
- New tchap feature flag "feature_video_group_call"
- Updated test for room header
- Test config for translations
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [x] Tests written for new code (and old code if feasible).
-   [x] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [x] Linter and other CI checks pass.
-   [x] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
