### PR TITLE
TCHAP: add posthog analytics

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -126,5 +126,9 @@
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json",
     "element_call": {
         "url": "https://element-call.tchap.incubateur.net/"
+    },
+    "posthog": {
+        "project_api_key": "phc_FFa4pkvmuWjF9nZOMmYJWUXMibuYnCnPyf3DqPGZs4L",
+        "api_host": "https://posthogdev.tchap.incubateur.net"
     }
 }

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -117,5 +117,9 @@
     "tchap_sso_flow": {
         "isActive": true
     },
-    "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
+    "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json",
+    "posthog": {
+        "project_api_key": "phc_FFa4pkvmuWjF9nZOMmYJWUXMibuYnCnPyf3DqPGZs4L",
+        "api_host": "https://posthogdev.tchap.incubateur.net"
+    }
 }

--- a/config.prod.json
+++ b/config.prod.json
@@ -204,5 +204,9 @@
     "tchap_sso_flow": {
         "isActive": false
     },
-    "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json"
+    "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json",
+    "posthog": {
+        "project_api_key": "phc_FFa4pkvmuWjF9nZOMmYJWUXMibuYnCnPyf3DqPGZs4L",
+        "api_host": "https://posthogdev.tchap.incubateur.net"
+    }
 }

--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -139,5 +139,12 @@
             "src/components/views/spaces/SpaceCreateMenu.tsx",
             "src/createRoom.ts"
         ]
+    },
+    "metrics-call": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1184",
+        "files": [
+            "src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx",
+            "src/LegacyCallHandler.tsx"
+        ]
     }
 }

--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -96,3 +96,8 @@
     mask-image: url("$(res)/img/e2e/verified.svg");
     background-color: var(--confirmation-color);
 }
+
+/* For analytics modal, using tchap icon */
+.mx_AnalyticsLearnMoreDialog .mx_AnalyticsLearnMore_image_holder {
+    background-image: url("$(res)/themes/tchap/img/logos/tchap-logo.svg");
+}

