### PR TITLE
TCHAP: css quick fix on thread chevron, bug icon color call

### DIFF
--- a/res/themes/tchap-common/css/_tchap_custom.pcss
+++ b/res/themes/tchap-common/css/_tchap_custom.pcss
@@ -89,7 +89,21 @@
     .mx_LegacyCallEvent {
       &.mx_LegacyCallEvent_voice {
         .mx_LegacyCallEvent_content_button_reportBug span::before {
-          mask-image: url("@vector-im/compound-design-tokens/icons/warning.svg");
+            mask-size: 0px;
+            width: 0px;
+            height: 0px;
+            flex-shrink: 0;
+                
+       }
+      }
+
+      &.mx_LegacyCallEvent_video {
+        .mx_LegacyCallEvent_content_button_reportBug span::before {
+            mask-size: 0px;
+            width: 0px;
+            height: 0px;
+            flex-shrink: 0;
+                
        }
       }
     }

--- a/res/themes/tchap-dark/css/_tchap_custom.pcss
+++ b/res/themes/tchap-dark/css/_tchap_custom.pcss
@@ -36,3 +36,18 @@ div[data-floating-ui-portal] {
 .mx_RoomView_MessageList > li:nth-child(2) {
     --backgroundColor: transparent !important;
 }
+
+.mx_RoomHeader .mx_FacePile.mx_FacePile_toggled {
+    background: var(--cpd-color-bg-action-primary-rest);
+    color: var(--cpd-color-text-on-solid-primary);
+    font: var(--cpd-font-body-sm-semibold);
+}
+
+/* Alleger le Background d'une ligne de message au survol */
+.mx_EventTile[data-layout=bubble].mx_EventTile_selected:before, .mx_EventTile[data-layout=bubble]:hover:before {
+    background: var(--eventbubble-bg-hover, var(--cpd-color-gray-100));
+}
+
+.mx_ThreadSummary_chevron {
+    background: linear-gradient(270deg,  var(--cpd-color-bg-subtle-secondary) 50%, $system-transparent 100%) !important;
+}

--- a/res/themes/tchap-light/css/_tchap_custom.pcss
+++ b/res/themes/tchap-light/css/_tchap_custom.pcss
@@ -117,3 +117,7 @@ $e2e-verified-color: var(--confirmation-color);
 .mx_ThreadSummary > div:first-child {
     color: var(--cpd-color-icon-secondary);
 }
+
+.mx_ThreadSummary_chevron {
+    background: linear-gradient(270deg,  var(--cpd-color-gray-400) 50%, $system-transparent 100%) !important;
+}

--- a/src/components/views/messages/LegacyCallEvent.tsx
+++ b/src/components/views/messages/LegacyCallEvent.tsx
@@ -11,7 +11,7 @@ import { type MatrixEvent } from "matrix-js-sdk/src/matrix";
 import { CallErrorCode, CallState } from "matrix-js-sdk/src/webrtc/call";
 import classNames from "classnames";
 import { Clock } from "@element-hq/web-shared-components";
-import { VolumeOffSolidIcon, VolumeOnSolidIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { VolumeOffSolidIcon, VolumeOnSolidIcon, WarningIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { _t } from "../../../languageHandler";
 import MemberAvatar from "../avatars/MemberAvatar";
@@ -273,6 +273,7 @@ export default class LegacyCallEvent extends React.PureComponent<IProps, IState>
                 onClick={this.onReportBugClick}
                 kind="primary"
             >
+                <WarningIcon />
                 <span> {_t("Report a problem")} </span>
             </AccessibleButton>
         );

--- a/test/unit-tests/tchap/components/views/messages/__snapshots__/LegacyCallEvent-test.tsx.snap
+++ b/test/unit-tests/tchap/components/views/messages/__snapshots__/LegacyCallEvent-test.tsx.snap
@@ -6,6 +6,22 @@ exports[`<LegacyCallEvent> shows 'Report a problem' button if the call ended cle
   role="button"
   tabindex="0"
 >
+  <svg
+    fill="currentColor"
+    height="1em"
+    viewBox="0 0 24 24"
+    width="1em"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      d="M12.713 17.713A.97.97 0 0 1 12 18a.97.97 0 0 1-.713-.288A.97.97 0 0 1 11 17q0-.424.287-.712A.97.97 0 0 1 12 16q.424 0 .713.288.287.287.287.712 0 .424-.287.712m0-3.999A.97.97 0 0 1 12 14a.97.97 0 0 1-.713-.287A.97.97 0 0 1 11 13V9q0-.424.287-.713A.97.97 0 0 1 12 8q.424 0 .713.287Q13 8.576 13 9v4q0 .424-.287.713"
+    />
+    <path
+      clip-rule="evenodd"
+      d="M10.264 3.039c.767-1.344 2.705-1.344 3.472 0l8.554 14.969c.762 1.333-.2 2.992-1.736 2.992H3.446c-1.535 0-2.498-1.659-1.736-2.992zM3.446 19 12 4.031 20.554 19z"
+      fill-rule="evenodd"
+    />
+  </svg>
   <span>
      
     Report a problem


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1519

<img width="527" height="133" alt="image" src="https://github.com/user-attachments/assets/893cfe20-9dd5-4f7e-b0fc-3ca34725d79c" />

<img width="209" height="126" alt="image" src="https://github.com/user-attachments/assets/a8338a7d-1bbf-404c-8c55-d3c33e614d72" />

<img width="427" height="138" alt="image" src="https://github.com/user-attachments/assets/901fc425-271b-465d-bfb1-00ab53dccc37" />

