### PR TITLE
TCHAP: content scanner instead of block, make it retryable

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -183,7 +183,7 @@
         "en": "Save your Tchap Keys (encryption keys)",
         "fr": "Sauvegardez vos Clés Tchap (clés de chiffrement)"
     },
-    "Scan unavailable": { "en": "Scan unavailable", "fr": "Scan unavailable" },
+    "Scan unavailable": { "en": "Scan unavailable. Please try again later.", "fr": "Scan non disponible. Veuillez réessayer ultérieurement." },
     "Scanning": { "en": "Scanning", "fr": "Scanning" },
     "encryption|access_secret_storage_dialog|security_key_title": {
         "en": "Verification Code",

--- a/src/tchap/components/views/elements/ContentScanningStatus.tsx
+++ b/src/tchap/components/views/elements/ContentScanningStatus.tsx
@@ -38,7 +38,7 @@ export const ContentScanningStatus: React.FC<ContentScanningStatusProps> = (prop
     if (props.status === "scanning") {
         return (
             <div>
-                <TextWithTooltip class={`mx_ContentScanningStatus mx_ContentScanningStatus_scanning mx_ContentScanningStatus_scanning--${theme}`} tooltip={props.fileName}>
+                <TextWithTooltip className={`mx_ContentScanningStatus mx_ContentScanningStatus_scanning mx_ContentScanningStatus_scanning--${theme}`} tooltip={props.fileName || ""}>
                     {_t("Scanning")}
                 </TextWithTooltip>
             </div>
@@ -48,7 +48,7 @@ export const ContentScanningStatus: React.FC<ContentScanningStatusProps> = (prop
     if (props.status === "unsafe") {
         return (
             <div>
-                <TextWithTooltip class="mx_ContentScanningStatus mx_ContentScanningStatus_unsafe" tooltip={props.fileName}>
+                <TextWithTooltip className="mx_ContentScanningStatus mx_ContentScanningStatus_unsafe" tooltip={props.fileName || ""}>
                     {_t("Content blocked")}
                 </TextWithTooltip>
             </div>
@@ -58,7 +58,7 @@ export const ContentScanningStatus: React.FC<ContentScanningStatusProps> = (prop
     if (props.status === "error") {
         return (
             <div>
-                <TextWithTooltip class="mx_ContentScanningStatus mx_ContentScanningStatus_error" tooltip={props.fileName}>
+                <TextWithTooltip className="mx_ContentScanningStatus mx_ContentScanningStatus_error" tooltip={props.fileName || ""}>
                     {_t("Scan unavailable")}
                 </TextWithTooltip>
             </div>

--- a/src/tchap/customisations/components/views/messages/ContentScanningDownloadActionButton.tsx
+++ b/src/tchap/customisations/components/views/messages/ContentScanningDownloadActionButton.tsx
@@ -22,7 +22,7 @@ import { FileDownloader } from "~tchap-web/src/utils/FileDownloader";
 import { _t } from "~tchap-web/src/languageHandler";
 import Spinner from "~tchap-web/src/components/views/elements/Spinner";
 import { RovingAccessibleButton } from "~tchap-web/src/accessibility/RovingTabIndex";
-import { DownloadIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
+import { DownloadIcon, RotateRightIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { type Media } from "../../../ContentScanningMedia";
 import { BlockedIcon } from "../../../../components/views/elements/BlockedIcon";
@@ -134,9 +134,10 @@ export default class ContentScanningDownloadActionButton extends React.PureCompo
                 icon = this.renderBlockedIcon();
                 tooltip = _t("Content blocked");
                 break;
+            // Display retry icon when an error as occured 
             case DownloadState.Error:
-                icon = this.renderBlockedIcon();
-                tooltip = _t("Scan unavailable");
+                icon = this.renderRetryIcon();
+                tooltip = _t("action|retry");
                 break;
         }
 
@@ -163,11 +164,15 @@ export default class ContentScanningDownloadActionButton extends React.PureCompo
     }
 
     private renderSpinner(): JSX.Element {
-        return <Spinner w={18} h={18} />;
+        return <Spinner size={18}/>;
+    }
+
+    private renderRetryIcon(): JSX.Element {
+        return <RotateRightIcon />
     }
 
     private get disabled(): boolean {
-        return [DownloadState.Scanning, DownloadState.Error, DownloadState.Untrusted].includes(
+        return [DownloadState.Scanning, DownloadState.Untrusted].includes(
             this.state.downloadState,
         );
     }


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1545

## TODO
Still need to add retry icon and button on the preview image