### PR TITLE
TCHAP: fix room preference roles tab wrong merged

### DIFF
--- a/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
+++ b/src/components/views/settings/tabs/room/RolesRoomSettingsTab.tsx
@@ -441,7 +441,7 @@ export default class RolesRoomSettingsTab extends React.Component<IProps, RolesR
 
         // :TCHAP: group-calls-settings-tab
         if (SettingsStore.getValue("feature_group_calls")) {
-            delete eventsLevels[ElementCall.CALL_EVENT_TYPE.name];
+            delete eventsLevels[ElementCallEventType.name];
         }
 
         const eventPowerSelectors = Object.keys(eventsLevels)


### PR DESCRIPTION
## changes
- During upgrade 1.11.100, forgot this part on role preference of a room