### PR TITLE
TCHAP: add tchap posthog tracking interaction type

### DIFF
--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -199,5 +199,12 @@
         "files": [
             "src/components/views/spaces/threads-activity-centre/ThreadsActivityCentreButton.tsx"
         ]
+    },
+    "mail-signature": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1254",
+        "files": [
+            "src/tchap/components/views/settings/tabs/user/TchapMailSignature.tsx",
+            "src/PosthogTrackers.ts"
+        ]
     }
 }

--- a/src/PosthogTrackers.ts
+++ b/src/PosthogTrackers.ts
@@ -18,6 +18,15 @@ import { PosthogAnalytics } from "./PosthogAnalytics";
 export type ScreenName = ScreenEvent["$current_url"];
 export type InteractionName = InteractionEvent["name"];
 
+// :TCHAP: mail-signature
+// Extend the interface using declaration merging
+export type TchapInteractionName = 
+  | "WebTchapMailSignatureButton" 
+  | InteractionEvent['name'];
+
+export type TchapScreenName = "EmailPrecheckSso" | ScreenName;
+// end :TCHAP:
+
 const notLoggedInMap: Record<Exclude<Views, Views.LOGGED_IN>, ScreenName> = {
     [Views.LOADING]: "Loading",
     [Views.CONFIRM_LOCK_THEFT]: "ConfirmStartup",
@@ -30,6 +39,7 @@ const notLoggedInMap: Record<Exclude<Views, Views.LOGGED_IN>, ScreenName> = {
     [Views.E2E_SETUP]: "E2ESetup",
     [Views.SOFT_LOGOUT]: "SoftLogout",
     [Views.LOCK_STOLEN]: "SessionLockStolen",
+    [Views.EMAIL_PRECHECK_SSO]: "EmailPrecheckSso" as ScreenName // :TCHAP:
 };
 
 const loggedInPageTypeMap: Record<PageType, ScreenName> = {

--- a/src/tchap/components/views/settings/tabs/user/TchapMailSignature.tsx
+++ b/src/tchap/components/views/settings/tabs/user/TchapMailSignature.tsx
@@ -3,6 +3,7 @@ import { SettingsSubsection, SettingsSubsectionText } from '~tchap-web/src/compo
 import { _t } from "~tchap-web/src/languageHandler";
 import CopyableText from '~tchap-web/src/components/views/elements/CopyableText';
 import TchapUrls from '~tchap-web/src/tchap/util/TchapUrls';
+import PosthogTrackers, { InteractionName } from '~tchap-web/src/PosthogTrackers';
 
 interface TchapMailSignatureProps {
     userPermalink: string
@@ -44,11 +45,15 @@ export const generateSignatureHtml = (userPermalink: string): string => {
     `;
 };
 
+
 /**
  * A copyable mail signature html bloc to add in emails
  */
 const TchapMailSignature: React.FC<TchapMailSignatureProps> = (props) => {
-    const signatureHtml = generateSignatureHtml(props.userPermalink);
+    const signatureHtmlCopy = () => {
+        PosthogTrackers.trackInteraction("WebTchapMailSignatureButton" as InteractionName);
+        return generateSignatureHtml(props.userPermalink);
+    }
 
     return <SettingsSubsection
             heading={_t("settings|general|mail_signature")}
@@ -67,8 +72,8 @@ const TchapMailSignature: React.FC<TchapMailSignatureProps> = (props) => {
                         })}
                     </SettingsSubsectionText>
                 </div>
-                <CopyableText getTextToCopy={() => signatureHtml} aria-labelledby={"mail-signature"}>
-                    <div dangerouslySetInnerHTML={{ __html: signatureHtml }} />
+                <CopyableText getTextToCopy={signatureHtmlCopy} aria-labelledby={"mail-signature"}>
+                    <div dangerouslySetInnerHTML={{ __html: generateSignatureHtml(props.userPermalink) }} />
                 </CopyableText>
             </SettingsSubsection>
 }


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1254

## Description
It is reusing [matrix analytics event](https://matrix-org.github.io/matrix-analytics-events/) Interaction event. A name event has been added to match the click on the copy of the mail signature. WebTchapMailSignatureButton

## changes
- Add tchap Posthog interaction tracking
- Extends existing interactionEvent to add tchap events
- The screen name for email_precheck_sso was added to make the typing system happy, but was not necessary