### PR TITLE
Harmonize proconnect button

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -848,7 +848,7 @@
     },
     "auth|proconnect|button_title": {
         "en": "Login with <br/><b>ProConnect </b>",
-        "fr": "Se connecter avec <br/><b>ProConnect </b>"
+        "fr": "S'identifier avec <br/><b>ProConnect </b>"
     },
     "auth|proconnect|continue": {
         "en": "Continue with ProConnect",

--- a/res/welcome_sso.html
+++ b/res/welcome_sso.html
@@ -237,7 +237,8 @@ we don't have an account and should hide them. No account == no guest account ei
     }
 
     .tc_Button_iconPC {
-        background-image: url("welcome/images/proconnect.svg");   
+        background-image: url("welcome/images/proconnect.svg");
+        background-position-x: 40px;
     }
 
     .tc_paragraph a {

--- a/src/tchap/components/views/sso/ProconnectButton.tsx
+++ b/src/tchap/components/views/sso/ProconnectButton.tsx
@@ -8,7 +8,17 @@ export default function ProconnectButton(): JSX.Element {
     return (
         <div className="tc_pronnect">
             <a href="#/email-precheck-sso" className="tc_ButtonParent tc_ButtonProconnect tc_Button_iconPC">
-                <div>{_t("auth|proconnect|email_title")}</div>
+                <div>{_t("auth|proconnect|button_title", 
+                    {},
+                    {
+                        b: (sub) => (
+                            <span style={{fontWeight: "bold"}}>
+                                {sub}
+                            </span>
+                        ),
+                        br: () => (<></>)
+                    })}
+                </div>
             </a>
         </div>
     );


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1241

## Changes 
- wording
- styling


For the login and register page, the button were kept on one line because there is lot of width for them

![image](https://github.com/user-attachments/assets/aa0765f2-c7ea-4795-8671-a7bb07172fec)

![image](https://github.com/user-attachments/assets/dbd212df-6edf-4f9b-b0c2-21243858f01d)

![image](https://github.com/user-attachments/assets/81d0ff31-c63e-46c8-8fce-7211e74e49e2)

![image](https://github.com/user-attachments/assets/94f88653-83bb-4b15-9863-df0409fd18ae)

