### PR TITLE
TCHAP: fix space panel crash and icon missing quickfaq

### DIFF
--- a/src/tchap/components/views/common/QuickFaq.tsx
+++ b/src/tchap/components/views/common/QuickFaq.tsx
@@ -8,8 +8,8 @@ import IconizedContextMenu, { IconizedContextMenuOption, IconizedContextMenuOpti
 import TchapUrls from '../../../util/TchapUrls';
 import Modal from '~tchap-web/src/Modal';
 import BugReportDialog from '~tchap-web/src/components/views/dialogs/BugReportDialog';
-import { IconButton, Tooltip } from '@vector-im/compound-web';
-import { HelpSolidIcon } from '@vector-im/compound-design-tokens/assets/web/icons';
+import { IconButton, Text, Tooltip } from '@vector-im/compound-web';
+import { BugIcon, ChatIcon, HelpSolidIcon, HomeIcon, InfoIcon } from '@vector-im/compound-design-tokens/assets/web/icons';
 
 const QuickFaqButton: React.FC<{
     isPanelCollapsed: boolean;
@@ -29,28 +29,28 @@ const QuickFaqButton: React.FC<{
             >
                 <IconizedContextMenuOptionList>
                     <IconizedContextMenuOption
-                        className="mx_UserMenu_iconInfo"
+                        icon={<InfoIcon />}
                         label={_t("quick_faq|faq")}
                         onClick={(e) => {
                             TchapUrls.openHelper("https://www.tchap.gouv.fr/faq")
                         }}
                     />
                     <IconizedContextMenuOption
-                        className="mx_UserMenu_iconMessage"
+                        icon={<ChatIcon />}
                         label={_t("quick_faq|contact")}
                         onClick={(e) => {
                             TchapUrls.openHelper("mailto:support@tchap.beta.gouv.fr")
                         }}
                     />
                     <IconizedContextMenuOption
-                        className="mx_UserMenu_iconHome"
+                        icon={<HomeIcon />}
                         label={_t("quick_faq|guides")}
                         onClick={(e) => {
                             TchapUrls.openHelper(TchapUrls.helpUserOnboarding)
                         }}
                     />
                     <IconizedContextMenuOption
-                        className="mx_UserMenu_iconBug"
+                        icon={ <BugIcon />}
                         label={_t("quick_faq|bug")}
                         onClick={(e) => {
                             e.preventDefault();
@@ -79,9 +79,9 @@ const QuickFaqButton: React.FC<{
                 <HelpSolidIcon />
                 {/* This is dirty, but we need to add the label to the indicator icon */}
                 {!isPanelCollapsed && (
-                    <Text className="mx_QuickSettingsButton_label" as="span" size="md" title={_t("common|settings")}>
-                        {_t("common|settings")}
-                    </Text>
+                 <Text className="mx_QuickSettingsButton_label" as="span" size="md" title={_t("common|settings")}>
+                    {_t("common|settings")}
+                </Text>
                 )}
             </>
         </IconButton>


### PR DESCRIPTION
## Changes 
- Fix crash on space panel expanded
- Fix missing icon on quick faq
<img width="375" height="278" alt="image" src="https://github.com/user-attachments/assets/879064c9-41cc-4766-9659-c00dbafd7758" />
