### PR TITLE
add base url for dev env

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -27,7 +27,7 @@
     "disable_login_language_selector": false,
     "disable_3pid_login": false,
     "brand": "Tchap",
-    "bug_report_endpoint_url": "/bugreports/submit",
+    "bug_report_endpoint_url": "https://matrix.dev01.tchap.incubateur.net/bugreports/submit",
     "uisi_autorageshake_app": "element-auto-uisi",
     "default_country_code": "FR",
     "show_labs_settings": false,


### PR DESCRIPTION
Fix configuration on dev to use rageshake

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
