### PR TITLE
Fix setting group calls and remove deprecated CALL_EVENT_TYPE

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -979,5 +979,9 @@
     "onboarding|create_room": {
         "en": "Download the mobile app",
         "fr": "Télécharger l'application mobile"
+    },
+    "room_settings|permissions|m.call.member": {
+        "en": "Allow users to start group calls",
+        "fr": "Autoriser les utilisateurs à démarrer les appels groupés"
     }
 }

--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -983,5 +983,13 @@
     "room_settings|permissions|m.call.member": {
         "en": "Allow users to start group calls",
         "fr": "Autoriser les utilisateurs à démarrer les appels groupés"
+    },
+    "room_settings|voip|enable_element_call_caption": {
+        "en": "Group calls are end-to-end encrypted, but is currently limited to smaller numbers of users.",
+        "fr": "Les appels de groupe sont chiffrés de bout en bout, mais sont actuellement limité à un nombre plus petit d'utilisateurs."
+    },
+    "room_settings|voip|enable_element_call_label": {
+        "en": "Enable group calls as an additional calling option in this room",
+        "fr": "Activer les appels de groupe comme une option d'appel supplémentaire dans ce salon"
     }
 }

--- a/modules/tchap-translations/tchap_translations_removed.json
+++ b/modules/tchap-translations/tchap_translations_removed.json
@@ -54,11 +54,10 @@
     "spaces|error_no_permission_add_space",
     "auth|continue_with_sso",
     "room|header_avatar_open_settings_label",
-    "voip|disabled_no_perms_start_voice_call",
-    "voip|disabled_no_perms_start_video_call",
     "unsupported_browser|title",
     "unsupported_browser|description",
     "unsupported_browser",
     "common|not_trusted",
-    "voip|video_call_using"
+    "voip|video_call_using",
+    "room_settings|permissions|m.call"
 ]

