### PR TITLE
TCHAP: keyback out of sync hidetoast after opning modale

### DIFF
--- a/patches/tchap-modifications.json
+++ b/patches/tchap-modifications.json
@@ -281,5 +281,11 @@
         "files": [
             "src/async-components/views/dialogs/eventindex/ManageEventIndexDialog.tsx"
         ]
+    },
+    "keybackup-out-of-sync-hide-toast": {
+        "issue": "",
+        "files": [
+            "src/toasts/SetupEncryptionToast.ts"
+        ]
     }
 }

--- a/src/toasts/SetupEncryptionToast.ts
+++ b/src/toasts/SetupEncryptionToast.ts
@@ -197,6 +197,10 @@ export const showToast = (kind: Kind): void => {
                 break;
             }
         }
+        // :TCHAP: keybackup-out-of-sync-hide-toast
+        // it will still re-appear after refresh if no action is done by the user
+        hideToast();
+        // end :TCHAP:
     };
 
     const onSecondaryClick = async (): Promise<void> => {
@@ -237,6 +241,9 @@ export const showToast = (kind: Kind): void => {
             default:
                 DeviceListener.sharedInstance().dismissEncryptionSetup();
         }
+        // :TCHAP: keybackup-out-of-sync-hide-toast
+        hideToast();
+        // end :TCHAP:
     };
 
     /**


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1452

## Changes 
Force hiding out of sync toast after clicking on one of the possible action. So that the user can still skip the phases even if he give up doing the action.
The toast will still appear after refresh if no concrete action has been done by the user