### PR TITLE
TCHAP(onpill): remove description mxid

### DIFF
--- a/patches_tchap/tchap-modifications.json
+++ b/patches_tchap/tchap-modifications.json
@@ -252,5 +252,9 @@
     "flag-setting-change-ecnrypted-rooms": {
         "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1537",
         "files": "src/components/views/settings/tabs/room/SecurityRoomSettingsTab.tsx"
+    },
+    "remove-mxid-onpill": {
+        "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1560",
+        "files": ["src/autocomplete/UserProvider.tsx"]
     }
 }

--- a/src/autocomplete/UserProvider.tsx
+++ b/src/autocomplete/UserProvider.tsx
@@ -127,7 +127,8 @@ export default class UserProvider extends AutocompleteProvider {
                     suffix: selection.beginning && range!.start === 0 ? ": " : " ",
                     href: makeUserPermalink(user.userId),
                     component: (
-                        <PillCompletion title={displayName} description={description ?? undefined}>
+                        // :TCHAP: remove-mxid-onpill <PillCompletion title={displayName} description={description ?? undefined}>
+                        <PillCompletion title={displayName} description={undefined}>
                             <MemberAvatar member={user} size="24px" />
                         </PillCompletion>
                     ),


### PR DESCRIPTION
It is long in tchap, and display name already includes instance

fixes https://github.com/tchapgouv/tchap-web-v4/issues/1560

<img width="638" height="720" alt="image" src="https://github.com/user-attachments/assets/9d7c7256-86f7-4e50-bab9-598e96982500" />