--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -216,7 +216,22 @@
     "flow-legacy-call-element-call": {
         "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1174",
         "files": [
-            "src/components/views/rooms/RoomHeader.tsx"
+            "src/components/views/rooms/RoomHeader.tsx",
+            "src/TextForEvent.ts",
+            "src/components/views/rooms/EventTile.tsx",
+            "src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx",
+            "src/components/views/settings/tabs/room/VoipRoomSettingsTab.tsx",
+            "src/createRoom.ts"
+        ]
+    },
+    "deprecated-call-event-permissions": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1268",
+        "files": [
+            "src/TextForEvent.ts",
+            "src/components/views/rooms/EventTile.tsx",
+            "src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx",
+            "src/components/views/settings/tabs/room/VoipRoomSettingsTab.tsx",
+            "src/createRoom.ts"
         ]
     },
     "sso-login-hint": {

--- a/src/TextForEvent.tsx
+++ b/src/TextForEvent.tsx
@@ -922,7 +922,9 @@ for (const evType of ALL_RULE_TYPES) {
 }
 
 // Add both stable and unstable m.call events
-for (const evType of ElementCall.CALL_EVENT_TYPE.names) {
+// :TCHAP: deprecated-call-event-permissions
+// for (const evType of ElementCall.CALL_EVENT_TYPE.names) {
+for (const evType of ElementCall.MEMBER_EVENT_TYPE.names) {
     stateHandlers[evType] = textForCallEvent;
 }
 

--- a/src/components/views/rooms/EventTile.tsx
+++ b/src/components/views/rooms/EventTile.tsx
@@ -1040,7 +1040,8 @@ export class UnwrappedEventTile extends React.Component<EventTileProps, IState> 
         } else if (
             (this.props.continuation && this.context.timelineRenderingType !== TimelineRenderingType.File) ||
             eventType === EventType.CallInvite ||
-            ElementCall.CALL_EVENT_TYPE.matches(eventType)
+            // ElementCall.CALL_EVENT_TYPE.matches(eventType) :TCHAP: deprecated-call-event-permissions
+            ElementCall.MEMBER_EVENT_TYPE.matches(eventType)
         ) {
             // no avatar or sender profile for continuation messages and call tiles
             avatarSize = null;

--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -63,7 +63,7 @@ const plEventsToShow: Record<string, IEventShowOpts> = {
     [EventType.RoomRedaction]: { isState: false, hideForSpace: true },
 
     // MSC3401: Native Group VoIP signaling
-    [ElementCall.CALL_EVENT_TYPE.name]: { isState: true, hideForSpace: true },
+    // [ElementCall.CALL_EVENT_TYPE.name]: { isState: true, hideForSpace: true }, // :TCHAP: deprecated-call-event-permissions
     [ElementCall.MEMBER_EVENT_TYPE.name]: { isState: true, hideForSpace: true },
 
     // TODO: Enable support for m.widget event type (https://github.com/vector-im/element-web/issues/13111)
@@ -183,15 +183,9 @@ export default class RolesRoomSettingsTab extends React.Component<IProps, RolesR
         stateLevel: number,
         eventsLevel: number,
     ): void {
-        console.log("populateDefaultPlEvents", eventsSection, stateLevel, eventsLevel);
-        console.log("plEventsToShow", plEventsToShow);
         for (const desiredEvent of Object.keys(plEventsToShow)) {
             if (!(desiredEvent in eventsSection)) {
-                if (desiredEvent === ElementCall.MEMBER_EVENT_TYPE.name) {
-                    eventsSection[desiredEvent] = 100; // Set to 0 instead of stateLevel
-                } else {
-                    eventsSection[desiredEvent] = plEventsToShow[desiredEvent].isState ? stateLevel : eventsLevel;
-                }
+                eventsSection[desiredEvent] = plEventsToShow[desiredEvent].isState ? stateLevel : eventsLevel;
             }
         }
     }
@@ -304,7 +298,7 @@ export default class RolesRoomSettingsTab extends React.Component<IProps, RolesR
 
         // MSC3401: Native Group VoIP signaling
         if (SettingsStore.getValue("feature_group_calls")) {
-            plEventsToLabels[ElementCall.CALL_EVENT_TYPE.name] = _td("room_settings|permissions|m.call");
+            // plEventsToLabels[ElementCall.CALL_EVENT_TYPE.name] = _td("room_settings|permissions|m.call"); // :TCHAP: deprecated-call-event-permissions
             plEventsToLabels[ElementCall.MEMBER_EVENT_TYPE.name] = _td("room_settings|permissions|m.call.member");
         }
 

--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -183,9 +183,15 @@ export default class RolesRoomSettingsTab extends React.Component<IProps, RolesR
         stateLevel: number,
         eventsLevel: number,
     ): void {
+        console.log("populateDefaultPlEvents", eventsSection, stateLevel, eventsLevel);
+        console.log("plEventsToShow", plEventsToShow);
         for (const desiredEvent of Object.keys(plEventsToShow)) {
             if (!(desiredEvent in eventsSection)) {
-                eventsSection[desiredEvent] = plEventsToShow[desiredEvent].isState ? stateLevel : eventsLevel;
+                if (desiredEvent === ElementCall.MEMBER_EVENT_TYPE.name) {
+                    eventsSection[desiredEvent] = 100; // Set to 0 instead of stateLevel
+                } else {
+                    eventsSection[desiredEvent] = plEventsToShow[desiredEvent].isState ? stateLevel : eventsLevel;
+                }
             }
         }
     }
@@ -440,6 +446,11 @@ export default class RolesRoomSettingsTab extends React.Component<IProps, RolesR
         // hide the power level selector for enabling E2EE if it the room is already encrypted
         if (this.state.isRoomEncrypted) {
             delete eventsLevels[EventType.RoomEncryption];
+        }
+
+        // :TCHAP: group-calls-settings-tab
+        if (SettingsStore.getValue("feature_group_calls")) {
+            delete eventsLevels[ElementCall.CALL_EVENT_TYPE.name];
         }
 
         const eventPowerSelectors = Object.keys(eventsLevels)

--- a/src/components/views/settings/tabs/room/VoipRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/VoipRoomSettingsTab.tsx
@@ -54,20 +54,21 @@ const ElementCallSwitch: React.FC<ElementCallSwitchProps> = ({ room }) => {
 
             if (enabled) {
                 const userLevel = newContent.events[EventType.RoomMessage] ?? content.users_default ?? 0;
-                const moderatorLevel = content.kick ?? 50;
+                // const moderatorLevel = content.kick ?? 50; // :TCHAP: remove deprecated CALL_EVENT_TYPE
 
-                newContent.events[ElementCall.CALL_EVENT_TYPE.name] = isPublic ? moderatorLevel : userLevel;
+                // newContent.events[ElementCall.CALL_EVENT_TYPE.name] = isPublic ? moderatorLevel : userLevel; // :TCHAP: remove deprecated CALL_EVENT_TYPE
                 newContent.events[ElementCall.MEMBER_EVENT_TYPE.name] = userLevel;
             } else {
                 const adminLevel = newContent.events[EventType.RoomPowerLevels] ?? content.state_default ?? 100;
 
-                newContent.events[ElementCall.CALL_EVENT_TYPE.name] = adminLevel;
+                // newContent.events[ElementCall.CALL_EVENT_TYPE.name] = adminLevel; // :TCHAP: remove deprecated CALL_EVENT_TYPE
                 newContent.events[ElementCall.MEMBER_EVENT_TYPE.name] = adminLevel;
             }
 
             room.client.sendStateEvent(room.roomId, EventType.RoomPowerLevels, newContent);
         },
-        [room.client, room.roomId, content, isPublic],
+        // [room.client, room.roomId, content, isPublic], // :TCHAP:
+        [room.client, room.roomId, content], 
     );
 
     const brand = SdkConfig.get("element_call").brand ?? DEFAULTS.element_call.brand;

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -169,7 +169,7 @@ export default async function createRoom(client: MatrixClient, opts: IOpts): Pro
                     // Allow all users to send call membership updates
                     [ElementCall.MEMBER_EVENT_TYPE.name]: 0,
                     // Make calls immutable, even to admins
