### PR TITLE
TCHAP: use tchap room for new room list and fix label badge dark mode

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -218,7 +218,7 @@
         "en": "This code will allow you to always restore your messages.",
         "fr": "Ce code vous permettra de toujours récupérer vos messages."
     },
-    "This room is a public forum": { "en": "This room is a public forum", "fr": "Ce salon est un forum public" },
+    "This room is a public forum": { "en": "This room is a public room", "fr": "Ce salon est un salon public" },
     "This room is private": { "en": "This room is private", "fr": "Ce salon est privé" },
     "This room is private and open to external users": {
         "en": "This room is private and open to external users",
@@ -271,7 +271,7 @@
     },
     "a number": { "en": "a number", "fr": "un chiffre" },
     "a symbol": { "en": "a symbol", "fr": "un caractère spécial" },
-    "action|explore_public_rooms": { "en": "Explore public rooms", "fr": "Rejoindre un forum" },
+    "action|explore_public_rooms": { "en": "Explore public rooms", "fr": "Rejoindre un salon public" },
     "action|start_chat": { "en": "New direct message", "fr": "Nouveau message direct" },
     "an uppercase letter": { "en": "an uppercase letter", "fr": "une lettre majuscule" },
     "auth|check_email_wrong_email_button": { "en": "Re-enter email address", "fr": "Re-saisir l'adresse mail" },
@@ -321,7 +321,7 @@
         "en": "Verify your email to continue",
         "fr": "Vérifiez vos mails avant de continuer"
     },
-    "common|public_room": { "en": "Public room", "fr": "Forum" },
+    "common|public_room": { "en": "Public room", "fr": "Salon public" },
     "common|secure_backup": { "en": "Automatic Backup of Messages", "fr": "Sauvegarde automatique des messages" },
     "common|unverified": { "en": "Unverified", "fr": "Non vérifié" },
     "common|verified": { "en": "Verified ", "fr": "Vérifié" },
@@ -386,7 +386,7 @@
         "en": "Messages will be sent when your connection returns.",
         "fr": "Les messages seront envoyés automatiquement dès que la connexion sera rétablie."
     },
-    "room_list|join_public_room_label": { "en": "Join a public room", "fr": "Rejoindre un forum" },
+    "room_list|join_public_room_label": { "en": "Join a public room", "fr": "Rejoindre un salon public" },
     "room_settings|permissions|ban": {
         "en": "Ban users",
         "fr": "Interdire aux utilisateurs l’accès au salon (définitif)"
@@ -1103,7 +1103,7 @@
         "en": "Private secure room with external guests",
         "fr": "Salon privé sécurisé avec externes"
     },
-    "create|public_room": { "en": "Public room", "fr": "Forum" },
+    "create|public_room": { "en": "Public room", "fr": "Salon public" },
     "badge|external_guests": {
         "en": "External guests",
         "fr": "Invités externes"

--- a/res/css/tchap/views/rooms/_BadgeRoomType.pcss
+++ b/res/css/tchap/views/rooms/_BadgeRoomType.pcss
@@ -26,7 +26,7 @@
     .external {
         background-color: var(--badge-external-color);
         border: 0px !important;
-        color: #5b3620 !important;
+        color: var(--badge-external-text-color) !important;
     }
 
     .badge-content {

--- a/res/themes/tchap-dark/css/_tchap_custom_vars.pcss
+++ b/res/themes/tchap-dark/css/_tchap_custom_vars.pcss
@@ -4,6 +4,7 @@ should be loaded before res/themes/light-custom/css/_custom.pcss */
     --private-color: #27ae60;
     --external-color: #f07a12;
     --badge-external-color: #7c3f12;
+    --badge-external-text-color: #fff;
     --forum-color: #27ae60;
     --sidebar-button-color: #9999fc;
     --main-title-color: white;

--- a/res/themes/tchap-light/css/_tchap_custom_vars.pcss
+++ b/res/themes/tchap-light/css/_tchap_custom_vars.pcss
@@ -9,6 +9,7 @@ body {
     --private-color: #27ae60;
     --external-color: #f07a12;
     --badge-external-color: #ffe0c5;
+    --badge-external-text-color: #5b3620;
     --forum-color: #27ae60;
     --sidebar-color-50pct: #030c1b4d; /* for modal backdrop*/
     --roomlist-highlights-color: var(--cpd-color-bg-action-secondary-pressed);

--- a/src/components/viewmodels/avatars/RoomAvatarViewModel.tsx
+++ b/src/components/viewmodels/avatars/RoomAvatarViewModel.tsx
@@ -11,6 +11,8 @@ import { useEffect, useState } from "react";
 import { useTypedEventEmitter } from "../../../hooks/useEventEmitter";
 import { useDmMember, usePresence, type Presence } from "../../views/avatars/WithPresenceIndicator";
 import { DefaultTagID } from "../../../stores/room-list/models";
+import { useTchapRoom } from "~tchap-web/src/tchap/util/TchapRoomHook";
+import { TchapRoomType } from "~tchap-web/src/tchap/@types/tchap";
 
 export enum AvatarBadgeDecoration {
     LowPriority = "LowPriority",
@@ -40,7 +42,10 @@ export function useRoomAvatarViewModel(room: Room): RoomAvatarViewState {
     const isVideoRoom = room.isElementVideoRoom() || room.isCallRoom();
     const roomMember = useDmMember(room);
     const presence = usePresence(room, roomMember);
-    const isPublic = useIsPublic(room);
+    // :TCHAP:
+    // const isPublic = useIsPublic(room);
+    const { currentRoomType } = useTchapRoom(room);
+    // end :TCHAP:
     const isLowPriority = !!room.tags[DefaultTagID.LowPriority];
 
     let badgeDecoration: AvatarBadgeDecoration | undefined;
@@ -48,7 +53,7 @@ export function useRoomAvatarViewModel(room: Room): RoomAvatarViewState {
         badgeDecoration = AvatarBadgeDecoration.LowPriority;
     } else if (isVideoRoom) {
         badgeDecoration = AvatarBadgeDecoration.VideoRoom;
-    } else if (isPublic) {
+    } else if (currentRoomType == TchapRoomType.Forum) {
         badgeDecoration = AvatarBadgeDecoration.PublicRoom;
     } else if (presence) {
         badgeDecoration = AvatarBadgeDecoration.Presence;


### PR DESCRIPTION
- use tchap room public information to display badgeavatar 
<img width="374" height="367" alt="image" src="https://github.com/user-attachments/assets/1b7140b7-4a55-437b-854c-16bd365bf5fc" />

- Better dark mode color
<img width="272" height="68" alt="image" src="https://github.com/user-attachments/assets/01d4ef4e-369e-4865-a7f2-06475142c2b2" />

- use wording salon public instead of forum
<img width="480" height="120" alt="image" src="https://github.com/user-attachments/assets/2a216731-05c8-435e-9c7a-59ee33d65820" />
