### PR TITLE
Simplify start_url in PWA

### DIFF
--- a/res/manifest.json
+++ b/res/manifest.json
@@ -3,7 +3,7 @@
     "short_name": "Tchap",
     "display": "standalone",
     "theme_color": "#162d58",
-    "start_url": "index.html",
+    "start_url": "/",
     "icons": [
         {
             "src": "/vector-icons/44.png",


### PR DESCRIPTION
Problem with sso redirection and Tchap WAF: 
https://github.com/tchapgouv/tchap-web-v4/issues/1247#issuecomment-2696786006

steps : 
- install PWA
- url should be : https://whateverdomain/
- close, reopen PWA
- url must be : https://whateverdomain/


Before : 
- close, reopen PWA
- url was : https://whateverdomain/index.html





<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
