### PR TITLE
TCHAP: hide history settings since selection for encrypted rooms

### DIFF
--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -161,5 +161,11 @@
         "files": [
             "src/vector/init.tsx"
         ]
+    },
+    "hide-history-setting-since-selection": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1160",
+        "files": [
+            "src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx"
+        ]
     }
 }

--- a/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx
@@ -380,6 +380,12 @@ export default class SecurityRoomSettingsTab extends React.Component<IProps, ISt
             });
         }
 
+        // :TCHAP: hide-history-setting-since-selection
+        if (this.state.encrypted) {
+            // we remove HistoryVisibility.Shared, its not working on encrypted rooms
+            options.shift();
+        }
+        // end :TCHAP:
         const description = _t("room_settings|security|history_visibility_warning");
 
         return (

--- a/test/unit-tests/tchap/components/views/settings/SecurityRoomSettingsTab-test.tsx
+++ b/test/unit-tests/tchap/components/views/settings/SecurityRoomSettingsTab-test.tsx
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 New Vector Ltd.
+Copyright 2023 The Matrix.org Foundation C.I.C.
+
+SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only
+Please see LICENSE files in the repository root for full details.
+*/
+
+import React from "react";
+import { render, screen, waitFor } from "jest-matrix-react";
+import { EventType, GuestAccess, HistoryVisibility, JoinRule, MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
+import { mocked } from "jest-mock";
+
+import SecurityRoomSettingsTab from "~tchap-web/src/components/views/settings/tabs/room/SecurityRoomSettingsTab";
+import MatrixClientContext from "~tchap-web/src/contexts/MatrixClientContext";
+import SettingsStore from "~tchap-web/src/settings/SettingsStore";
+import { clearAllModals, stubClient } from "~tchap-web/test/test-utils";
+import { filterBoolean } from "~tchap-web/src/utils/arrays";
+
+describe("<SecurityRoomSettingsTab />", () => {
+    const userId = "@alice:server.org";
+    const client = mocked(stubClient());
+    const roomId = "!room:server.org";
+
+    const getComponent = (room: Room, closeSettingsFn = jest.fn()) =>
+        render(<SecurityRoomSettingsTab room={room} closeSettingsFn={closeSettingsFn} />, {
+            wrapper: ({ children }) => (
+                <MatrixClientContext.Provider value={client}>{children}</MatrixClientContext.Provider>
+            ),
+        });
+
+    const setRoomStateEvents = (
+        room: Room,
+        joinRule?: JoinRule,
+        guestAccess?: GuestAccess,
+        history?: HistoryVisibility,
+    ): void => {
+        const events = filterBoolean<MatrixEvent>([
+            new MatrixEvent({
+                type: EventType.RoomCreate,
+                content: { version: "test" },
+                sender: userId,
+                state_key: "",
+                room_id: room.roomId,
+            }),
+            guestAccess &&
+                new MatrixEvent({
+                    type: EventType.RoomGuestAccess,
+                    content: { guest_access: guestAccess },
+                    sender: userId,
+                    state_key: "",
+                    room_id: room.roomId,
+                }),
+            history &&
+                new MatrixEvent({
+                    type: EventType.RoomHistoryVisibility,
+                    content: { history_visibility: history },
+                    sender: userId,
+                    state_key: "",
+                    room_id: room.roomId,
+                }),
+            joinRule &&
+                new MatrixEvent({
+                    type: EventType.RoomJoinRules,
+                    content: { join_rule: joinRule },
+                    sender: userId,
+                    state_key: "",
+                    room_id: room.roomId,
+                }),
+        ]);
+
+        room.currentState.setStateEvents(events);
+    };
+
+    beforeEach(async () => {
+        client.sendStateEvent.mockReset().mockResolvedValue({ event_id: "test" });
+        jest.spyOn(client.getCrypto()!, "isEncryptionEnabledInRoom").mockResolvedValue(false);
+        client.getClientWellKnown.mockReturnValue(undefined);
+        jest.spyOn(SettingsStore, "getValue").mockRestore();
+
+        await clearAllModals();
+    });
+
+    describe("history visibility", () => {
+        it("does not render shared readable option when room is encrypted", async () => {
+            const room = new Room(roomId, client, userId);
+            jest.spyOn(client.getCrypto()!, "isEncryptionEnabledInRoom").mockResolvedValue(true);
+            setRoomStateEvents(room);
+
+            getComponent(room);
+
+            await waitFor(() => expect(screen.queryByDisplayValue(HistoryVisibility.Shared)).not.toBeInTheDocument());
+        });
+
+        it("uses shared as default history visibility when no state event found", () => {
+            const room = new Room(roomId, client, userId);
+            setRoomStateEvents(room);
+
+            getComponent(room);
+
+            expect(screen.getByText("Who can read history?").parentElement).toMatchSnapshot();
+            expect(screen.getByDisplayValue(HistoryVisibility.Shared)).toBeChecked();
+        });
+    });
+});

--- a/test/unit-tests/tchap/components/views/settings/__snapshots__/SecurityRoomSettingsTab-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/settings/__snapshots__/SecurityRoomSettingsTab-test.tsx.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<SecurityRoomSettingsTab /> history visibility uses shared as default history visibility when no state event found 1`] = `
+<fieldset
+  class="mx_SettingsFieldset"
+>
+  <legend
+    class="mx_SettingsFieldset_legend"
+  >
+    Who can read history?
+  </legend>
+  <div
+    class="mx_SettingsFieldset_description"
+  >
+    <div
+      class="mx_SettingsSubsection_text"
+    >
+      Changes to who can read history will only apply to future messages in this room. The visibility of existing history will be unchanged.
+    </div>
+  </div>
+  <div
+    class="mx_SettingsFieldset_content"
+  >
+    <label
+      class="mx_StyledRadioButton mx_StyledRadioButton_enabled"
+    >
+      <input
+        id="historyVis-world_readable"
+        name="historyVis"
+        type="radio"
+        value="world_readable"
+      />
+      <div>
+        <div />
+      </div>
+      <div
+        class="mx_StyledRadioButton_content"
+      >
+        Anyone
+      </div>
+      <div
+        class="mx_StyledRadioButton_spacer"
+      />
+    </label>
+    <label
+      class="mx_StyledRadioButton mx_StyledRadioButton_enabled mx_StyledRadioButton_checked"
+    >
+      <input
+        checked=""
+        id="historyVis-shared"
+        name="historyVis"
+        type="radio"
+        value="shared"
+      />
+      <div>
+        <div />
+      </div>
+      <div
+        class="mx_StyledRadioButton_content"
+      >
+        Members only (since the point in time of selecting this option)
+      </div>
+      <div
+        class="mx_StyledRadioButton_spacer"
+      />
+    </label>
+    <label
+      class="mx_StyledRadioButton mx_StyledRadioButton_enabled"
+    >
+      <input
+        id="historyVis-invited"
+        name="historyVis"
+        type="radio"
+        value="invited"
+      />
+      <div>
+        <div />
+      </div>
+      <div
+        class="mx_StyledRadioButton_content"
+      >
+        Members only (since they were invited)
+      </div>
+      <div
+        class="mx_StyledRadioButton_spacer"
+      />
+    </label>
+    <label
+      class="mx_StyledRadioButton mx_StyledRadioButton_enabled"
+    >
+      <input
+        id="historyVis-joined"
+        name="historyVis"
+        type="radio"
+        value="joined"
+      />
+      <div>
+        <div />
+      </div>
+      <div
+        class="mx_StyledRadioButton_content"
+      >
+        Members only (since they joined)
+      </div>
+      <div
+        class="mx_StyledRadioButton_spacer"
+      />
+    </label>
+  </div>
+</fieldset>
+`;


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1160

## Changes 
- Encrypted room 
![image](https://github.com/user-attachments/assets/374653b8-6a2a-4599-a510-5118d723fa7f)

- public room 
![image](https://github.com/user-attachments/assets/52f58331-8055-4b56-be7b-2548e676df5e)
