### PR TITLE
TCHAP: add support for new tchap permalinks

### DIFF
--- a/patches_tchap/tchap-modifications.json
+++ b/patches_tchap/tchap-modifications.json
@@ -244,5 +244,9 @@
     "error-tchap-is-down": {
         "issue": "",
         "files": ["packages/shared-components/src/room/RoomStatusBar/RoomStatusBarView.tsx"]
+    },
+    "tchapgouv-permalinks": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1378",
+        "files": "src/utils/permalinks/Permalinks.ts"
     }
 }

--- a/src/tchap/util/TchapPermalinkConstructor.ts
+++ b/src/tchap/util/TchapPermalinkConstructor.ts
@@ -1,0 +1,88 @@
+import PermalinkConstructor, { PermalinkParts } from "~tchap-web/src/utils/permalinks/PermalinkConstructor";
+
+
+export const host = "tchap.gouv.fr";
+export const baseUrl = `https://${host}`;
+// Needs to remove legacy uri from this check => /#/room/ and /#/user/
+// We only keep the matrix to format, the other format is processed in the elementPermalink
+export const baseUrlPattern = (tchapPrefix: string | undefined = baseUrl) => {
+    const url = new URL(tchapPrefix);
+    // remove protocole
+    const urlWithoutProtocole = url.href.replace(url.protocol + '//', '');
+    return `^(?:https?://)?${urlWithoutProtocole.replace(".", "\\.")}#/(?!room/|user/)(.*)`;
+}
+
+/**
+ * Generates tchap permalinks based on matrixTopermalinkconstructor
+ */
+export default class TchapToPermalinkConstructor extends PermalinkConstructor {
+    private tchapUrl: string;
+
+    public constructor(tchapUrl: string | undefined  = baseUrl) {
+        super();
+        this.tchapUrl = tchapUrl;
+    }
+
+    public forEvent(roomId: string, eventId: string, serverCandidates: string[]): string {
+        return `${this.tchapUrl}/#/${roomId}/${eventId}${this.encodeServerCandidates(serverCandidates)}`;
+    }
+
+    public forRoom(roomIdOrAlias: string, serverCandidates: string[]): string {
+        return `${this.tchapUrl}/#/${roomIdOrAlias}${this.encodeServerCandidates(serverCandidates)}`;
+    }
+
+    public forUser(userId: string): string {
+        return `${this.tchapUrl}/#/${userId}`;
+    }
+
+    public forEntity(entityId: string): string {
+        return `${this.tchapUrl}/#/${entityId}`;
+    }
+
+    public isPermalinkHost(testHost: string): boolean {
+        return testHost === host;
+    }
+
+    public encodeServerCandidates(candidates: string[]): string {
+        if (!candidates || candidates.length === 0) return "";
+        return `?via=${candidates.map((c) => encodeURIComponent(c)).join("&via=")}`;
+    }
+
+    // Heavily inspired by/borrowed from the matrix-bot-sdk (with permission):
+    // https://github.com/turt2live/matrix-js-bot-sdk/blob/7c4665c9a25c2c8e0fe4e509f2616505b5b66a1c/src/Permalinks.ts#L33-L61
+    public parsePermalink(fullUrl: string): PermalinkParts {
+        if (!fullUrl) {
+            throw new Error("Does not appear to be a permalink");
+        }
+
+        const matches = [...fullUrl.matchAll(new RegExp(baseUrlPattern(this.tchapUrl), "gi"))][0];
+
+        if (!matches || matches.length < 2) {
+            throw new Error("Does not appear to be a permalink");
+        }
+
+        const parts = matches[1].split("/");
+
+        const entity = parts[0];
+        if (entity[0] === "@") {
+            // Probably a user, no further parsing needed.
+            return PermalinkParts.forUser(entity);
+        } else if (entity[0] === "#" || entity[0] === "!") {
+            if (parts.length === 1) {
+                // room without event permalink
+                const [roomId, query = ""] = entity.split("?");
+                const via = query.split(/&?via=/g).filter((p) => !!p);
+                return PermalinkParts.forRoom(roomId, via);
+            }
+
+            // rejoin the rest because v3 events can have slashes (annoyingly)
+            const eventIdAndQuery = parts.length > 1 ? parts.slice(1).join("/") : "";
+            const [eventId, query = ""] = eventIdAndQuery.split("?");
+            const via = query.split(/&?via=/g).filter((p) => !!p);
+
+            return PermalinkParts.forEvent(entity, eventId, via);
+        } else {
+            throw new Error("Unknown entity type in permalink");
+        }
+    }
+}