-                    [ElementCall.CALL_EVENT_TYPE.name]: 200,
+                    // [ElementCall.CALL_EVENT_TYPE.name]: 200, :TCHAP: (DEPRECATED)
                 },
                 users: {
                     // Temporarily give ourselves the power to set up a call
@@ -182,10 +182,9 @@ export default async function createRoom(client: MatrixClient, opts: IOpts): Pro
             events: {
                 ...DEFAULT_EVENT_POWER_LEVELS,
                 // It should always (including non video rooms) be possible to join a group call.
-                // [ElementCall.MEMBER_EVENT_TYPE.name]: 0, // :TCHAP: group-calls-settings-tab only admin can enable group calls
-                [ElementCall.MEMBER_EVENT_TYPE.name]: 100, // :TCHAP: group-calls-settings-tab only admin can enable group calls
+                [ElementCall.MEMBER_EVENT_TYPE.name]: 0,
                 // Make sure only admins can enable it (DEPRECATED)
-                [ElementCall.CALL_EVENT_TYPE.name]: 100,
+                // [ElementCall.CALL_EVENT_TYPE.name]: 100, :TCHAP:
             },
         };
     }

--- a/src/createRoom.ts
+++ b/src/createRoom.ts
@@ -182,7 +182,8 @@ export default async function createRoom(client: MatrixClient, opts: IOpts): Pro
             events: {
                 ...DEFAULT_EVENT_POWER_LEVELS,
                 // It should always (including non video rooms) be possible to join a group call.
-                [ElementCall.MEMBER_EVENT_TYPE.name]: 0,
+                // [ElementCall.MEMBER_EVENT_TYPE.name]: 0, // :TCHAP: group-calls-settings-tab only admin can enable group calls
+                [ElementCall.MEMBER_EVENT_TYPE.name]: 100, // :TCHAP: group-calls-settings-tab only admin can enable group calls
                 // Make sure only admins can enable it (DEPRECATED)
                 [ElementCall.CALL_EVENT_TYPE.name]: 100,
             },

