### PR TITLE
fix(theme): add github md css file in theme import

### DIFF
--- a/res/themes/tchap-dark/css/tchap-dark.pcss
+++ b/res/themes/tchap-dark/css/tchap-dark.pcss
@@ -10,3 +10,4 @@
 @import "../../../../node_modules/matrix-react-sdk/res/css/_components.pcss";
 @import "../../tchap-common/css/_tchap_custom.pcss"; /* import override from the common folder */
 @import url("highlight.js/styles/atom-one-light.css");
+@import url("github-markdown-css/github-markdown-dark.css");

--- a/res/themes/tchap-light/css/tchap-light.pcss
+++ b/res/themes/tchap-light/css/tchap-light.pcss
@@ -9,3 +9,4 @@
 @import url("highlight.js/styles/atom-one-light.css"); /* taken from matrix theme, don't know what it is */
 @import "../../tchap-common/css/_tchap_custom.pcss"; /* import override from the common folder */
 @import "_tchap_custom.pcss";
+@import url("github-markdown-css/github-markdown-light.css");


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1132

## TODO 
- most of the import of the theme files are obsolète since the switch to compound-web. Need to clean up

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] Sign-off given on the changes (see [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md)).
