### PR TITLE
Render stand alone external member when access by link is activated

### DIFF
--- a/src/tchap/components/views/settings/TchapJoinRuleSettings.tsx
+++ b/src/tchap/components/views/settings/TchapJoinRuleSettings.tsx
@@ -176,6 +176,21 @@ const JoinRuleSettings : React.FC<JoinRuleSettingsProps> = ({
         });
     };
 
+    const openedToExternalUsers = accessRule === TchapRoomAccessRule.Unrestricted;
+    const onExternalAccessChange = async () => {
+        const { finished } = Modal.createDialog(QuestionDialog, {
+            title: _t("Allow external users to join this room"),
+            description:
+                _t("This action is irreversible.") +
+                " " +
+                _t("Are you sure you want to allow the externals to join this room ?"),
+            button: _t("action|ok"),
+        });
+        const [ confirmed ] = await finished;
+        if (!confirmed) return;
+        setTchapAccessRule({ rule: TchapRoomAccessRule.Unrestricted });
+    };
+
     /* code from element web
     const definitions: IDefinition<JoinRule>[] = [{
         value: JoinRule.Invite,
@@ -200,20 +215,6 @@ const JoinRuleSettings : React.FC<JoinRuleSettingsProps> = ({
         // :TCHAP: We could add functions in 'TchapUtils' to determine the type of room and rely on this logic to display components as we did in Android :
         // :TCHAP: https://github.com/tchapgouv/tchap-android/blob/develop/vector/src/main/java/fr/gouv/tchap/core/utils/RoomUtils.kt#L31
         if (accessRule) {
-            const openedToExternalUsers = accessRule === TchapRoomAccessRule.Unrestricted;
-            const onExternalAccessChange = async () => {
-                const { finished } = Modal.createDialog(QuestionDialog, {
-                    title: _t("Allow external users to join this room"),
-                    description:
-                        _t("This action is irreversible.") +
-                        " " +
-                        _t("Are you sure you want to allow the externals to join this room ?"),
-                    button: _t("action|ok"),
-                });
-                const [ confirmed ] = await finished;
-                if (!confirmed) return;
-                setTchapAccessRule({ rule: TchapRoomAccessRule.Unrestricted });
-            };
             privateRoomDescription = (
                 <div>
                     <div>{_t("room_settings|security|join_rule_invite_description")}</div>
@@ -454,6 +455,22 @@ const JoinRuleSettings : React.FC<JoinRuleSettingsProps> = ({
         return <TchapRoomLinkAccess room={room} onUpdateParentView={activateLinkSharingChange}></TchapRoomLinkAccess>
     }
 
+    const renderStandaloneExternalButton = () => {
+        // show the toggle only on share link activated
+        if (isShareLinkActivated) {
+            return (
+                <LabelledToggleSwitch 
+                    className="tc_JoinRuleSettings_externs_switch"
+                    value={openedToExternalUsers}
+                    onChange={onExternalAccessChange}
+                    label={_t("Allow external users to join this room")}
+                    disabled={disabled || openedToExternalUsers}
+                    data-testid="standalone_external_switch"/>
+            );
+        }
+        return null;
+    }
+
     return (
         <>
             {!isShareLinkActivated && <StyledRadioGroup
@@ -464,6 +481,7 @@ const JoinRuleSettings : React.FC<JoinRuleSettingsProps> = ({
                 disabled={disabled}
                 className="mx_JoinRuleSettings_radioButton"
             />}
+            { renderStandaloneExternalButton() }
             { renderLinkSharing() }
         </>
     );

--- a/src/tchap/util/TchapRoomUtils.ts
+++ b/src/tchap/util/TchapRoomUtils.ts
@@ -59,7 +59,7 @@ export default class TchapRoomUtils {
      */
     static isUserAdmin(room: Room) : boolean {
         const userId = room.client.getSafeUserId();
-        return room.getMember(userId)?.powerLevelNorm == 100
+        return room.getMember(userId)?.powerLevel == 100
     }
 
     static getRoomJoinRule(room: Room): JoinRule|undefined {

--- a/test/unit-tests/tchap/components/views/settings/TchapJoinRuleSettings-test.tsx
+++ b/test/unit-tests/tchap/components/views/settings/TchapJoinRuleSettings-test.tsx
@@ -1,22 +1,50 @@
-import React from "react";
-import { render, screen } from "jest-matrix-react";
+import React, { act } from "react";
+import { fireEvent, logRoles, render, screen, waitFor } from "jest-matrix-react";
 import { mocked } from "jest-mock";
-import { JoinRule, type MatrixClient, type Room } from "matrix-js-sdk/src/matrix";
+import {
+    EventType,
+    JoinRule,
+    MatrixEvent,
+    Room,
+    type MatrixClient,
+    RoomMember,
+    EventTimeline,
+} from "matrix-js-sdk/src/matrix";
 
 import TchapJoinRuleSettings from "~tchap-web/src/tchap/components/views/settings/TchapJoinRuleSettings";
 import { TchapRoomAccessRule, TchapRoomAccessRulesEventId } from "~tchap-web/src/tchap/@types/tchap";
-import {
-    createTestClient,
-    mkStubRoom,
-    mockStateEventImplementation,
-    mkEvent,
-} from "~tchap-web/test/test-utils/test-utils";
+import { mkStubRoom, mockStateEventImplementation, mkEvent, stubClient } from "~tchap-web/test/test-utils/test-utils";
 import DMRoomMap from "~tchap-web/src/utils/DMRoomMap";
+import SdkConfig from "~tchap-web/src/SdkConfig";
 
-function mkStubRoomWithInviteRule(roomId: string, name: string, client: MatrixClient, joinRule: JoinRule): Room {
-    const stubRoom: Room = mkStubRoom(roomId, name, client);
-    stubRoom.getJoinRule = jest.fn().mockReturnValue(joinRule);
-    stubRoom.currentState.getJoinRule = jest.fn().mockReturnValue(joinRule);
+//assert that spaces option is not here while private and public are
+const privateText = "Private (invite only)";
+const publicText = "Public";
+const allowExternalText = "Allow external users to join this room";
+const spaceText = "Anyone in a space can find and join";
+
+function mkStubRoomWithInviteRule(
+    roomId: string,
+    name: string,
+    client: MatrixClient,
+    joinRule: JoinRule,
+    isAdmin: boolean = false,
+): Room {
+    const stubRoom: Room = new Room(roomId, client, name);
+    // Just once, since the next value can be changed depending on the actions in the test
+    jest.spyOn(stubRoom.currentState, "getStateEvents").mockReturnValueOnce(
+        new MatrixEvent({
+            type: EventType.RoomJoinRules,
+            content: {
+                join_rule: joinRule,
+            },
+        }),
+    );
+
+    const member = new RoomMember(roomId, "@userId");
+    // mock user as powerlevel : admin or not
+    member.powerLevel = isAdmin ? 100 : 0;
+    jest.spyOn(stubRoom, "getMember").mockReturnValue(member);
     return stubRoom;
 }
 
@@ -46,26 +74,20 @@ function mkStubRoomWithAccessRule(
 
 describe("TchapJoinRule", () => {
     beforeEach(() => {
-        DMRoomMap.makeShared(createTestClient());
+        DMRoomMap.makeShared(stubClient());
         jest.spyOn(DMRoomMap.shared(), "getUserIdForRoomId").mockReturnValue(null);
     });
 
     it("should render the tchap join rule with only private option", () => {
         //build stub private room
         const props = {
-            room: mkStubRoomWithInviteRule("roomId", "roomName", createTestClient(), JoinRule.Invite),
+            room: mkStubRoomWithInviteRule("roomId", "roomName", stubClient(), JoinRule.Invite),
             closeSettingsFn() {},
             onError(error: Error) {},
         };
 
         //arrange
         render(<TchapJoinRuleSettings {...props} />);
-
-        //assert that spaces option is not here while private and public are
-        const publicText = "Public";
-        const privateText = "Private (invite only)";
-        const allowExternalText = "Allow external users to join this room";
-        const spaceText = "Anyone in a space can find and join";
 
         expect(screen.queryByText(publicText)).toBe(null);
         expect(screen.queryByText(privateText)).toBeDefined();
@@ -79,7 +101,7 @@ describe("TchapJoinRule", () => {
             room: mkStubRoomWithAccessRule(
                 "roomId",
                 "roomName",
-                createTestClient(),
+                stubClient(),
                 JoinRule.Invite,
                 TchapRoomAccessRule.Restricted,
             ),
@@ -90,40 +112,89 @@ describe("TchapJoinRule", () => {
         //arrange
         render(<TchapJoinRuleSettings {...props} />);
 
-        //assert that spaces option is not here while private and public are
-        const publicText = "Public";
-        const privateText = "Private (invite only)";
-        const allowExternalText = "Allow external users to join this room";
-        const spaceText = "Anyone in a space can find and join";
-
         expect(screen.queryByText(publicText)).toBe(null);
         expect(screen.queryByText(privateText)).toBeDefined();
         expect(screen.queryByText(allowExternalText)).toBeDefined();
         expect(screen.queryByText(spaceText)).toBe(null);
     });
 
-    // eslint-disable-next-line jest/no-commented-out-tests
-    /*
-    Impossible to mock a room to be considered as Public from TchapJoinRuleSettings point of view
-    it("should render the tchap join rule with only public option", () => {
+    it("should render accesss room by link switch to be disable if member is not admin", async () => {
         //build stub private room
         const props = {
-            room: mkStubRoomWithInviteRule("roomId", "roomName", createTestClient(), JoinRule.Public),
-            closeSettingsFn(){},
-            onError(error: Error){},
-        }
+            room: mkStubRoomWithInviteRule("roomId", "roomName", stubClient(), JoinRule.Invite, false),
+            closeSettingsFn() {},
+            onError(error: Error) {},
+        };
 
-        //arrange
         render(<TchapJoinRuleSettings {...props} />);
 
-        //assert that spaces option is not here while private and public are
-        const privateText = "Private (invite only)"
-        const publicText = "Public"
-        const spaceText = "Anyone in a space can find and join"
+        // link room access button
+        const linkSwitch = screen.getByRole("switch", { name: "room_settings" });
 
-        expect(screen.getByText(privateText)).toBe(null);
-        expect(screen.getByText(publicText)).toBeDefined();
-        expect(screen.queryByText(spaceText)).toBe(null);
+        expect(linkSwitch.getAttribute("aria-disabled")).toBeTruthy();
+        // should not see external link switch, since we didnt click on activate access by link
+        expect(
+            screen.queryByRole("switch", { name: "Allow external users to join this room" }),
+        ).not.toBeInTheDocument();
     });
-    */
+
+    it("should render standalone external switch when access link is activated and joinrule is invite", async () => {
+        const cli = stubClient();
+        cli.createAlias = jest.fn().mockResolvedValue({});
+
+        SdkConfig.put({
+            permalink_prefix: "https://tchap.gouv.fr",
+        });
+
+        const room = mkStubRoomWithInviteRule("roomId", "roomName", cli, JoinRule.Invite, true);
+
+        jest.spyOn(room.getLiveTimeline().getState(EventTimeline.FORWARDS)!, "getStateEvents").mockReturnValue(
+            new MatrixEvent({
+                type: TchapRoomAccessRulesEventId,
+                content: {
+                    rule: "restricted",
+                },
+            }),
+        );
+        jest.spyOn(cli, "isRoomEncrypted").mockReturnValue(true);
+        jest.spyOn(room.client, "sendStateEvent").mockResolvedValue({ event_id: "dada" });
+        jest.spyOn(cli, "getRoom").mockReturnValue(room);
+        // change join rule to public since we activated the access room by link
+        // simulate the consequence on the  click of the activation of access link
+        jest.spyOn(room.currentState, "getStateEvents").mockReturnValue(
+            new MatrixEvent({
+                type: EventType.RoomJoinRules,
+                content: {
+                    join_rule: "Public",
+                },
+            }),
+        );
+
+        //build stub private room
+        const props = {
+            room,
+            closeSettingsFn() {},
+            onError(error: Error) {},
+        };
+
+        const { container } = render(<TchapJoinRuleSettings {...props} />);
+
+        // click on access room by link
+        const linkButton = screen.getByRole("switch", { name: "room_settings" });
+
+        await waitFor(() => fireEvent.click(linkButton));
+
+        // click confirm we want to activate access by link
+        const okButton = screen.getByTestId("dialog-primary-button");
+        await act(() => fireEvent.click(okButton));
+        // should only display room link and external switch
+        expect(screen.queryByText(privateText)).toBe(null);
+        screen.debug();
+        logRoles(container);
+        // should see external link switch
+        expect(screen.getByRole("switch", { name: "Allow external users to join this room" })).toBeInTheDocument();
+
+        // should see copy link
+        expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+    });
 });

--- a/test/unit-tests/tchap/components/views/sso/EmailVerificationPage-test.tsx
+++ b/test/unit-tests/tchap/components/views/sso/EmailVerificationPage-test.tsx
@@ -295,47 +295,6 @@ describe("Tests sso and oidc native flow", () => {
         });
     });
 
-    /* Unit Test does not work, tested by hand
-    it("should redirect to login when m.login.password is detected (during MAS migration)", async () => {
-        
-        const config: ConfigOptions = 
-            { tchap_mas_flow:{ 
-                isActive: true , 
-                isMASmigration: true 
-            } 
-        };
-        SdkConfig.put(config);
-        
-         mockedLogin.mockImplementation(() => ({
-            hsUrl: defaultHsUrl,
-            createTemporaryClient: jest.fn().mockReturnValue(mockedClient),
-            getFlows: jest.fn().mockResolvedValue([{ type: "m.login.pasword" }]),
-        }));
-
-        renderEmailVerificationPage();
-
-        // Mock the implementation without error, what we want is to be sure they are called with the correct parameters
-        mockedFetchHomeserverFromEmail(defaultHsUrl);
-        mockedValidatedServerConfig(false, defaultHsUrl);
-        mockedPlatformPegStartSSO(false);
-
-        // Put text in email field
-        const emailField = screen.getByRole("textbox");
-        fireEvent.focus(emailField);
-        fireEvent.change(emailField, { target: { value: userEmail } });
-
-        await flushPromises();
-
-        // click on proconnect button
-        const proconnectButton = screen.getByTestId("mas-submit");
-        await act(async () => {
-            await fireEvent.click(proconnectButton);
-        });
-        
-        expect(onServerConfigChangeMock).toHaveBeenCalled();
-    });
-    */
-
     it("should call start oidc native flow with login_hint", async () => {
         const config: ConfigOptions = {
             tchap_mas_flow: {


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1402

## changes 
<img width="717" height="225" alt="image" src="https://github.com/user-attachments/assets/240bef15-b8d7-4054-8046-1775e9b18cfb" />
