### PR TITLE
TCHAP(desktop): fix sometimes error on tauri ss initialization

### DIFF
--- a/src/vector/platform/tchap-desktop/TauriPlatform.ts
+++ b/src/vector/platform/tchap-desktop/TauriPlatform.ts
@@ -77,7 +77,6 @@ export default class TauriPlatform extends BasePlatform {
         this.protocol = "tchap";
 
         dis.register(onAction);
-        this.tauriSecureStorage = new TauriSecureStorage(this.baseUrl, this.ipc);
 
         this.ipc.call("welcome");
 
@@ -236,6 +235,10 @@ export default class TauriPlatform extends BasePlatform {
 
 
     public getSecureStorageInstance(): TauriSecureStorage {
+        if (!this.tauriSecureStorage) {
+            this.tauriSecureStorage = new TauriSecureStorage(this.baseUrl, this.ipc);
+            return this.tauriSecureStorage
+        }
         return this.tauriSecureStorage;
     }
 


### PR DESCRIPTION
It can happen : 
<img width="677" height="273" alt="image" src="https://github.com/user-attachments/assets/0a372644-ea2f-441b-a19f-e6b10b3d580d" />

Looks like SDKConfig.get during tauriSecureStorage initialization is called but not yet available