### PR TITLE
TCHAP: Fix tchap key wording

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -67,9 +67,9 @@
     },
     "Create Room": { "en": "Create New Room", "fr": "Créer un nouveau salon" },
     "Create a room in this space": { "en": "Create a room in this space", "fr": "Créer un salon dans cet espace" },
-    "Create your Tchap Key password (minimum 8 characters)": {
-        "en": "Create your Tchap Key password (minimum 8 characters)",
-        "fr": "Créez votre mot de passe Clé Tchap (minimum 8 caractères)"
+    "Create your Tchap Key password": {
+        "en": "Create your Tchap Key password",
+        "fr": "Créez votre mot de passe Clé Tchap"
     },
     "Decryption fail: Please open Tchap on an other connected device to allow key sharing.": {
         "en": "Decryption fail: Please open Tchap on an other connected device to allow key sharing.",

--- a/src/tchap/async-components/views/dialogs/security/TchapExportE2eKeysDialog.tsx
+++ b/src/tchap/async-components/views/dialogs/security/TchapExportE2eKeysDialog.tsx
@@ -203,7 +203,7 @@ export default class TchapExportE2eKeysDialog extends React.Component<IProps, IS
                             )}
                         </p>
                         <p className="tc_modalParagraph tc_withMarginBottom tc_withMarginTop">
-                            {_t("Create your Tchap Key password (minimum 8 characters)")}
+                            {_t("Create your Tchap Key password")}
                         </p>
                         <div className="error">{this.state.errStr}</div>
                         <div className="mx_E2eKeysDialog_inputTable">


### PR DESCRIPTION

<img width="1165" height="637" alt="image" src="https://github.com/user-attachments/assets/0d58e42a-35bf-4f6e-abec-2d91af06a1ea" />


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
