### PR TITLE
Reput legacy olm package in webpack conf

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -682,6 +682,8 @@ module.exports = (env, argv) => {
                     "res/welcome.html",
                     // :TCHAP: sso-agentconnect-flow
                     "res/welcome_sso.html",
+                    // :TCHAP: legacy_olm TODO: remove all when content scanner will be updated to use rust crypto
+                    "node_modules/@matrix-org/olm/olm_legacy.js",
                     // end :TCHAP:
                     { from: "welcome/**", context: path.resolve(__dirname, "res") },
                     { from: "themes/**", context: path.resolve(__dirname, "res") },


### PR DESCRIPTION
In tchap we still use the legacy olm package because the content scanner still need it .
Will need to be remove when the content scanner will be updated to use rust crypto. In this case, we can remove everything related to legacy olm.

This line in webpack conf includes the olm_legacy file in case the package was not correctly loaded via webssembly. It is only used as a fallback. https://github.com/tchapgouv/tchap-web-v4/blob/8e2610e379cf1f7ecc126ab9fcd48d0879fb71f8/src/vector/init.tsx#L67

