### PR TITLE
TCHAP: invalidate client on account expiry

### DIFF
--- a/src/tchap/lib/ExpiredAccountHandler.ts
+++ b/src/tchap/lib/ExpiredAccountHandler.ts
@@ -54,9 +54,25 @@ class ExpiredAccountHandler {
         if (this.isPanelOpen) {
             return;
         }
-        //shutdown all matrix react services, but without unsetting the client
-        stopMatrixClient(false);
-        logger.debug(":tchap: matrix react services have been shutdown");
+
+        // Capture the minimal credentials needed by the account_validity
+        // endpoints (renew-email + expiry re-check) *before* tearing the client
+        // down, so the renewal flow keeps working without a live Matrix client.
+        const cli = MatrixClientPeg.get();
+        if (cli) {
+            TchapUtils.setExpiredAccountCredentials({
+                homeserverUrl: cli.getHomeserverUrl(),
+                accessToken: cli.getAccessToken() ?? "",
+                userId: cli.getUserId() ?? "",
+            });
+        }
+
+        // Fully shut down AND unset the Matrix client (unsetClient=true). This
+        // destroys the in-memory (decrypted) room/crypto store and removes the
+        // client peg, so an expired account can no longer read already-synced
+        // content or reuse the still-authenticated client.
+        stopMatrixClient(true);
+        logger.debug(":tchap: matrix client has been stopped and unset");
 
         //should we sent the email directly? Normally they should have received already an email 7 days earlier
         this.showExpirationPanel();

--- a/src/tchap/util/TchapApi.ts
+++ b/src/tchap/util/TchapApi.ts
@@ -13,6 +13,7 @@ export default {
     //thumbnailParams: "?width=800&height=600&method=scale", not used
     //lookupUrl: "/_matrix/client/unstable/account/3pid/lookup", this endpoint is deleted from the mainlining
     accountValidityResendEmailUrl: "/_matrix/client/unstable/account_validity/send_mail",
+    profileUrl: "/_matrix/client/v3/profile/",
     passwordRulesUrl: "/_matrix/client/r0/password_policy",
     //expiredInfoUrl: "/_matrix/client/r0/user/", not used
 };

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -7,7 +7,6 @@ import { logger } from "matrix-js-sdk/src/logger";
 
 import TchapApi from "./TchapApi";
 import { ClientConfig } from "matrix-js-sdk/src/autodiscovery";
-import { MatrixError } from "matrix-js-sdk/src/http-api";
 
 /**
  * Tchap utils.
@@ -195,22 +194,70 @@ export default class TchapUtils {
     }
 
     /**
+     * Credentials captured at account-expiry time, scoped strictly to the two
+     * account_validity endpoints (renew-email + expiry re-check). They are kept
+     * here so the renewal flow keeps working *after* the authenticated Matrix
+     * client and its in-memory (decrypted) store have been fully torn down by
+     * stopMatrixClient(true) on expiry. See ExpiredAccountHandler.
+     */
+    private static expiredAccountCredentials: {
+        homeserverUrl: string;
+        accessToken: string;
+        userId: string;
+    } | null = null;
+
+    /**
+     * Store (or clear, by passing null) the minimal credentials needed by the
+     * account_validity endpoints once the Matrix client has been torn down.
+     */
+    static setExpiredAccountCredentials(
+        creds: { homeserverUrl: string; accessToken: string; userId: string } | null,
+    ): void {
+        this.expiredAccountCredentials = creds;
+    }
+
+    /**
+     * Resolve the credentials for the account_validity endpoints: prefer the
+     * ones captured at expiry time; otherwise fall back to a still-live client
+     * (e.g. when called outside the expiry flow).
+     */
+    private static getAccountValidityCredentials(): {
+        homeserverUrl: string;
+        accessToken: string;
+        userId: string;
+    } | null {
+        if (this.expiredAccountCredentials) {
+            return this.expiredAccountCredentials;
+        }
+        const client = MatrixClientPeg.get();
+        if (client) {
+            return {
+                homeserverUrl: client.getHomeserverUrl(),
+                accessToken: client.getAccessToken() ?? "",
+                userId: client.getUserId() ?? "",
+            };
+        }
+        return null;
+    }
+
+    /**
      * Request a new validity email for a user account (expired or not).
      * @returns true if the mail was sent succesfully, false otherwise
      */
     static async requestNewExpiredAccountEmail(): Promise<boolean> {
         logger.debug(":tchap: Requesting an email to renew to account");
 
-        // safeGet will throw if client is not initialised. We don't handle it because we don't know when this would happen.
-        const client = MatrixClientPeg.safeGet();
+        const creds = this.getAccountValidityCredentials();
+        if (!creds?.accessToken) {
+            logger.error(":tchap: no credentials available to request a renewal email");
+            return false;
+        }
 
-        const homeserverUrl = client.getHomeserverUrl();
-        const accessToken = client.getAccessToken();
-        const url = `${homeserverUrl}${TchapApi.accountValidityResendEmailUrl}`;
+        const url = `${creds.homeserverUrl}${TchapApi.accountValidityResendEmailUrl}`;
         const options = {
             method: "POST",
             headers: {
-                Authorization: `Bearer ${accessToken}`,
+                Authorization: `Bearer ${creds.accessToken}`,
             },
         };
 
@@ -226,26 +273,32 @@ export default class TchapUtils {
     }
 
     /**
-     * Verify if the currently logged in account is expired.
-     * It executes an API call (to getProfileInfo) and checks whether the call throws a ORG_MATRIX_EXPIRED_ACCOUNT
+     * Verify if the account is expired.
+     * Performs a raw authenticated profile request (no Matrix client / in-memory
+     * store required) and checks for the ORG_MATRIX_EXPIRED_ACCOUNT errcode, so
+     * this still works after the client has been torn down on expiry.
      * @returns true if account is expired, false otherwise
      */
     static async isAccountExpired(): Promise<boolean> {
-        const client = MatrixClientPeg.safeGet();
-        const matrixId: string | null = client.credentials.userId;
-        if (!matrixId) {
+        const creds = this.getAccountValidityCredentials();
+        if (!creds?.userId || !creds.accessToken) {
             // user is not logged in. Or something went wrong.
             return false;
         }
         try {
-            await client.getProfileInfo(matrixId!);
-        } catch (error) {
-            const err = error as MatrixError;
-            if (err.errcode === "ORG_MATRIX_EXPIRED_ACCOUNT") {
-                return true;
+            const response = await fetch(
+                `${creds.homeserverUrl}${TchapApi.profileUrl}${encodeURIComponent(creds.userId)}`,
+                { method: "GET", headers: { Authorization: `Bearer ${creds.accessToken}` } },
+            );
+            if (response.ok) {
+                return false;
             }
+            const body = (await response.json().catch(() => ({}))) as { errcode?: string };
+            return body?.errcode === "ORG_MATRIX_EXPIRED_ACCOUNT";
+        } catch (error) {
+            logger.error(":tchap: isAccountExpired check failed", error);
+            return false;
         }
-        return false;
     }
 
     /**


### PR DESCRIPTION
# Fix: tear down the Matrix client on account expiry instead of keeping it live

## Summary

When the homeserver reports an expired account
(`HttpApiEvent.ORG_MATRIX_EXPIRED_ACCOUNT`, from the
`synapse-email-account-validity` module), `ExpiredAccountHandler` called:

```js
//shutdown all matrix react services, but without unsetting the client
stopMatrixClient(false);
```

With `unsetClient = false`, `Lifecycle.stopMatrixClient()` only stops the sync
loop and React services. It does **not** call `MatrixClientPeg.unset()` or
`cli.store.destroy()`, so after expiry:

- the `MatrixClient` and its **in-memory, already-decrypted** room/crypto store
  stay fully resident and reachable (e.g. `mxMatrixClientPeg.get().getRooms()`),
- the OAuth access token is still valid and still attached to a usable client,

and the only thing enforcing expiry is the non-cancelable `ExpiredAccountDialog`
React overlay.

## Impact

An expired account is meant to be revoked (account-lifecycle / off-boarding).
Because the session is only "paused" and never invalidated client-side, an
expired user can, in the still-open tab:

- read the entire already-synced **decrypted** message store with no further
  server calls, and
- reuse the live authenticated client / token against any endpoint the
  server-side account-validity module does not gate.

The control is effectively cosmetic. **Confidentiality** of already-synced
content is the primary impact.

## Why it wasn't simply `stopMatrixClient(true)`

The renewal flow legitimately needs an authenticated call *after* expiry:

- `TchapUtils.requestNewExpiredAccountEmail()` — POST `account_validity/send_mail`
- `TchapUtils.isAccountExpired()` — re-check used by `onBeforeClose`

Both used `MatrixClientPeg.safeGet()`, which throws once the client is unset.
That coupling is why the client was kept alive — and why the hole existed.

## Fix

Decouple the renewal flow from the live client, then tear the client down
properly:

1. `ExpiredAccountHandler.onExpiredAccountError()` now captures the **minimal**
   credentials (`homeserverUrl`, `accessToken`, `userId`) *before* teardown via
   `TchapUtils.setExpiredAccountCredentials(...)`, then calls
   `stopMatrixClient(true)` — which unsets the peg and destroys the in-memory
   (decrypted) room/crypto store.
2. `requestNewExpiredAccountEmail()` and `isAccountExpired()` no longer touch the
   Matrix client. They use the captured credentials and raw `fetch`:
   - `isAccountExpired()` now does an authenticated GET on the profile endpoint
     and checks the `ORG_MATRIX_EXPIRED_ACCOUNT` errcode (same signal the old
     `getProfileInfo()` relied on), so it works with no client/store.
   - A fallback to a still-live client is kept for any call outside the expiry
     flow (behaviour unchanged there).
3. On successful renewal the existing `PlatformPeg.get().reload()` rebuilds a
   fresh client from the stored session, so the user experience is unchanged.

### Residual risk (intentional / out of scope)

This does **not** clear the persisted session (localStorage/IndexedDB) or revoke
the token server-side — doing so would force a full re-login after every renewal
and is the server's responsibility (the account-validity module). The token is
still held transiently in JS memory while the expiry dialog is open, scoped to
the two `account_validity` endpoints, and discarded on reload. The concrete
improvements are: the resident **decrypted** message/crypto store is destroyed,
the live client and `mxMatrixClientPeg` access are removed, and credential
exposure is reduced to an ephemeral, endpoint-scoped token.

## Changes

- `src/tchap/lib/ExpiredAccountHandler.ts` — capture creds before teardown;
  `stopMatrixClient(false)` → `stopMatrixClient(true)`.
- `src/tchap/util/TchapUtils.ts` — credential holder + setter/getter; rewrite
  `requestNewExpiredAccountEmail()` / `isAccountExpired()` to be client-free;
  drop now-unused `MatrixError` import.
- `src/tchap/util/TchapApi.ts` — add `profileUrl` constant.

## Testing

- [ ] Trigger account expiry: dialog appears; `mxMatrixClientPeg.get()` is now
      null and `getRooms()`/decrypted timelines are no longer reachable.
- [ ] "Request new email" from the expired dialog still sends the renewal mail.
- [ ] After renewing the account, the dialog closes and the app reloads into a
      working, logged-in session.
- [ ] Non-expired account: normal operation unaffected (fallback path).

---

Nils Putnins / OffSeq Cybersecurity
npu@offseq.com / https://offseq.com / https://radar.offseq.com
