### PR TITLE
TCHAP: github workflow update upload-artifact used in build

### DIFF
--- a/.github/workflows/tchap_build.yml
+++ b/.github/workflows/tchap_build.yml
@@ -37,7 +37,7 @@ jobs:
               run: "yarn build"
 
             - name: Upload build in artifact
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: devbuild # because we used the dev config file
                   path: webapp


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1186