### PR TITLE
TCHAP(mail): signature image as png

### DIFF
--- a/res/themes/tchap-light/css/_tchap_custom_vars.pcss
+++ b/res/themes/tchap-light/css/_tchap_custom_vars.pcss
@@ -60,4 +60,5 @@ body {
 
     /* element green to tchap blue */
     --cpd-color-icon-accent-primary: var(--accent);
+    --cpd-color-text-action-accent: var(--accent);
 }

--- a/src/tchap/components/views/settings/tabs/user/TchapMailSignature.tsx
+++ b/src/tchap/components/views/settings/tabs/user/TchapMailSignature.tsx
@@ -21,7 +21,7 @@ export const generateSignatureHtml = (userPermalink: string): string => {
                     <table cellpadding="0" style="border-collapse:collapse;">
                         <tr>
                             <td valign="top" style="margin:0px;padding:0 10px 0 0;">
-                                <img src="https://www.tchap.gouv.fr/themes/tchap/img/logos/tchap-logo.svg" width="50" style="display:block;min-width:50px;" alt="Tchap">
+                                <img src="https://www.tchap.gouv.fr/vector-icons/120.png" width="50" style="display:block;min-width:50px;" alt="Tchap">
                             </td>
                             <td style="margin:0px;padding:0 10px 0 0;" valign="top">
                                 <table cellpadding="0" cellspacing="0" style="border-collapse:collapse;">

--- a/test/unit-tests/tchap/components/views/settings/__snapshots__/AccountUserSettingsTab-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/settings/__snapshots__/AccountUserSettingsTab-test.tsx.snap
@@ -193,7 +193,7 @@ exports[`<AccountUserSettingsTab /> common view snapshot should render section w
                                 
                                   <img
                                     alt="Tchap"
-                                    src="https://www.tchap.gouv.fr/themes/tchap/img/logos/tchap-logo.svg"
+                                    src="https://www.tchap.gouv.fr/vector-icons/120.png"
                                     style="display:block;min-width:50px;"
                                     width="50"
                                   />


### PR DESCRIPTION
## Changes
- use remote png image instead of svg
- inline Base64 image seems to be not well supported on some mail clients

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