--- a/src/LegacyCallHandler.tsx
+++ b/src/LegacyCallHandler.tsx
@@ -969,6 +969,9 @@ export default class LegacyCallHandler extends EventEmitter {
 
         call.answer();
         this.setActiveCallRoomId(roomId);
+        /** :TCHAP: metrics-call **/
+        TchapPosthog.instance.trackCallStart(call);
+        /** end :TCHAP: **/
         dis.dispatch<ViewRoomPayload>({
             action: Action.ViewRoom,
             room_id: roomId,

--- a/src/LegacyCallHandler.tsx
+++ b/src/LegacyCallHandler.tsx
@@ -60,6 +60,7 @@ import { showCantStartACallDialog } from "./voice-broadcast/utils/showCantStartA
 import { isNotNull } from "./Typeguards";
 import { BackgroundAudio } from "./audio/BackgroundAudio";
 import { Jitsi } from "./widgets/Jitsi.ts";
+import TchapPosthog from "./tchap/util/TchapPosthog.ts";
 
 export const PROTOCOL_PSTN = "m.protocol.pstn";
 export const PROTOCOL_PSTN_PREFIXED = "im.vector.protocol.pstn";
@@ -618,6 +619,9 @@ export default class LegacyCallHandler extends EventEmitter {
                 if (isNotNull(mappedRoomId)) {
                     this.removeCallForRoom(mappedRoomId);
                 }
+                /** :TCHAP: metrics-call **/
+                TchapPosthog.instance.trackCallEnded(call);
+                /** end :TCHAP: **/
 
                 if (oldState === CallState.InviteSent && call.hangupParty === CallParty.Remote) {
                     this.play(AudioID.Busy);
@@ -842,12 +846,18 @@ export default class LegacyCallHandler extends EventEmitter {
 
         this.setActiveCallRoomId(roomId);
 
+        /** :TCHAP: metrics-call **/
+        TchapPosthog.instance.trackCallStart(call);
+        /** end :TCHAP: **/
         if (type === CallType.Voice) {
             call.placeVoiceCall();
         } else if (type === "video") {
             call.placeVideoCall();
         } else {
             logger.error("Unknown conf call type: " + type);
+            /** :TCHAP: metrics-call **/
+            TchapPosthog.instance.trackCallEnded(call);
+            /** end :TCHAP: **/
         }
     }
 

--- a/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/SecurityUserSettingsTab.tsx
@@ -339,7 +339,7 @@ export default class SecurityUserSettingsTab extends React.Component<IProps, ISt
             };
             privacySection = (
                 <SettingsSection heading={_t("common|privacy")}>
-                    <DiscoverySettings />
+                    {/* <DiscoverySettings /> :TCHAP: metrics-call we remove the discovery settings that appear when posthog is enabled */}
                     <SettingsSubsection
                         heading={_t("common|analytics")}
                         description={_t("settings|security|analytics_description")}

--- a/src/tchap/util/TchapPosthog.ts
+++ b/src/tchap/util/TchapPosthog.ts
@@ -1,0 +1,58 @@
+import { MatrixCall } from "matrix-js-sdk/src/matrix";
+import { CallDirection, CallType } from "matrix-js-sdk/src/webrtc/call";
+import { PosthogAnalytics } from "~tchap-web/src/PosthogAnalytics";
+import { CallEnded as CallEndedEvent } from "@matrix-org/analytics-events/types/typescript/CallEnded";
+import { CallStarted as CallStartEvent } from "@matrix-org/analytics-events/types/typescript/CallStarted";
+import PerformanceMonitor from "~tchap-web/src/performance";
+
+export default class TchapPosthog {
+
+    private static internalInstance: TchapPosthog;
+
+    public static get instance(): TchapPosthog {
+        if (!TchapPosthog.internalInstance) {
+            TchapPosthog.internalInstance = new TchapPosthog();
+        }
+        return TchapPosthog.internalInstance;
+    }
+
+
+    async trackCallStart(call: MatrixCall): Promise<void> {
+        this.startTimer(call.callId);
+
+        PosthogAnalytics.instance.trackEvent<CallStartEvent>({
+            eventName: "CallStarted",
+            placed: true,
+            isVideo: call.type == CallType.Video,
+            numParticipants: 2,
+        });
+    }
+
+    async trackCallEnded(call: MatrixCall): Promise<void> {
+        const durationMs = this.stopTimer(call.callId);
+
+        PosthogAnalytics.instance.trackEvent<CallEndedEvent>({
+            eventName: "CallEnded",
+            placed: call.direction! == CallDirection.Outbound,
+            isVideo: call.type == CallType.Video,
+            durationMs: durationMs,
+            numParticipants: 2,
+        });
+    }
+
+    private startTimer(id : string): void {
+        PerformanceMonitor.instance.start(id);
+    }
+
+    private stopTimer(id: string): number {
+        const perfMonitor = PerformanceMonitor.instance;
+
+        perfMonitor.stop(id);
+
+        const entries = perfMonitor.getEntries({ name: id });
+
+        const measurement = entries.pop();
+
+        return measurement ? measurement.duration : 0;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1184 
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1088

Copied from https://github.com/tchapgouv/tchap-web-v4/pull/1089 : 
- [x] Scenario 1 : appel de user A vers user B - user A doit envoyer un event `CallStarted` lors de l'emission d'un appel (au démarrage de l'appel)
- [x] Scenario 2 : appel de user A vers user B - user B doit envoyer un event `CallStarted` lors de la réception et acceptation d'un appel (au démarrage de l'appel)
- [x] Scenario 3 : appel de user A vers user B - user A doit envoyer un event `CallEnded` lors de la fin d'appel lorsque user A termine l'appel
- [x] Scenario 4 : appel de user A vers user B - user B doit envoyer un event `CallEnded` lors de la fin d'appel lorsque user A termine l'appel

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

-   [ ] Tests written for new code (and old code if feasible).
-   [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
-   [ ] Linter and other CI checks pass.
-   [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