--- a/src/hooks/room/useRoomCall.tsx
+++ b/src/hooks/room/useRoomCall.tsx
@@ -261,12 +261,8 @@ export const useRoomCall = (
     let videoCallDisabledReason: string | null;
     switch (state) {
         case State.NoPermission:
-            // :tchap: display-call-button-anyway - disable noPermission
-            // voiceCallDisabledReason = _t("voip|disabled_no_perms_start_voice_call");
-            // videoCallDisabledReason = _t("voip|disabled_no_perms_start_video_call");
-            voiceCallDisabledReason = null;
-            videoCallDisabledReason = null;
-            // end :TCHAP:
+            voiceCallDisabledReason = _t("voip|disabled_no_perms_start_voice_call");
+            videoCallDisabledReason = _t("voip|disabled_no_perms_start_video_call");
             break;
         case State.Ongoing:
             voiceCallDisabledReason = _t("voip|disabled_ongoing_call");

--- a/src/utils/EventRenderingUtils.ts
+++ b/src/utils/EventRenderingUtils.ts
@@ -81,8 +81,12 @@ export function getEventDisplayInfo(
         eventType === EventType.RoomCreate ||
         eventType === EventType.RoomEncryption ||
         factory === JitsiEventFactory;
+    // :TCHAP:
+    // const isLeftAlignedBubbleMessage =
+    //     !isBubbleMessage && (eventType === EventType.CallInvite || ElementCall.CALL_EVENT_TYPE.matches(eventType));
     const isLeftAlignedBubbleMessage =
-        !isBubbleMessage && (eventType === EventType.CallInvite || ElementCall.CALL_EVENT_TYPE.matches(eventType));
+        !isBubbleMessage && (eventType === EventType.CallInvite || ElementCall.MEMBER_EVENT_TYPE.matches(eventType));
+    // end :TCHAP:
     let isInfoMessage = calcIsInfoMessage(eventType, content, isBubbleMessage, isLeftAlignedBubbleMessage);
     // Some non-info messages want to be rendered in the appropriate bubble column but without the bubble background
     const noBubbleEvent =

--- a/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
+++ b/test/unit-tests/tchap/components/views/rooms/RoomHeaders-test.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { KnownMembership, PendingEventOrdering, Room } from "matrix-js-sdk/src/matrix";
-import { screen, render, type RenderOptions, getByLabelText, queryByLabelText } from "jest-matrix-react";
+import { screen, render, type RenderOptions, getByLabelText, queryByLabelText, logRoles } from "jest-matrix-react";
 import { mocked } from "jest-mock";
 import { CallType } from "matrix-js-sdk/src/webrtc/call";
 
@@ -81,7 +81,8 @@ describe("RoomHeader", () => {
     function mockDMRoom(memberCount: number = 2) {
         mockRoomMembers(room, memberCount);
         jest.spyOn(SettingsStore, "getValue").mockImplementation(() => false);
-        jest.spyOn(room.currentState, "mayClientSendStateEvent").mockReturnValue(false);
+        // in a dm room, the users are both admins
+        jest.spyOn(room.currentState, "mayClientSendStateEvent").mockReturnValue(true);
         jest.spyOn(room, "getMember").mockReturnValue(mkRoomMember(room.roomId, "@alice:example.org"));
 
         DMRoomMap.setShared({
@@ -153,11 +154,13 @@ describe("RoomHeader", () => {
     });
 
     // For 1 to 1 video call
-    it("display well the video button when feature is activated for 1v1 call", () => {
+    it("display well the video button when feature is activated for 1v1 call and has permission to send state event", () => {
         addHomeserverToMockConfig([homeserverName], featureVideoName);
+
         mockDMRoom();
 
         const { container } = getComponent();
+        logRoles(container);
 
         expect(queryByLabelText(container, "Video call")).toBeInTheDocument();
     });
@@ -208,6 +211,18 @@ describe("RoomHeader", () => {
         addHomeserverToMockConfig(["other.homeserver"], featureVideoGroupName);
 
         mockRoomMembers(room, 4);
+
+        const { container } = getComponent();
+
+        expect(queryByLabelText(container, "Video call")).toBeNull();
+    });
+
+    it("disables the video group when feature is activated user as not the right permissions", () => {
+        addHomeserverToMockConfig([homeserverName], featureVideoGroupName);
+
+        mockRoomMembers(room, 4);
+        // give  lower permissions to the user
+        jest.spyOn(room.currentState, "mayClientSendStateEvent").mockReturnValue(false);
 
         const { container } = getComponent();
 


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1268

## Changes
- remove `ElementCall.CALL_EVENT_TYPE` event since it is deprecated and only `ElementCall.MEMBER_EVENT_TYPE` is used
- Change translation to use group call instead of element call


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
