### PR TITLE
TCHAP(desktop): add custom deep_link_scheme in config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Tchap is a web app that allows you to chat through the matrix protocol for the F
     - feature_use_ec_in_dm: give options to use Element call in DM room
 - "tchap_sso_flow"
     - "isActive": Activate ProConnect SSO flow
+- tchap_desktop: 
+    - "deep_link_scheme": Determine the value of the scheme depending on the environment, used by tchap-desktop
 
 ## File structures
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Tchap is a web app that allows you to chat through the matrix protocol for the F
     - feature_use_ec_in_dm: give options to use Element call in DM room
 - "tchap_sso_flow"
     - "isActive": Activate ProConnect SSO flow
-- tchap_desktop: 
+- tchap_desktop:
     - "deep_link_scheme": Determine the value of the scheme depending on the environment, used by tchap-desktop
 
 ## File structures

--- a/config.dev.json
+++ b/config.dev.json
@@ -126,6 +126,9 @@
         "feature_create_room_non_encrypted": ["*"],
         "feature_use_ec_in_dm": ["*"]
     },
+    "tchap_desktop": {
+        "deep_link_scheme": "tchap-dev"
+    },
     "tchap_mas_flow": {
         "isActive": true,
         "temp_is_MAS_migration": true

--- a/config.preprod.json
+++ b/config.preprod.json
@@ -129,6 +129,9 @@
         "isActive": true,
         "temp_is_MAS_migration": true
     },
+    "tchap_desktop": {
+        "deep_link_scheme": "tchap-preprod"
+    },
     "map_style_url": "https://openmaptiles.geo.data.gouv.fr/styles/osm-bright/style.json",
     "posthog": {
         "project_api_key": "phc_yf5yr3PrgiUTZMZpSmUlR6hdtqAejwhcUMQGsK8Nx5w",

--- a/config.prod.json
+++ b/config.prod.json
@@ -222,6 +222,9 @@
         "feature_create_room_non_encrypted": [],
         "feature_use_ec_in_dm": []
     },
+    "tchap_desktop": {
+        "deep_link_scheme": "tchap"
+    },
     "tchap_mas_flow": {
         "isActive": true,
         "temp_is_MAS_migration": true

--- a/src/IConfigOptions.ts
+++ b/src/IConfigOptions.ts
@@ -231,6 +231,9 @@ export interface ISsoRedirectOptions {
 export interface IConfigOptions {
     tchap_features?: {
         feature_email_notification?:[string]//activate email notification on a list of home servers, ie : "dev01.tchap.incubateur.net"
+    },
+    tchap_desktop: {
+        deep_link_scheme: string
     }
 }
 //end :tchap:

--- a/src/vector/platform/tchap-desktop/TauriPlatform.ts
+++ b/src/vector/platform/tchap-desktop/TauriPlatform.ts
@@ -65,7 +65,6 @@ export default class TauriPlatform extends BasePlatform {
     private readonly ipc = new IPCManager();
     private readonly eventIndexManager: BaseEventIndexManager = new TauriSeshatIndexManager(this);
     protected tauriSecureStorage: TauriSecureStorage;
-    private protocol!: string;
 
     // this is the opaque token we pass to the HS which when we get it in our callback we can resolve to a profile
     private readonly ssoID: string = secureRandomString(32);
@@ -75,7 +74,6 @@ export default class TauriPlatform extends BasePlatform {
         if (!window.__TAURI__) {
             throw new Error("Cannot instantiate TauriPlatform, window.__TAURI__ is not set");
         }
-        this.protocol = "tchap";
 
         dis.register(onAction);
 
@@ -300,11 +298,12 @@ export default class TauriPlatform extends BasePlatform {
 
 
     public getSSOCallbackUrl(fragmentAfterLogin?: string): URL {
+        const scheme = SdkConfig.get().tchap_desktop.deep_link_scheme;        
         const href = window.location.href;
-        const urlTchap = href.replace(/^https?/, this.protocol);
+        const urlTchap = href.replace(/^https?/, scheme);
         const url = new URL(urlTchap);
         url.hash = fragmentAfterLogin ?? "";
-        url.protocol = this.protocol; // only using this is not working to change the protocol, dont know why...
+        url.protocol = scheme; // only using this is not working to change the protocol, dont know why...
         url.searchParams.set(SSO_ID_KEY, this.ssoID);
         return url;
     }
@@ -353,13 +352,14 @@ export default class TauriPlatform extends BasePlatform {
      * The URL to return to after a successful OIDC authentication
      */
     public getOidcCallbackUrl(): URL {
+        const scheme = SdkConfig.get().tchap_desktop.deep_link_scheme;
         const href = window.location.href;
-        const urlTchap = href.replace(/^https?/, this.protocol);
+        const urlTchap = href.replace(/^https?/, scheme);
         const url = new URL(urlTchap);
         // The redirect URL has to exactly match that registered at the OIDC server, so
         // ensure that the fragment part of the URL is empty.
         url.hash = "";
-        url.protocol = this.protocol;
+        url.protocol = scheme;
         // Trim the double slash into a single slash to comply with https://datatracker.ietf.org/doc/html/rfc8252#section-7.1
         if (url.href.startsWith(`${url.protocol}//`)) {
             url.href = url.href.replace("://", ":/");


### PR DESCRIPTION
- add ability to customize deep link by environment so you can have a dev app and a prod app installed at the same time

needs https://github.com/tchapgouv/tchap-desktop/pull/209

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
