### PR TITLE
fix: access link first refresh

### DIFF
--- a/src/components/views/context_menus/RoomGeneralContextMenu.tsx
+++ b/src/components/views/context_menus/RoomGeneralContextMenu.tsx
@@ -202,7 +202,7 @@ export const RoomGeneralContextMenu: React.FC<RoomGeneralContextMenuProps> = ({
                 label={_t("room|context_menu|copy_link")}
                 iconClassName="mx_RoomGeneralContextMenu_iconCopyLink"
                 // :TCHAP: copy-link-room-behavior
-                disabled={TchapRoomUtils.getRoomJoinRule(room) === JoinRule.Invite}
+                disabled={TchapRoomUtils.getRoomJoinRule(room) !== JoinRule.Public}
                 // end :TCHAP:
             />
         );

--- a/src/tchap/components/views/rooms/TchapRoomLinkAccess.tsx
+++ b/src/tchap/components/views/rooms/TchapRoomLinkAccess.tsx
@@ -1,6 +1,6 @@
-import { EventTimeline, EventType, GuestAccess, JoinRule, Room } from "matrix-js-sdk/src/matrix";
+import { EventType, GuestAccess, JoinRule, Room } from "matrix-js-sdk/src/matrix";
 
-import React, { useEffect, useState } from 'react';
+import React, { JSX, useEffect, useState } from 'react';
 import LabelledToggleSwitch from '~tchap-web/src/components/views/elements/LabelledToggleSwitch';
 import { _t } from '~tchap-web/src/languageHandler';
 import { secureRandomString } from 'matrix-js-sdk/src/randomstring';
@@ -12,7 +12,6 @@ import CopyableText from "~tchap-web/src/components/views/elements/CopyableText"
 import Modal from "~tchap-web/src/Modal";
 import QuestionDialog from "~tchap-web/src/components/views/dialogs/QuestionDialog";
 import ErrorDialog from "~tchap-web/src/components/views/dialogs/ErrorDialog";
-import MatrixToPermalinkConstructor from "~tchap-web/src/utils/permalinks/MatrixToPermalinkConstructor";
 import ElementPermalinkConstructor from "~tchap-web/src/utils/permalinks/ElementPermalinkConstructor";
 import SdkConfig from "~tchap-web/src/SdkConfig";
 import DMRoomMap from "~tchap-web/src/utils/DMRoomMap";
@@ -115,11 +114,12 @@ export default function TchapRoomLinkAccess({room, onUpdateParentView}: ITchapRo
             const activationIsConfirmed = await activateLinksharingModal();
     
             if (activationIsConfirmed) {
+                await _setUpRoomByLink();
                 // create link if we activate the sharing, otherwise change nothing
                 if (TchapRoomUtils.getRoomGuessAccessRule(room) === GuestAccess.CanJoin) {
                     await _setGuestAccessRules(GuestAccess.Forbidden)
                 }
-                await Promise.all([_setUpRoomByLink(), _setJoinRules(JoinRule.Public)]);
+                await _setJoinRules(JoinRule.Public);
                 setIsLinkSharingActivated(checked);
                 onUpdateParentView(checked, false);
             }

--- a/test/unit-tests/tchap/components/views/context_menus/RoomGeneralContextMenu-test.tsx
+++ b/test/unit-tests/tchap/components/views/context_menus/RoomGeneralContextMenu-test.tsx
@@ -77,6 +77,7 @@ describe("RoomGeneralContextMenu", () => {
     });
 
     it("renders the default context menu", async () => {
+        mockedTchapRoomUtils.getRoomJoinRule.mockImplementation(() => JoinRule.Public);
         const { container } = getComponent({});
         expect(container).toMatchSnapshot();
     });


### PR DESCRIPTION
fixes https://github.com/tchapgouv/tchap-web-v4/issues/1353

## Changes
Weird behavior when `_setJoinRules` is executed before `_setUpRoomByLink`. Looks like the room state didnt change to public when it did. Inspecting with devtools still show that the room is in restricted rule, but when joining the room with the link it works and the room state will change to public at this time.
Sometimes refreshing also work to fix this.

Here we put the instruction _setUpRoomByLink clearly before _setUpRoomByLink, and the probleme seems to be fixed 

