### PR TITLE
rename im.vector.room.access_rules.encrypted to im.vector.room.access_rules.force_unencrypted_at_creation

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -619,7 +619,11 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             cli.sendStateEvent(
                 room.roomId,
                 TchapRoomAccessRulesEventId,
-                { rule: TchapRoomAccessRule.Unrestricted, visibility: this.tchapAccessRule?.visibility },
+                { 
+                rule: TchapRoomAccessRule.Unrestricted, 
+                visibility: this.tchapAccessRule?.visibility,
+                force_unencrypted_at_creation: this.tchapAccessRule?.force_unencrypted_at_creation
+                },
                 ""
             );
         }

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -619,7 +619,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             cli.sendStateEvent(
                 room.roomId,
                 TchapRoomAccessRulesEventId,
-                { rule: TchapRoomAccessRule.Unrestricted, encrypted: this.tchapAccessRule?.encrypted, visibility: this.tchapAccessRule?.visibility },
+                { rule: TchapRoomAccessRule.Unrestricted, visibility: this.tchapAccessRule?.visibility },
                 ""
             );
         }

--- a/src/tchap/@types/tchap.ts
+++ b/src/tchap/@types/tchap.ts
@@ -20,7 +20,7 @@ export enum TchapRoomAccessRuleVisibility {
 
 export interface TchapIAccessRuleEventContent {
     rule: TchapRoomAccessRule; // eslint-disable-line camelcase
-    encrypted?: boolean | undefined;
+    force_unencrypted_at_creation?: boolean | undefined;
     visibility?: TchapRoomAccessRuleVisibility | undefined
 }
 

--- a/src/tchap/lib/createTchapRoom.ts
+++ b/src/tchap/lib/createTchapRoom.ts
@@ -115,7 +115,7 @@ export default class TchapCreateRoom {
                 createRoomOpts.initial_state.push({
                     content: {
                         rule: TchapRoomAccessRule.Restricted,
-                        encrypted: false
+                        force_unencrypted_at_creation: true
                     },
                     type: TchapRoomAccessRulesEventId,
                     state_key: "",

--- a/src/tchap/util/TchapRoomUtils.ts
+++ b/src/tchap/util/TchapRoomUtils.ts
@@ -23,8 +23,8 @@ export default class TchapRoomUtils {
         const isEncrypted: boolean = await this.isRoomEncrypted(room.roomId);
         // need to have visibility private or public to know if it is a forum or not
         if (!isEncrypted) {
-            // Should be explicitly encrypted to false, private room does not have this value if the backend is not compatible or the data not well updated
-            if (tchapRoomAccessRule?.encrypted == false && tchapRoomAccessRule.visibility == TchapRoomAccessRuleVisibility.Private) {
+            // Should be explicitly force_unencrypted_at_creation to true, private room does not have this value if the backend is not compatible or the data not well updated
+            if (tchapRoomAccessRule?.force_unencrypted_at_creation == true && tchapRoomAccessRule.visibility == TchapRoomAccessRuleVisibility.Private) {
                 if (tchapRoomAccessRule?.rule == TchapRoomAccessRule.Unrestricted) {
                     return TchapRoomType.PrivateNonEncryptedExternal;
                 }

--- a/test/unit-tests/tchap/lib/createTchapRoom-test.ts
+++ b/test/unit-tests/tchap/lib/createTchapRoom-test.ts
@@ -104,7 +104,7 @@ describe("Create room options", () => {
                     {
                         content: {
                             rule: "restricted",
-                            encrypted: false,
+                            force_unencrypted_at_creation: true,
                         },
                         state_key: "",
                         type: "im.vector.room.access_rules",

--- a/test/unit-tests/tchap/util/TchapRoomUtils-test.ts
+++ b/test/unit-tests/tchap/util/TchapRoomUtils-test.ts
@@ -21,11 +21,11 @@ describe("Provides utils method to get room type and state", () => {
         jest.spyOn(client, "getRoomDirectoryVisibility").mockResolvedValue({ visibility: Visibility.Private });
         jest.spyOn(cryptoApi, "isEncryptionEnabledInRoom").mockResolvedValue(true);
         const resultRestricted = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Restricted},
+            { rule: TchapRoomAccessRule.Restricted },
             room,
         );
         const resultUnRestricted = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Unrestricted},
+            { rule: TchapRoomAccessRule.Unrestricted },
             room,
         );
         expect(resultRestricted).toStrictEqual(TchapRoomType.Private);
@@ -65,20 +65,14 @@ describe("Provides utils method to get room type and state", () => {
     it("returns room type Forum for room without encryption and visibility public", async () => {
         jest.spyOn(client, "getRoomDirectoryVisibility").mockResolvedValue({ visibility: Visibility.Public });
         jest.spyOn(cryptoApi, "isEncryptionEnabledInRoom").mockResolvedValue(false);
-        const result = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Restricted},
-            room,
-        );
+        const result = await TchapRoomUtils.getTchapRoomTypeInternal({ rule: TchapRoomAccessRule.Restricted }, room);
         expect(result).toStrictEqual(TchapRoomType.Forum);
     });
 
     it("returns room type External for room with encryption and unrestricted access rule", async () => {
         jest.spyOn(client, "getRoomDirectoryVisibility").mockResolvedValue({ visibility: Visibility.Private });
         jest.spyOn(cryptoApi, "isEncryptionEnabledInRoom").mockResolvedValue(true);
-        const result = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Unrestricted},
-            room,
-        );
+        const result = await TchapRoomUtils.getTchapRoomTypeInternal({ rule: TchapRoomAccessRule.Unrestricted }, room);
         expect(result).toStrictEqual(TchapRoomType.External);
     });
 });

--- a/test/unit-tests/tchap/util/TchapRoomUtils-test.ts
+++ b/test/unit-tests/tchap/util/TchapRoomUtils-test.ts
@@ -21,11 +21,11 @@ describe("Provides utils method to get room type and state", () => {
         jest.spyOn(client, "getRoomDirectoryVisibility").mockResolvedValue({ visibility: Visibility.Private });
         jest.spyOn(cryptoApi, "isEncryptionEnabledInRoom").mockResolvedValue(true);
         const resultRestricted = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Restricted, encrypted: undefined },
+            { rule: TchapRoomAccessRule.Restricted},
             room,
         );
         const resultUnRestricted = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Unrestricted, encrypted: undefined },
+            { rule: TchapRoomAccessRule.Unrestricted},
             room,
         );
         expect(resultRestricted).toStrictEqual(TchapRoomType.Private);
@@ -39,7 +39,7 @@ describe("Provides utils method to get room type and state", () => {
         const result = await TchapRoomUtils.getTchapRoomTypeInternal(
             {
                 rule: TchapRoomAccessRule.Unrestricted,
-                encrypted: false,
+                force_unencrypted_at_creation: true,
                 visibility: TchapRoomAccessRuleVisibility.Private,
             },
             room,
@@ -54,7 +54,7 @@ describe("Provides utils method to get room type and state", () => {
         const result = await TchapRoomUtils.getTchapRoomTypeInternal(
             {
                 rule: TchapRoomAccessRule.Restricted,
-                encrypted: false,
+                force_unencrypted_at_creation: true,
                 visibility: TchapRoomAccessRuleVisibility.Private,
             },
             room,
@@ -66,7 +66,7 @@ describe("Provides utils method to get room type and state", () => {
         jest.spyOn(client, "getRoomDirectoryVisibility").mockResolvedValue({ visibility: Visibility.Public });
         jest.spyOn(cryptoApi, "isEncryptionEnabledInRoom").mockResolvedValue(false);
         const result = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Restricted, encrypted: undefined },
+            { rule: TchapRoomAccessRule.Restricted},
             room,
         );
         expect(result).toStrictEqual(TchapRoomType.Forum);
@@ -76,7 +76,7 @@ describe("Provides utils method to get room type and state", () => {
         jest.spyOn(client, "getRoomDirectoryVisibility").mockResolvedValue({ visibility: Visibility.Private });
         jest.spyOn(cryptoApi, "isEncryptionEnabledInRoom").mockResolvedValue(true);
         const result = await TchapRoomUtils.getTchapRoomTypeInternal(
-            { rule: TchapRoomAccessRule.Unrestricted, encrypted: undefined },
+            { rule: TchapRoomAccessRule.Unrestricted},
             room,
         );
         expect(result).toStrictEqual(TchapRoomType.External);


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
