### PR TITLE
TCHAP: reactivate federation forum switch for all

### DIFF
--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -38,17 +38,10 @@ export default class TchapUtils {
         const cli = MatrixClientPeg.safeGet();
         const baseDomain = cli.getDomain();
 
-        // Only show the federate switch to defense users : it's difficult to understand, so we avoid
-        // displaying it unless it's really necessary.
-        if (baseDomain === "agent.intradef.tchap.gouv.fr") {
-            return {
-                showForumFederationSwitch: true,
-                forumFederationSwitchDefaultValue: false,
-            };
-        }
-
+        // Show for all but default to false only for intradef
         return {
-            showForumFederationSwitch: false,
+            showForumFederationSwitch: true,
+            forumFederationSwitchDefaultValue: baseDomain !== "agent.intradef.tchap.gouv.fr",
         };
     }
 


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1091

## Changes 
- Afficher le bouton pour la création de forum en fédération ou non pour toute les instances
- Valeur par défaut à NON fédéré seulement pour intradef et fédérer pour les autres

![image](https://github.com/user-attachments/assets/6a911608-0000-4b80-9c7e-0bba120be4e1)
