### PR TITLE
TCHAP(roomHeader): remove options menu when element call enabled

### DIFF
--- a/modules/tchap-translations/tchap_translations_removed.json
+++ b/modules/tchap-translations/tchap_translations_removed.json
@@ -59,5 +59,6 @@
     "unsupported_browser|title",
     "unsupported_browser|description",
     "unsupported_browser",
-    "common|not_trusted"
+    "common|not_trusted",
+    "voip|video_call_using"
 ]

--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -212,5 +212,11 @@
         "files": [
             "src/components/views/rooms/MemberList/MemberListHeaderView.tsx"
         ]
+    },
+    "flow-legacy-call-element-call": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1174",
+        "files": [
+            "src/components/views/rooms/RoomHeader.tsx"
+        ]
     }
 }

--- a/src/components/views/rooms/RoomHeader/RoomHeader.tsx
+++ b/src/components/views/rooms/RoomHeader/RoomHeader.tsx
@@ -159,51 +159,65 @@ export default function RoomHeader({
     );
 
     const startVideoCallButton = (
+        // :TCHAP: flow-legacy-call-element-call
+        // We don't show the user a selection of different type of calls, we make the descision based on the number of members in the room
+        // <>
+        //     {/* Can be either a menu or just a button depending on the number of call options.*/}
+        //     {callOptions.length > 1 ? (
+        //         <Menu
+        //             open={menuOpen}
+        //             onOpenChange={onOpenChange}
+        //             title={_t("voip|video_call_using")}
+        //             trigger={
+        //                 <IconButton
+        //                     disabled={!!videoCallDisabledReason}
+        //                     aria-label={videoCallDisabledReason ?? _t("voip|video_call")}
+        //                 >
+        //                     {callIconWithTooltip}
+        //                 </IconButton>
+        //             }
+        //             side="left"
+        //             align="start"
+        //         >
+        //             {callOptions.map((option) => {
+        //                 const { label, children } = getPlatformCallTypeProps(option);
+        //                 return (
+        //                     <MenuItem
+        //                         key={option}
+        //                         label={label}
+        //                         aria-label={label}
+        //                         children={children}
+        //                         className="mx_RoomHeader_videoCallOption"
+        //                         onClick={(ev) => videoCallClick(ev, option)}
+        //                         Icon={VideoCallIcon}
+        //                         onSelect={() => {} /* Dummy handler since we want the click event.*/}
+        //                     />
+        //                 );
+        //             })}
+        //         </Menu>
+        //     ) : (
+        //         <IconButton
+        //             disabled={!!videoCallDisabledReason}
+        //             aria-label={videoCallDisabledReason ?? _t("voip|video_call")}
+        //             onClick={videoClick}
+        //         >
+        //             {callIconWithTooltip}
+        //         </IconButton>
+        //     )}
+        // </>
+
         <>
-            {/* Can be either a menu or just a button depending on the number of call options.*/}
-            {callOptions.length > 1 ? (
-                <Menu
-                    open={menuOpen}
-                    onOpenChange={onOpenChange}
-                    title={_t("voip|video_call_using")}
-                    trigger={
-                        <IconButton
-                            disabled={!!videoCallDisabledReason}
-                            aria-label={videoCallDisabledReason ?? _t("voip|video_call")}
-                        >
-                            {callIconWithTooltip}
-                        </IconButton>
-                    }
-                    side="left"
-                    align="start"
-                >
-                    {callOptions.map((option) => {
-                        const { label, children } = getPlatformCallTypeProps(option);
-                        return (
-                            <MenuItem
-                                key={option}
-                                label={label}
-                                aria-label={label}
-                                children={children}
-                                className="mx_RoomHeader_videoCallOption"
-                                onClick={(ev) => videoCallClick(ev, option)}
-                                Icon={VideoCallIcon}
-                                onSelect={() => {} /* Dummy handler since we want the click event.*/}
-                            />
-                        );
-                    })}
-                </Menu>
-            ) : (
-                <IconButton
-                    disabled={!!videoCallDisabledReason}
-                    aria-label={videoCallDisabledReason ?? _t("voip|video_call")}
-                    onClick={videoClick}
-                >
-                    {callIconWithTooltip}
-                </IconButton>
-            )}
+            <IconButton
+                disabled={!!videoCallDisabledReason}
+                aria-label={videoCallDisabledReason ?? _t("voip|video_call")}
+                onClick={videoClick}
+            >
+                {callIconWithTooltip}
+            </IconButton>
         </>
+        // end :TCHAP:
     );
+    
     let voiceCallButton: JSX.Element | undefined = (
         <Tooltip label={voiceCallDisabledReason ?? _t("voip|voice_call")}>
             <IconButton

--- a/src/hooks/room/useRoomCall.tsx
+++ b/src/hooks/room/useRoomCall.tsx
@@ -143,6 +143,8 @@ export const useRoomCall = (
         const options: PlatformCallType[] = [];
         if (memberCount <= 2) {
             options.push(PlatformCallType.LegacyCall);
+            return options; // :TCHAP: flow-legacy-call-element-call in all case if 
+                            // we are only two in the room we use legacy call, compatible with legacy mobile apps
         }/* :TCHAP: remove-jitsi-option
         else if (mayEditWidgets || hasJitsiWidget) {
             options.push(PlatformCallType.JitsiCall);

--- a/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
+++ b/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { KnownMembership, PendingEventOrdering, Room } from "matrix-js-sdk/src/matrix";
 import { screen, render, type RenderOptions, getByLabelText, queryByLabelText } from "jest-matrix-react";
 import { mocked } from "jest-mock";
+import { CallType } from "matrix-js-sdk/src/webrtc/call";
 
 import { mkRoomMember, stubClient } from "~tchap-web/test/test-utils";
 import RoomHeader from "~tchap-web/src/components/views/rooms/RoomHeader/RoomHeader";
@@ -13,8 +14,11 @@ import SettingsStore from "~tchap-web/src/settings/SettingsStore";
 import { UIFeature } from "~tchap-web/src/settings/UIFeature";
 import TchapRoomUtils from "~tchap-web/src/tchap/util/TchapRoomUtils";
 import { TchapRoomType } from "~tchap-web/src/tchap/@types/tchap";
+import { placeCall } from "~tchap-web/src/utils/room/placeCall";
+import { PlatformCallType } from "~tchap-web/src/hooks/room/useRoomCall";
 
 jest.mock("~tchap-web/src/tchap/util/TchapRoomUtils");
+jest.mock("~tchap-web/src/utils/room/placeCall");
 
 jest.mock("~tchap-web/src/hooks/right-panel/useCurrentPhase", () => ({
     useCurrentPhase: () => {
@@ -60,10 +64,15 @@ describe("RoomHeader", () => {
     const homeserverName: string = "my.home.server";
     const mockedTchapRoomUtils = mocked(TchapRoomUtils);
 
-    const addHomeserverToMockConfig = (homeservers: string[], feature: string) => {
-        // mock SdkConfig.get("tchap_features")
+    const addHomeserverToMockConfig = (homeservers: string[], feature: string | string[]) => {
         const config: ConfigOptions = { tchap_features: {} };
-        config.tchap_features[feature] = homeservers;
+        if (Array.isArray(feature)) {
+            feature.forEach((f) => {
+                config.tchap_features[f] = homeservers;
+            });
+        } else {
+            config.tchap_features[feature] = homeservers;
+        }
         SdkConfig.put(config);
     };
 
@@ -106,6 +115,10 @@ describe("RoomHeader", () => {
         DMRoomMap.setShared({
             getUserIdForRoomId: jest.fn(),
         } as unknown as DMRoomMap);
+
+        jest.mocked(placeCall).mockImplementation(async (room, type, deviceOptions, startWithVideo) => {
+            return Promise.resolve();
+        });
     });
 
     afterEach(() => {
@@ -161,7 +174,7 @@ describe("RoomHeader", () => {
     it("hides the video button when feature is activated but is not a direct message room", () => {
         addHomeserverToMockConfig([homeserverName], featureVideoName);
 
-        mockDMRoom(4);
+        mockRoomMembers(room, 4);
 
         const { container } = getComponent();
 
@@ -199,5 +212,45 @@ describe("RoomHeader", () => {
         const { container } = getComponent();
 
         expect(queryByLabelText(container, "Video call")).toBeNull();
+    });
+
+    // :TCHAP: flow-legacy-call-element-call
+    it("directly start legacy call when there is only two users in the room", async () => {
+        addHomeserverToMockConfig([homeserverName], featureVideoGroupName);
+        mockRoomMembers(room, 2);
+
+        const { container } = getComponent();
+        const videoButton = getByLabelText(container, "Video call");
+
+        // Click the video call button
+        await videoButton.click();
+        // placeCall to have been called with PlatformCallType.LegacyCall
+        expect(placeCall).toHaveBeenCalledWith(room, CallType.Video, PlatformCallType.LegacyCall, false);
+    });
+
+    it("directly start legacy call when it is a DM room and element call is enabled", async () => {
+        addHomeserverToMockConfig([homeserverName], [featureVideoGroupName, featureVideoName]);
+        mockDMRoom();
+
+        const { container } = getComponent();
+        const videoButton = getByLabelText(container, "Video call");
+
+        // Click the video call button
+        await videoButton.click();
+        // placeCall to have been called with PlatformCallType.LegacyCall
+        expect(placeCall).toHaveBeenCalledWith(room, CallType.Video, PlatformCallType.LegacyCall, false);
+    });
+
+    it("directly start element call when there is more than two users in the room", async () => {
+        addHomeserverToMockConfig([homeserverName], featureVideoGroupName);
+        mockRoomMembers(room, 4);
+
+        const { container } = getComponent();
+        const videoButton = getByLabelText(container, "Video call");
+
+        // Click the video call button
+        await videoButton.click();
+        // placeCall to have been called with PlatformCallType.ElementCall
+        expect(placeCall).toHaveBeenCalledWith(room, CallType.Video, PlatformCallType.ElementCall, false);
     });
 });


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1174

## Changes
Before when element-call was activated and a room had less than 2 users or in a DM room, what had this option : 
![Image](https://github.com/user-attachments/assets/97d3ef6e-3c25-49c0-9b68-ea71dd9ffeda)

After : 
The call, there is no more dropdown menu option. We directly call using webrtc in a DM and room < 2 users. For other room (>2) we directly use element call
