### PR TITLE
TCHAP: fix external detection for prod HS

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -67,6 +67,7 @@ import { type UserProfilesStore } from "../../../stores/UserProfilesStore";
 import InviteProgressBody from "./InviteProgressBody.tsx";
 
 import TchapRoomUtils from "~tchap-web/src/tchap/util/TchapRoomUtils.ts";
+import TchapUtils from "~tchap-web/src/tchap/util/TchapUtils.ts";
 import { type TchapIAccessRuleEventContent, TchapRoomAccessRule, TchapRoomAccessRulesEventId, TchapRoomType } from "~tchap-web/src/tchap/@types/tchap.ts";
 import { useTchapRoom } from "~tchap-web/src/tchap/util/TchapRoomHook.ts";
 import { TchapStore } from "~tchap-web/src/tchap/util/TchapStore.ts";
@@ -496,15 +497,14 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             return false;
         }
         // If at least one of the selected member is external, we return true
+        const externalHomeServerDomains = TchapUtils.getExternalHomeServerDomains();
         return members.some(m => {
-            console.log("in doesTargetsContainsExternal member", m)
             // get homeserver
             const userIdArray = m.userId.split(":");
             const hs = userIdArray.pop() || "";
             return m instanceof ThreepidMember
                 || Email.looksValid(m.name)
-                || ["externe.tchap.gouv.fr", "e.tchap.gouv.fr", "ext01.tchap.incubateur.net"].includes(hs);
-
+                || externalHomeServerDomains.includes(hs);
         });
     }
 

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -67,6 +67,28 @@ export default class TchapUtils {
     };
 
     /**
+     * Returns the MXID domain(s) of the "external" homeserver(s) declared in the
+     * runtime config (the homeserver_list entries whose server_name contains
+     * "Externes"). The domain is derived from base_url (stripping the scheme and
+     * the leading "matrix." label) so it stays correct across environments
+     * (prod / preprod / dev) instead of relying on a hardcoded list that can
+     * drift from the deployed config.
+     * @returns {string[]} The external homeserver domains, e.g. ["agent.externe.tchap.gouv.fr"].
+     */
+    static getExternalHomeServerDomains = (): string[] => {
+        const homeServerList = SdkConfig.get()["homeserver_list"] ?? [];
+        return homeServerList
+            .filter((hs) => typeof hs?.server_name === "string" && hs.server_name.includes("Externes"))
+            .map((hs) =>
+                String(hs?.base_url ?? "")
+                    .replace(/^https?:\/\//, "")
+                    .replace(/^matrix\./, "")
+                    .replace(/\/+$/, ""),
+            )
+            .filter(Boolean);
+    };
+
+    /**
      * Find the homeserver corresponding to the given email.
      * @param email Note : if email is invalid, this function still works and returns the externs server. (todo : fix)
      * @returns


### PR DESCRIPTION
# Fix: external-user detection in invite flow misses the production external homeserver

## Summary

`InviteDialog.doesTargetsContainsExternal()` decides whether selected invite
targets include an **external** user. That decision drives the entire
external-invite safeguard introduced in the new invite flow (PR #1565):

- showing the "this room will become **accessible to external users** —
  irreversible" confirmation modal, and
- sending the `m.room.accessRules` → `Unrestricted` state event so the room is
  correctly classified as containing external participants.

The external check used a **hardcoded** domain list:

```js
["externe.tchap.gouv.fr", "e.tchap.gouv.fr", "ext01.tchap.incubateur.net"].includes(hs)
```

This list does **not** contain the production external homeserver domain.
Per `config.prod.json` (and `config.prod.lab.json`) the external homeserver is:

```
"base_url": "https://matrix.agent.externe.tchap.gouv.fr",
"server_name": "Externes"
```

so production external accounts are `@user:agent.externe.tchap.gouv.fr`. The
match is an exact `Array.includes`, and `"agent.externe.tchap.gouv.fr"` is not
in the list (the list has `externe.tchap.gouv.fr` with no `agent.` prefix, plus
the preprod and dev domains).

## Impact

In **production**, inviting an existing external user by Matrix ID / directory
pick (a resolved user — not a `ThreepidMember`, display name is not an email)
into a `Restricted` internal-only room is **not detected as external**.
Consequently:

- the "accessible to external / irreversible" confirmation is never shown, and
- the room's access-rule classification is never updated.

Internal members lose the signal that an external party is present in the room —
the exact internal/external segregation guarantee Tchap is built around.

## Fix

Derive the external homeserver domain(s) from the **runtime config** instead of
a hardcoded list. A new helper `TchapUtils.getExternalHomeServerDomains()`
returns the MXID domain(s) of the `homeserver_list` entries whose `server_name`
contains `"Externes"`, by stripping the scheme and the leading `matrix.` label
from `base_url`.

This stays correct across every environment without code changes:

| env       | base_url                                      | derived domain                |
|-----------|-----------------------------------------------|-------------------------------|
| prod      | `https://matrix.agent.externe.tchap.gouv.fr`  | `agent.externe.tchap.gouv.fr` |
| preprod   | `https://matrix.e.tchap.gouv.fr`              | `e.tchap.gouv.fr`             |
| dev       | `https://matrix.ext01.tchap.incubateur.net`   | `ext01.tchap.incubateur.net`  |

`InviteDialog.doesTargetsContainsExternal()` now uses that helper. The stray
`console.log("in doesTargetsContainsExternal member", m)` (which leaked member
objects to the browser console) was also removed.

## Changes

- `src/tchap/util/TchapUtils.ts` — add `getExternalHomeServerDomains()`.
- `src/components/views/dialogs/InviteDialog.tsx` — use config-derived domains;
  remove debug `console.log`.

---

Nils Putnins / OffSeq Cybersecurity
npu@offseq.com / https://offseq.com / https://radar.offseq.com