### PR TITLE
Remove uifeature feedback and move to quick faq

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -65,6 +65,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "UIFeature.locationSharing": true,
+        "UIFeature.feedback": false,
         "MessageComposerInput.showPollsButton": true,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -64,6 +64,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "UIFeature.locationSharing": true,
+        "UIFeature.feedback": false,
         "MessageComposerInput.showPollsButton": true,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,

--- a/config.prod.json
+++ b/config.prod.json
@@ -153,6 +153,7 @@
         "UIFeature.identityServer": true,
         "UIFeature.advancedEncryption": false,
         "UIFeature.locationSharing": true,
+        "UIFeature.feedback": false,
         "MessageComposerInput.showPollsButton": true,
         "RoomList.orderAlphabetically": false,
         "Spaces.allRoomsInHome": true,

--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -139,10 +139,6 @@
         "en": "Invite someone using their name, email address, username (like <userId/>) or <a>share this space</a>. It is possible to invite multiple people by copy-pasting an email list separated by a comma (prenom1.nom1@beta.gouv.fr, prenom2.nom2@beta.gouv.fr, prenom3.nom3@beta.gouv.fr) or separated by a line break.",
         "fr": "Invitez quelqu’un grâce à son nom, adresse mail, nom d’utilisateur (tel que <userId/>) ou <a>partagez cet espace</a>. Il est possible d'inviter en masse en copiant et collant une liste de mails séparés par une virgule (prenom1.nom1@beta.gouv.fr, prenom2.nom2@beta.gouv.fr, prenom3.nom3@beta.gouv.fr) ou séparés par un saut à la ligne."
     },
-    "Just want to get your own logs, without sharing them with the Tchap team?": {
-        "en": "Just want to get your own logs, without sharing them with the Tchap team?",
-        "fr": "Vous voulez juste obtenir vos journaux sans les partager avec l'équipe Tchap ?"
-    },
     "restore_key_backup_dialog|keys_restored_title": { "en": "Messages restored", "fr": "Messages récupérés" },
     "Known issues": { "en": "Known issues", "fr": "Problèmes connus" },
     "One of your devices <b>wants to check your Tchap Keys</b> to unlock your messages.": {
@@ -199,10 +195,22 @@
     },
     "Set up": { "en": "Activate", "fr": "Activer" },
     "auth|logout_dialog|use_key_backup": { "en": "Use automatic Backup", "fr": "Utiliser la sauvegarde automatique" },
