### PR TITLE
Add email-precheck-sso page in AUTH_SCREENS list

### DIFF
--- a/src/components/structures/MatrixChat.tsx
+++ b/src/components/structures/MatrixChat.tsx
@@ -149,7 +149,9 @@ import EmailVerificationPage from "~tchap-web/src/tchap/components/views/sso/Ema
 // legacy export
 export { default as Views } from "../../Views";
 
-const AUTH_SCREENS = ["register", "mobile_register", "login", "forgot_password", "start_sso", "start_cas", "welcome"];
+// :TCHAP: const AUTH_SCREENS = ["register", "mobile_register", "login", "forgot_password", "start_sso", "start_cas", "welcome", ""];
+const AUTH_SCREENS = ["register", "mobile_register", "login", "forgot_password", "start_sso", "start_cas", "welcome", "email_precheck_sso"];
+// end :TCHAP
 
 // Actions that are redirected through the onboarding process prior to being
 // re-dispatched. NOTE: some actions are non-trivial and would require

--- a/src/vector/routing.ts
+++ b/src/vector/routing.ts
@@ -47,7 +47,7 @@ function onHashChange(): void {
 
     //only for migration
     const activateLoginLegacyDuringMASMigration= TchapUIFeature.isMASmigration();
-    
+
     if (TchapUIFeature.isMASFlowActive() && !activateLoginLegacyDuringMASMigration) {
         if (["#/login", "#/register"].includes(window.location.hash)) {
             window.location.replace("#/email-precheck-sso");


### PR DESCRIPTION
Here we add email-precheck-sso in  auth_screen list, so that it is loaded the same as the other auth screen bby MatrixChat component

closes https://github.com/tchapgouv/tchap-web-v4/issues/1404