### PR TITLE
TCHAP(olm): remove all legacy olm package and use js-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,6 @@
         "@gouvfr-lasuite/integration": "^1.0.3",
         "@matrix-org/analytics-events": "^0.29.2",
         "@matrix-org/emojibase-bindings": "^1.3.4",
-        "@matrix-org/olm": "3.2.15",
         "@matrix-org/react-sdk-module-api": "^2.4.0",
         "@matrix-org/spec": "^1.7.0",
         "@sentry/browser": "^10.0.0",

--- a/patches/expose-pkencryption/matrix-js-sdk+39.0.0.patch
+++ b/patches/expose-pkencryption/matrix-js-sdk+39.0.0.patch
@@ -1,0 +1,52 @@
+diff --git a/node_modules/matrix-js-sdk/src/crypto-api/index.ts b/node_modules/matrix-js-sdk/src/crypto-api/index.ts
+index ff55c43..5a0979f 100644
+--- a/node_modules/matrix-js-sdk/src/crypto-api/index.ts
++++ b/node_modules/matrix-js-sdk/src/crypto-api/index.ts
+@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+ 
+-import type { SecretsBundle } from "@matrix-org/matrix-sdk-crypto-wasm";
++import type { PkMessage, SecretsBundle } from "@matrix-org/matrix-sdk-crypto-wasm";
+ import type { IMegolmSessionData } from "../@types/crypto.ts";
+ import type { ToDeviceBatch, ToDevicePayload } from "../models/ToDeviceMessage.ts";
+ import { type Room } from "../models/room.ts";
+@@ -726,6 +726,14 @@ export interface CryptoApi {
+      * @experimental
+      */
+     shareRoomHistoryWithUser(roomId: string, userId: string): Promise<void>;
++
++    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
++    //
++    // PkEncryption method, used for content scanner in tchap
++    //
++    ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
++
++    pkEncryptString(publicKey: string, message: string): Record<string, any>;
+ }
+ 
+ /** A reason code for a failure to decrypt an event. */
+diff --git a/node_modules/matrix-js-sdk/src/rust-crypto/rust-crypto.ts b/node_modules/matrix-js-sdk/src/rust-crypto/rust-crypto.ts
+index 638bf37..9f2e1b5 100644
+--- a/node_modules/matrix-js-sdk/src/rust-crypto/rust-crypto.ts
++++ b/node_modules/matrix-js-sdk/src/rust-crypto/rust-crypto.ts
+@@ -2111,6 +2111,19 @@ export class RustCrypto extends TypedEventEmitter<RustCryptoEvents, CryptoEventH
+     public async getOwnIdentity(): Promise<RustSdkCryptoJs.OwnUserIdentity | undefined> {
+         return await this.olmMachine.getIdentity(new RustSdkCryptoJs.UserId(this.userId));
+     }
++
++    // Expose PkEncryption methods to use in tchap-web
++    public pkEncryptString(publicKey: string, message: string): Record<string, any> {
++        const key = new RustSdkCryptoJs.Curve25519PublicKey(publicKey);
++        // Taken from the crypto-wasm package, based on vodozemac. Before we directly loaded libolm wasm in tchap
++        // Now it is taken from this package
++        const result = RustSdkCryptoJs.PkEncryption.fromKey(key).encryptString(message);
++        return {
++            ciphertext: encodeBase64(result.ciphertext()),
++            mac: encodeBase64(result.mac()),
++            ephemeral: result.ephemeralKey().toBase64(),
++        };
++    }
+ }
+ 
+ class EventDecryptor {

--- a/patches/patches.json
+++ b/patches/patches.json
@@ -18,5 +18,12 @@
         "files": [
             "src/interactive-auth.ts"
         ]
+    },
+    "expose-pkencryption": {
+        "package": "matrix-js-sdk",
+        "files": [
+            "src/crypto-api/index.ts",
+            "src/rust-crypto/rust-crypto.ts"
+        ]
     }
 }

--- a/src/tchap/content-scanner/ContentScanner.ts
+++ b/src/tchap/content-scanner/ContentScanner.ts
@@ -15,8 +15,7 @@
  */
 
 import { getHttpUriForMxc } from "matrix-js-sdk/src/content-repo";