-    "Submit debug logs to Tchap support team": {
+    "bug_reporting|title": {
         "comment": "The title of BugReportDialog is unclear, specify it",
-        "en": "Submit debug logs to Tchap support team",
-        "fr": "Envoyez les journaux de débogage à l'équipe support de Tchap"
+        "en": "Report a bug and send debug logs",
+        "fr": "Signalez un bug et envoyez les journaux de débogage"
+    },
+    "bug_reporting|download_left": {
+        "en": "You can also consult the logs by",
+        "fr": "Vous pouvez aussi consulter les journaux en les"
+    },
+    "bug_reporting|download_right": {
+        "en": "downloading them locally",
+        "fr": "téléchargeant localement"
+    },
+    "bug_reporting|description": {
+        "en": "The debug logs can contain sensitive data related to your application usage, such as your username, id or alias of room you visited, recent elements of the interface and username of other users. It does not contain messages or file shared.",
+        "fr": "Les journaux de débogage contiennent certaines données relatives à votre utilisation de l'application telles que votre nom d'utilisateur, les identifiants ou alias de salons que vous avez visités, les éléments récents de l’interface utilisés et les noms d’utilisateur d’autres personnes. Ils ne contiennent aucun message ni contenu échangé."
     },
     "restore_key_backup_dialog|count_of_successfully_restored_keys": {
         "en": "%(sessionCount)s messages have been successfully restored.",
@@ -659,6 +667,10 @@
     "quick_faq|guides": {
         "en": "Get started",
         "fr": "Prise en main"
+    },
+    "quick_faq|bug": {
+        "en": "Report a bug",
+        "fr": "Signaler un bug"
     },
     "create_space|add_details_prompt": {
         "en": "A space is a dedicated folder in which you can organize your discussions by themes.",

--- a/modules/tchap-translations/tchap_translations_removed.json
+++ b/modules/tchap-translations/tchap_translations_removed.json
@@ -60,5 +60,6 @@
     "settings|security|key_backup_connect",
     "encryption|set_up_toast_description",
     "auth|logout_dialog|use_key_backup",
-    "settings|security|message_search_space_used"
+    "settings|security|message_search_space_used",
+    "bug_reporting|download_logs"
 ]

--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -154,6 +154,10 @@
     .mx_UserMenu_iconKey::before {
         mask-image: url("@vector-im/compound-design-tokens/icons/key-solid.svg");
     }
+
+    .mx_UserMenu_iconBug::before {
+        mask-image: url("$(res)/img/feather-customised/bug.svg");
+    }
 }
 
 
@@ -161,3 +165,4 @@
 .mx_ToastContainer .mx_Toast_toast .mx_Toast_description {
     max-width: 500px;
 }
+

--- a/src/components/views/dialogs/BugReportDialog.tsx
+++ b/src/components/views/dialogs/BugReportDialog.tsx
@@ -25,8 +25,9 @@ import DialogButtons from "../elements/DialogButtons";
 import { sendSentryReport } from "../../../sentry";
 import defaultDispatcher from "../../../dispatcher/dispatcher";
 import { Action } from "../../../dispatcher/actions";
-import TchapUtils from "~tchap-web/src/tchap/util/TchapUtils"; // :TCHAP:
 import { getBrowserSupport } from "../../../SupportedBrowser";
+
+import TchapUtils from "~tchap-web/src/tchap/util/TchapUtils"; // :TCHAP:
 
 export interface BugReportDialogProps {
     onFinished: (success: boolean) => void;
@@ -279,7 +280,7 @@ export default class BugReportDialog extends React.Component<BugReportDialogProp
             <BaseDialog
             className="mx_BugReportDialog"
             onFinished={this.onCancel}
-            title={_t('Submit debug logs to Tchap support team')}
+            title={_t('bug_reporting|title')}
             contentId="mx_Dialog_content"
         >
             <div className="mx_Dialog_content" id="mx_Dialog_content">
@@ -298,7 +299,7 @@ export default class BugReportDialog extends React.Component<BugReportDialogProp
                 {error}
                 <div className="mx_BugReportDialog_send_logs">
                     <DialogButtons
-                        primaryButton={_t("bug_reporting|send_logs")}
+                        primaryButton={_t("action|upload")}
                         onPrimaryButtonClick={this.onSubmit}
                         focus={true}
                         hasCancel={false}
@@ -307,17 +308,11 @@ export default class BugReportDialog extends React.Component<BugReportDialogProp
                 </div>
 
                 <div className="mx_BugReportDialog_download">
-                    <p>
-                        { _t("Just want to get your own logs, without sharing them with the Tchap team?") }
-                    </p>
-                    <DialogButtons
-                        primaryButton={_t("bug_reporting|download_logs")}
-                        onPrimaryButtonClick={this.onDownload}
-                        focus={true}
-                        hasCancel={false}
-                        disabled={this.state.downloadBusy}
-                    />
-                    {this.state.downloadProgress && <span>{this.state.downloadProgress} ...</span>}
+                        {_t("bug_reporting|download_left")} &nbsp;
+                        <AccessibleButton onClick={this.onDownload} kind="link" disabled={this.state.downloadBusy}>
+                            {_t("bug_reporting|download_right")}
+                        </AccessibleButton>
+                        {this.state.downloadProgress && <span>{this.state.downloadProgress} ...</span>}
                 </div>
             </div>
         </BaseDialog>

--- a/src/tchap/components/views/common/QuickFaq.tsx
+++ b/src/tchap/components/views/common/QuickFaq.tsx
@@ -1,13 +1,16 @@
 
-import React from 'react'
+import React, { JSX } from 'react'
+
+import "../../../../../res/css/common/_TchapLeftPanel.pcss";
 
 import { ChevronFace, alwaysAboveRightOf, useContextMenu } from '~tchap-web/src/components/structures/ContextMenu';
 import AccessibleButton from '~tchap-web/src/components/views/elements/AccessibleButton';
 import classNames from 'classnames';
 import { _t } from '../../../../languageHandler';
-import "../../../../../res/css/common/_TchapLeftPanel.pcss";
 import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOptionList } from '~tchap-web/src/components/views/context_menus/IconizedContextMenu';
 import TchapUrls from '../../../util/TchapUrls';
+import Modal from '~tchap-web/src/Modal';
+import BugReportDialog from '~tchap-web/src/components/views/dialogs/BugReportDialog';
 
 const QuickFaqButton: React.FC<{
     isPanelCollapsed: boolean;
@@ -45,6 +48,17 @@ const QuickFaqButton: React.FC<{
                         label={_t("quick_faq|guides")}
                         onClick={(e) => {
                             window.open(TchapUrls.helpUserOnboarding, '_blank')
+                        }}
+                    />
+                    <IconizedContextMenuOption
+                        iconClassName="mx_UserMenu_iconBug"
+                        label={_t("quick_faq|bug")}
+                        onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                    
+                            Modal.createDialog(BugReportDialog);
+                            closeMenu(e);
                         }}
                     />
                 </IconizedContextMenuOptionList>

--- a/test/unit-tests/tchap/components/views/dialogs/__snapshots__/BugReportDialog-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/dialogs/__snapshots__/BugReportDialog-test.tsx.snap
@@ -24,7 +24,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
             class="mx_Heading_h3 mx_Dialog_title"
             id="mx_BaseDialog_title"
           >
-            Submit debug logs to Tchap support team
+            Bug reporting
           </h1>
         </div>
         <div
@@ -71,7 +71,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
                   data-testid="dialog-primary-button"
                   type="button"
                 >
-                  Send logs
+                  Upload
                 </button>
               </span>
             </div>
@@ -79,23 +79,14 @@ exports[`<BugReportDialog> should render as expected 1`] = `
           <div
             class="mx_BugReportDialog_download"
           >
-            <p>
-              Just want to get your own logs, without sharing them with the Tchap team?
-            </p>
+            bug_reporting
+              
             <div
-              class="mx_Dialog_buttons"
+              class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_link"
+              role="button"
+              tabindex="0"
             >
-              <span
-                class="mx_Dialog_buttons_row"
-              >
-                <button
-                  class="mx_Dialog_primary"
-                  data-testid="dialog-primary-button"
-                  type="button"
-                >
-                  Download logs
-                </button>
-              </span>
+              bug_reporting
             </div>
           </div>
         </div>
@@ -133,7 +124,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
           class="mx_Heading_h3 mx_Dialog_title"
           id="mx_BaseDialog_title"
         >
-          Submit debug logs to Tchap support team
+          Bug reporting
         </h1>
       </div>
       <div
@@ -180,7 +171,7 @@ exports[`<BugReportDialog> should render as expected 1`] = `
                 data-testid="dialog-primary-button"
                 type="button"
               >
-                Send logs
+                Upload
               </button>
             </span>
           </div>
@@ -188,23 +179,14 @@ exports[`<BugReportDialog> should render as expected 1`] = `
         <div
           class="mx_BugReportDialog_download"
         >
-          <p>
-            Just want to get your own logs, without sharing them with the Tchap team?
-          </p>
+          bug_reporting
+            
           <div
-            class="mx_Dialog_buttons"
+            class="mx_AccessibleButton mx_AccessibleButton_hasKind mx_AccessibleButton_kind_link"
+            role="button"
+            tabindex="0"
           >
-            <span
-              class="mx_Dialog_buttons_row"
-            >
-              <button
-                class="mx_Dialog_primary"
-                data-testid="dialog-primary-button"
-                type="button"
-              >
-                Download logs
-              </button>
-            </span>
+            bug_reporting
           </div>
         </div>
       </div>


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1418

## Changes
- remove feedback from user menu (using config file)

<img width="282" height="213" alt="image" src="https://github.com/user-attachments/assets/9ab95ed2-b941-4673-9519-b2ccc3f5f9af" />

<img width="803" height="533" alt="image" src="https://github.com/user-attachments/assets/54d814bf-52dd-443b-8456-50e06a73958b" />