--- a/src/utils/permalinks/Permalinks.ts
+++ b/src/utils/permalinks/Permalinks.ts
@@ -23,6 +23,8 @@ import SdkConfig from "../../SdkConfig";
 import { ELEMENT_URL_PATTERN } from "../../linkify-matrix";
 import MatrixSchemePermalinkConstructor from "./MatrixSchemePermalinkConstructor";
 
+import TchapToPermalinkConstructor, { baseUrlPattern as tchapToBaseUrlPattern } from "~tchap-web/src/tchap/util/TchapPermalinkConstructor";
+
 // The maximum number of servers to pick when working out which servers
 // to add to permalinks. The servers are appended as ?via=example.org
 const MAX_SERVER_CANDIDATES = 3;
@@ -450,7 +452,13 @@ export function parsePermalink(fullUrl: string): PermalinkParts | null {
         const decodedUrl = decodeURIComponent(fullUrl);
         if (new RegExp(matrixToBaseUrlPattern, "i").test(decodedUrl)) {
             return new MatrixToPermalinkConstructor().parsePermalink(decodedUrl);
-        } else if (fullUrl.startsWith("matrix:")) {
+        } 
+        // :TCHAP: tchapgouv-permalinks . Needs to be put before Elementpermalink check, otherwise it wont enter here
+        else if (new RegExp(tchapToBaseUrlPattern(elementPrefix), "i").test(decodedUrl)) {
+            return new TchapToPermalinkConstructor(elementPrefix).parsePermalink(decodedUrl);
+        } 
+        // end :TCHAP:
+        else if (fullUrl.startsWith("matrix:")) {
             return new MatrixSchemePermalinkConstructor().parsePermalink(fullUrl);
         } else if (elementPrefix && fullUrl.startsWith(elementPrefix)) {
             return new ElementPermalinkConstructor(elementPrefix).parsePermalink(fullUrl);

--- a/test/unit-tests/tchap/util/TchapToPermalinkConstructor-test.ts
+++ b/test/unit-tests/tchap/util/TchapToPermalinkConstructor-test.ts
@@ -1,0 +1,48 @@
+import TchapToPermalinkConstructor from "~tchap-web/src/tchap/util/TchapPermalinkConstructor";
+import { PermalinkParts } from "~tchap-web/src/utils/permalinks/PermalinkConstructor";
+
+describe("TchapToPermalinkConstructor", () => {
+    const tchapprefix = "https://tchapgouv.com";
+    const tchaphost = "tchapgouv.com";
+    const peramlinkConstructor = new TchapToPermalinkConstructor(tchapprefix);
+
+    describe("parsePermalink", () => {
+        it.each([
+            ["empty URL", ""],
+            ["something that is not an URL", "hello"],
+            ["should raise an error for a non-matrix.to (tchapgouv) URL", "https://example.com/#/@user:example.com"],
+            ["should raise an error for a legacy permalink /room URL ", `${tchapprefix}/#/room/testidexample.com`],
+            ["should raise an error for a legacy permalink /user URL ", `${tchapprefix}/#/user/userid`],
+        ])("should raise an error for %s", (name: string, url: string) => {
+            expect(() => peramlinkConstructor.parsePermalink(url)).toThrow(
+                new Error("Does not appear to be a permalink"),
+            );
+        });
+
+        it.each([
+            ["(https)", `${tchapprefix}/#/@user:example.com`],
+            ["(http)", `http://${tchaphost}/#/@user:example.com`],
+            ["without protocol", `${tchaphost}/#/@user:example.com`],
+        ])("should parse an MXID %s", (name: string, url: string) => {
+            expect(peramlinkConstructor.parsePermalink(url)).toEqual(
+                new PermalinkParts(null, null, "@user:example.com", null),
+            );
+        });
+    });
+
+    describe("forRoom", () => {
+        it("constructs a link given a room ID and via servers", () => {
+            expect(peramlinkConstructor.forRoom("!myroom:example.com", ["one.example.com", "two.example.com"])).toEqual(
+                `${tchapprefix}/#/!myroom:example.com?via=one.example.com&via=two.example.com`,
+            );
+        });
+    });
+
+    describe("forEvent", () => {
+        it("constructs a link given an event ID, room ID and via servers", () => {
+            expect(
+                peramlinkConstructor.forEvent("!myroom:example.com", "$event4", ["one.example.com", "two.example.com"]),
+            ).toEqual(`${tchapprefix}/#/!myroom:example.com/$event4?via=one.example.com&via=two.example.com`);
+        });
+    });
+});


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1378

## Changes 
- Add support for new tchap matrix.to pattern permalinks
- matrix.to permalinks are still working
- Still working for tchap different environement (dev and preprod)


<img width="871" height="681" alt="image" src="https://github.com/user-attachments/assets/70e0ec3b-21be-4e73-a28e-3068e16801e1" />