-import { IEncryptedFile } from "~tchap-web/src/customisations/models/IMediaEventContent";
-import { PkEncryption } from "@matrix-org/olm";
+import { type EncryptedFile } from "matrix-js-sdk/src/types";
 import { ResizeMethod } from "matrix-js-sdk/src/@types/partials";
 import { MatrixClientPeg } from "~tchap-web/src/MatrixClientPeg";
 import SdkConfig from "~tchap-web/src/SdkConfig";
@@ -53,8 +52,7 @@ interface ContentScannerConfig extends IConfigOptions {
 export class ContentScanner {
     private static internalInstance: ContentScanner;
 
-    private mcsKey: PkEncryption = new global.Olm.PkEncryption();
-    private hasKey = false;
+    private publicKey?: string;
     private cachedScans = new Map<string, Promise<boolean>>();
 
     constructor(private scannerUrl: string) {}
@@ -70,20 +68,21 @@ export class ContentScanner {
         return matrixUrl.replace(/media\/r0/, "media_proxy/unstable");
     }
 
-    public async download(mxc: string, file?: IEncryptedFile): Promise<Response> {
+    public async download(mxc: string, file?: EncryptedFile): Promise<Response> {
         const authHeaders = this.getAuthHeaders();
         if (!file) {
             return fetch(this.urlForMxc(mxc));
         }
 
-        if (!this.hasKey) {
+        if (!this.publicKey) {
             await this.fetchKey();
         }
 
+        const encrypedtData = this.encryptData(file); 
         return fetch(this.scannerUrl + "/_matrix/media_proxy/unstable/download_encrypted", {
             method: "POST",
             body: JSON.stringify({
-                encrypted_body: this.mcsKey.encrypt(JSON.stringify({ file })),
+                encrypted_body: encrypedtData,
             }),
             headers: {
                 "Content-Type": "application/json",
@@ -92,7 +91,7 @@ export class ContentScanner {
         });
     }
 
-    public async scan(mxc: string, file?: IEncryptedFile): Promise<boolean> {
+    public async scan(mxc: string, file?: EncryptedFile): Promise<boolean> {
         // XXX: we're assuming that encryption won't be a differentiating factor and that the MXC URIs
         // will be different.
         if (this.cachedScans.has(mxc)) {
@@ -104,19 +103,19 @@ export class ContentScanner {
         return prom;
     }
 
-    private async doScan(mxc: string, file?: IEncryptedFile): Promise<boolean> {
+    private async doScan(mxc: string, file?: EncryptedFile): Promise<boolean> {
         let response: Response;
         const authHeaders = this.getAuthHeaders();
 
         if (file) {
-            if (!this.hasKey) {
+            if (!this.publicKey) {
                 await this.fetchKey();
             }
-
+            const encrypedtData = this.encryptData(file); 
             response = await fetch(this.scannerUrl + "/_matrix/media_proxy/unstable/scan_encrypted", {
                 method: "POST",
                 body: JSON.stringify({
-                    encrypted_body: this.mcsKey.encrypt(JSON.stringify({ file })),
+                    encrypted_body: encrypedtData
                 }),
                 headers: {
                     "Content-Type": "application/json",
@@ -139,10 +138,14 @@ export class ContentScanner {
         const response = await fetch(this.scannerUrl + "/_matrix/media_proxy/unstable/public_key").then((r) =>
             r.json(),
         );
-        this.mcsKey.set_recipient_key(response["public_key"]);
-        this.hasKey = true;
+        this.publicKey = response["public_key"];
     }
 
+    private encryptData(file: EncryptedFile) {
+        const crypto = MatrixClientPeg.get()?.getCrypto();
+        const encryptedData = crypto?.pkEncryptString(this.publicKey!, JSON.stringify({ file }))
+        return encryptedData;
+    }
     /**
      * Returns a ContentScanner instance.
      * The ContentScanner uses the same URL as the matrix client.
@@ -158,7 +161,7 @@ export class ContentScanner {
 
     private static get contentScannerUrl(): string {
         return (
-            (SdkConfig.get() as ContentScannerConfig)?.content_scanner?.url ?? MatrixClientPeg.get().getHomeserverUrl()
+            (SdkConfig.get() as ContentScannerConfig)?.content_scanner?.url ?? MatrixClientPeg.get()?.getHomeserverUrl()
         );
     }
 }

--- a/src/tchap/content-scanner/ContentScanner.ts
+++ b/src/tchap/content-scanner/ContentScanner.ts
@@ -78,11 +78,11 @@ export class ContentScanner {
             await this.fetchKey();
         }
 
-        const encrypedtData = this.encryptData(file); 
+        const encryptedData = this.encryptData(file); 
         return fetch(this.scannerUrl + "/_matrix/media_proxy/unstable/download_encrypted", {
             method: "POST",
             body: JSON.stringify({
-                encrypted_body: encrypedtData,
+                encrypted_body: encryptedData,
             }),
             headers: {
                 "Content-Type": "application/json",
@@ -111,11 +111,11 @@ export class ContentScanner {
             if (!this.publicKey) {
                 await this.fetchKey();
             }
-            const encrypedtData = this.encryptData(file); 
+            const encryptedData = this.encryptData(file); 
             response = await fetch(this.scannerUrl + "/_matrix/media_proxy/unstable/scan_encrypted", {
                 method: "POST",
                 body: JSON.stringify({
-                    encrypted_body: encrypedtData
+                    encrypted_body: encryptedData
                 }),
                 headers: {
                     "Content-Type": "application/json",

--- a/src/vector/index.ts
+++ b/src/vector/index.ts
@@ -114,7 +114,6 @@ async function start(): Promise<void> {
         rageshakePromise,
         setupLogStorage,
         preparePlatform,
-        loadOlm,
         loadConfig,
         loadLanguage,
         loadTheme,
@@ -161,7 +160,6 @@ async function start(): Promise<void> {
             }
         }
 
-        const loadOlmPromise = loadOlm();
         // set the platform for react sdk
         await preparePlatform();
         // load config requires the platform to be ready
@@ -232,7 +230,6 @@ async function start(): Promise<void> {
         // app load critical path starts here
         // assert things started successfully
         // ##################################
-        await loadOlmPromise;
         await loadPluginsPromise;
         await loadModulesPromise;
         await loadThemePromise;

--- a/src/vector/init.tsx
+++ b/src/vector/init.tsx
@@ -8,10 +8,6 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import olmWasmPath from "@matrix-org/olm/olm.wasm";
-import Olm from "@matrix-org/olm";
 import { createRoot } from "react-dom/client";
 import React, { StrictMode } from "react";
 import { logger } from "matrix-js-sdk/src/logger";
@@ -84,48 +80,6 @@ export async function loadConfig(): Promise<void> {
     } else {
         SdkConfig.reset();
     }
-}
-
-export function loadOlm(): Promise<void> {
-    /* Load Olm. We try the WebAssembly version first, and then the legacy,
-     * asm.js version if that fails. For this reason we need to wait for this
-     * to finish before continuing to load the rest of the app. In future
-     * we could somehow pass a promise down to react-sdk and have it wait on
-     * that so olm can be loading in parallel with the rest of the app.
-     *
-     * We also need to tell the Olm js to look for its wasm file at the same
-     * level as index.html. It really should be in the same place as the js,
-     * ie. in the bundle directory, but as far as I can tell this is
-     * completely impossible with webpack. We do, however, use a hashed
-     * filename to avoid caching issues.
-     */
-    return Olm.init({
-        locateFile: () => olmWasmPath,
-    })
-        .then(() => {
-            logger.log("Using WebAssembly Olm");
-        })
-        .catch((wasmLoadError) => {
-            logger.log("Failed to load Olm: trying legacy version", wasmLoadError);
-            return new Promise((resolve, reject) => {
-                const s = document.createElement("script");
-                s.src = "olm_legacy.js"; // XXX: This should be cache-busted too
-                s.onload = resolve;
-                s.onerror = reject;
-                document.body.appendChild(s);
-            })
-                .then(() => {
-                    // Init window.Olm, ie. the one just loaded by the script tag,
-                    // not 'Olm' which is still the failed wasm version.
-                    return window.Olm.init();
-                })
-                .then(() => {
-                    logger.log("Using legacy Olm");
-                })
-                .catch((legacyLoadError) => {
-                    logger.log("Both WebAssembly and asm.js Olm failed!", legacyLoadError);
-                });
-        });
 }
 
 export async function loadLanguage(): Promise<void> {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -358,10 +358,6 @@ module.exports = (env, argv) => {
                 // there is no need for webpack to parse them - they can just be
                 // included as-is.
                 /highlight\.js[\\/]lib[\\/]languages/,
-
-                // olm takes ages for webpack to process, and it's already heavily
-                // optimised, so there is little to gain by us uglifying it.
-                /olm[\\/](javascript[\\/])?olm\.js$/,
             ],
             rules: [
                 {
@@ -492,23 +488,6 @@ module.exports = (env, argv) => {
                         },
                     ],
                 },
-                // :TCHAP: we still use olm for the content scanner
-                // https://github.com/tchapgouv/tchap-web-v4/issues/1138
-                {
-                    // the olm library wants to load its own wasm, rather than have webpack do it.
-                    // We therefore use the `file-loader` to tell webpack to dump the contents to
-                    // a separate file and return the name, and override the default `type` for `.wasm` files
-                    // (which is `webassembly/experimental` under webpack 4) to stop webpack trying to interpret
-                    // the filename as webassembly. (see also https://github.com/webpack/webpack/issues/6725)
-                    test: /olm\.wasm$/,
-                    loader: "file-loader",
-                    type: "javascript/auto",
-                    options: {
-                        name: "[name].[hash:7].[ext]",
-                        outputPath: ".",
-                    },
-                },
-                // end :TCHAP:
                 {
                     // Fix up the name of the opus-recorder worker (react-sdk dependency).
                     // We more or less just want it to be clear it's for opus and not something else.
@@ -801,9 +780,6 @@ module.exports = (env, argv) => {
                     // :TCHAP: sso-agentconnect-flow
                     "res/welcome_with_proconnect.html",
                     "res/welcome_mas.html",
-                    // :TCHAP: legacy_olm TODO: remove all when content scanner will be updated to use rust crypto
-                    "node_modules/@matrix-org/olm/olm_legacy.js",
-                    // end :TCHAP:
                     { from: "welcome/**", context: path.resolve(__dirname, "res") },
                     { from: "themes/**", context: path.resolve(__dirname, "res") },
                     { from: "vector-icons/**", context: path.resolve(__dirname, "res") },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2312,11 +2312,6 @@
   resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-wasm/-/matrix-sdk-crypto-wasm-15.3.0.tgz#141fd041ae382b793369bcee4394b0b577bdea0c"
   integrity sha512-QyxHvncvkl7nf+tnn92PjQ54gMNV8hMSpiukiDgNrqF6IYwgySTlcSdkPYdw8QjZJ0NR6fnVrNzMec0OohM3wA==
 
-"@matrix-org/olm@3.2.15":
-  version "3.2.15"
-  resolved "https://registry.yarnpkg.com/@matrix-org/olm/-/olm-3.2.15.tgz#55f3c1b70a21bbee3f9195cecd6846b1083451ec"
-  integrity sha512-S7lOrndAK9/8qOtaTq/WhttJC/o4GAzdfK0MUPpo8ApzsJEC0QjtwrkC3KBXdFP1cD1MXi/mlKR7aaoVMKgs6Q==
-
 "@matrix-org/react-sdk-module-api@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@matrix-org/react-sdk-module-api/-/react-sdk-module-api-1.0.0.tgz#de73e163a439fe330f6971a6a0cef2ccb090d616"


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1082

## Changes
- Patch on matrix-js-sdk to expose PkEncryption in cryptoBackend in order to use in tchap-web
- Remove all package concerning legacy olm in tchap-web
- Use new crypto method in content scanner