### PR TITLE
TCHAP(config): modify uri redirect after logout to be welcome

### DIFF
--- a/config.dev.json
+++ b/config.dev.json
@@ -136,5 +136,6 @@
     "posthog": {
         "project_api_key": "phc_yf5yr3PrgiUTZMZpSmUlR6hdtqAejwhcUMQGsK8Nx5w",
         "api_host": "https://posthog.tchap.incubateur.net"
-    }
+    },
+    "logout_redirect_url": "#/welcome"
 }

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -135,5 +135,6 @@
         "url": "https://call.preprod.tchap.gouv.fr/",
         "participant_limit": 25,
         "brand": "Appel de groupe"
-    }
+    },
+    "logout_redirect_url": "#/welcome"
 }

--- a/config.prod.json
+++ b/config.prod.json
@@ -224,5 +224,6 @@
         "url": "https://call.tchap.gouv.fr/",
         "participant_limit": 25,
         "brand": "Appel de groupe"
-    }
+    },
+    "logout_redirect_url": "#/welcome"
 }

--- a/config.prod.lab.json
+++ b/config.prod.lab.json
@@ -224,5 +224,6 @@
         "url": "https://call.tchap.gouv.fr/",
         "participant_limit": 25,
         "brand": "Appel de groupe"
-    }
+    },
+    "logout_redirect_url": "#/welcome"
 }


### PR DESCRIPTION
Right now, when logging out of tchap we go back to the login page. 
This change will bring the user to the welcome page in order to go back using the original flow to check his email