### PR TITLE
TCHAP(desktop): apply open in defaut browser for MAS flow

### DIFF
--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -254,5 +254,14 @@
             "src/components/views/settings/tabs/user/EncryptionUserSettingsTab.tsx",
             "src/components/views/settings/encryption/RecoveryPanel.tsx"
         ]
+    },
+    "desktop-tauri-browser": {
+        "issue": "https://github.com/tchapgouv/tchap-desktop/issues/91",
+        "files": [
+            "src/Lifecycle.ts",
+            "src/utils/oidc/authorize.ts",
+            "src/BasePlatform.ts",
+            "src/components/structures/MatrixChat.tsx"
+        ]
     }
 }

--- a/src/BasePlatform.ts
+++ b/src/BasePlatform.ts
@@ -519,8 +519,7 @@ export default abstract class BasePlatform {
      */
     public startUpdater(): void {}
 
-    // :TCHAP: TODO remove when https://github.com/element-hq/element-web/pull/30643 is merged
-
+    // :TCHAP: desktop-tauri-browser TODO remove when https://github.com/element-hq/element-web/pull/30643 is merged
     /**
      * Checks if the current session is lock-free, i.e., no other instance is holding the session lock.
      * Platforms that support session locking should override this method.

--- a/src/Lifecycle.ts
+++ b/src/Lifecycle.ts
@@ -1114,7 +1114,7 @@ export async function onLoggedOut(): Promise<void> {
  * @param {object} opts Options for how to clear storage.
  * @returns {Promise} promise which resolves once the stores have been cleared
  */
-// :TCHAP: export async function clearStorage(opts?: { deleteEverything?: boolean }): Promise<void> {
+// :TCHAP: desktop-tauri-browser export async function clearStorage(opts?: { deleteEverything?: boolean }): Promise<void> {
 export async function clearStorage(opts?: { deleteEverything?: boolean, delegatedLoginSuccess?: boolean }): Promise<void> {
     logger.info(`Clearing storage, deleteEverything=${opts?.deleteEverything}`);
 
@@ -1126,7 +1126,8 @@ export async function clearStorage(opts?: { deleteEverything?: boolean, delegate
         const pendingInvites = ThreepidInviteStore.instance.getWireInvites();
         const registrationTime = window.localStorage.getItem("mx_registration_time");
 
-        // :TCHAP: try to save hs and idp for delegated auth in order to avoid error 
+        // :TCHAP: desktop-tauri-browser https://github.com/tchapgouv/tchap-desktop/issues/82 
+        // try to save hs and idp for delegated auth in order to avoid error 
         const hs = window.localStorage.getItem(SSO_HOMESERVER_URL_KEY);
         const idpServer = window.localStorage.getItem(SSO_ID_SERVER_URL_KEY);
         const idpId = window.localStorage.getItem(SSO_IDP_ID_KEY);
@@ -1155,7 +1156,8 @@ export async function clearStorage(opts?: { deleteEverything?: boolean, delegate
             }
         }
 
-        // :TCHAP: return from sso calback, set again the correct hs and ids to avoid sso_failed_missing_storage error
+        // :TCHAP: desktop-tauri-browser
+        // return from sso calback, set again the correct hs and ids to avoid sso_failed_missing_storage error
         if (opts?.delegatedLoginSuccess) {
             if(hs) window.localStorage.setItem(SSO_HOMESERVER_URL_KEY, hs);
             if (idpServer) window.localStorage.setItem(SSO_ID_SERVER_URL_KEY, idpServer);

--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -316,7 +316,7 @@ export default class MatrixChat extends React.PureComponent<IProps, IState> {
     private async initSession(): Promise<void> {
         // The Rust Crypto SDK will break if two Element instances try to use the same datastore at once, so
         // make sure we are the only Element instance in town (on this browser/domain).
-        // :TCHAP: remove when https://github.com/element-hq/element-web/pull/30643 is merged
+        // :TCHAP: desktop-tauri-browser remove when https://github.com/element-hq/element-web/pull/30643 is merged
         if (!(await PlatformPeg.get()?.getSessionLock(() => this.onSessionLockStolen()))) {
             // we failed to get the lock. onSessionLockStolen should already have been called, so nothing left to do.
             return;

--- a/src/utils/oidc/authorize.ts
+++ b/src/utils/oidc/authorize.ts
@@ -14,6 +14,7 @@ import { type IdTokenClaims } from "oidc-client-ts";
 
 import { OidcClientError } from "./error";
 import PlatformPeg from "../../PlatformPeg";
+import type TauriPlatform from "~tchap-web/src/vector/platform/tchap-desktop/TauriPlatform";
 
 /**
  * Start OIDC authorization code flow
@@ -55,7 +56,14 @@ export const startOidcLogin = async (
         //:tchap: end
     });
 
-    window.location.href = authorizationUrl;
+    // :TCHAP: desktop-tauri-browser
+    // window.location.href = authorizationUrl;
+    if (window.__TAURI__) {
+        const tauriPlatform = PlatformPeg.get() as TauriPlatform;
+        tauriPlatform.openAuthorizationInBrowser(authorizationUrl);
+    } else {
+        window.location.href = authorizationUrl;
+    }
 };
 
 /**

--- a/src/vector/platform/ElectronPlatform.tsx
+++ b/src/vector/platform/ElectronPlatform.tsx
@@ -490,4 +490,12 @@ export default class ElectronPlatform extends BasePlatform {
         }
         return url;
     }
+
+    public async checkSessionLockFree(): Promise<boolean> {
+        return true;
+    }
+
+    public async getSessionLock(_onNewInstance: () => Promise<void>): Promise<boolean> {
+        return true;
+    }
 }

--- a/src/vector/platform/tchap-desktop/TauriPlatform.ts
+++ b/src/vector/platform/tchap-desktop/TauriPlatform.ts
@@ -57,7 +57,8 @@ export default class TauriPlatform extends BasePlatform {
     private readonly ipc = new IPCManager();
     private readonly eventIndexManager: BaseEventIndexManager = new TauriSeshatIndexManager(this);
     protected tauriSecureStorage: TauriSecureStorage;
-    
+    private protocol!: string;
+
     // this is the opaque token we pass to the HS which when we get it in our callback we can resolve to a profile
     private readonly ssoID: string = secureRandomString(32);
     public constructor(tauriSecureStorage: TauriSecureStorage) {
@@ -66,6 +67,7 @@ export default class TauriPlatform extends BasePlatform {
         if (!window.__TAURI__) {
             throw new Error("Cannot instantiate TauriPlatform, window.__TAURI__ is not set");
         }
+        this.protocol = "tchap";
 
         dis.register(onAction);
         this.tauriSecureStorage = tauriSecureStorage;
@@ -82,9 +84,12 @@ export default class TauriPlatform extends BasePlatform {
             console.log('***** deep link:', urls)
             if (urls[0]) {
                 const url = new URL(urls[0]);
-                const loginToken = url.searchParams.get("loginToken");
+                const loginToken = url.searchParams.get("loginToken"); // for SSO
+                const code  = url.searchParams.get("code"); // for native OIDC
+                const state = url.searchParams.get("state"); // for native OIDC
                 // callback return from sso connexion 
                 if (loginToken) window.location.replace(`/?loginToken=${loginToken}`);
+                if (code && state) window.location.replace(`/?code=${code}&state=${state}`)
             }
         });
     }
@@ -187,10 +192,10 @@ export default class TauriPlatform extends BasePlatform {
 
     public getSSOCallbackUrl(fragmentAfterLogin?: string): URL {
         const href = window.location.href;
-        const urlTchap = href.replace(/^https?/, "tchap");
+        const urlTchap = href.replace(/^https?/, this.protocol);
         const url = new URL(urlTchap);
         url.hash = fragmentAfterLogin ?? "";
-        url.protocol = "tchap"; // only using this is not working to change the protocol, dont know why...
+        url.protocol = this.protocol; // only using this is not working to change the protocol, dont know why...
         url.searchParams.set(SSO_ID_KEY, this.ssoID);
         return url;
     }
@@ -219,20 +224,30 @@ export default class TauriPlatform extends BasePlatform {
             ssoLoginUrl = ssoLoginUrl + "&" + encodeParams({"login_hint" :loginHint});
         }
 
-        open(ssoLoginUrl).then(
-            () => {
-                Modal.createDialog(Spinner, { message: _t("auth|desktop_waiting_sso")});
-            }, 
-            (rejected) => {
-                console.log("rejected", rejected);
-            }
-        );
+        this.openAuthorizationInBrowser(ssoLoginUrl);
     }
 
     public getOidcClientState(): string {
         return `:${SSO_ID_KEY}:${this.ssoID}`;
     }
 
+    /**
+     * The URL to return to after a successful OIDC authentication
+     */
+    public getOidcCallbackUrl(): URL {
+        const href = window.location.href;
+        const urlTchap = href.replace(/^https?/, this.protocol);
+        const url = new URL(urlTchap);
+        // The redirect URL has to exactly match that registered at the OIDC server, so
+        // ensure that the fragment part of the URL is empty.
+        url.hash = "";
+        url.protocol = this.protocol;
+        // Trim the double slash into a single slash to comply with https://datatracker.ietf.org/doc/html/rfc8252#section-7.1
+        if (url.href.startsWith(`${url.protocol}//`)) {
+            url.href = url.href.replace("://", ":/");
+        }
+        return url;
+    }
 
     public async getAppVersion(): Promise<string> {
         return await getVersion();
@@ -324,5 +339,16 @@ export default class TauriPlatform extends BasePlatform {
 
     public async getSessionLock(_onNewInstance: () => Promise<void>): Promise<boolean> {
         return true;
+    }
+
+    public openAuthorizationInBrowser(authorizationUrl: string) {
+        open(authorizationUrl).then(
+            () => {
+                Modal.createDialog(Spinner, { message: _t("auth|desktop_waiting_sso")});
+            }, 
+            (rejected) => {
+                console.log("rejected", rejected);
+            }
+        );;
     }
 }


### PR DESCRIPTION
## Changes 
- Linked to https://github.com/tchapgouv/tchap-desktop/issues/91
- First PR that enable this fonctionnality for  SSO (not native) https://github.com/tchapgouv/tchap-web-v4/pull/1371
- Add support for opening default browser when using native oidc flow in Tauri