### PR TITLE
TCHAP: update flow more robust external invite

### DIFF
--- a/modules/tchap-translations/tchap_translations.json
+++ b/modules/tchap-translations/tchap_translations.json
@@ -1151,7 +1151,7 @@
     },
     "invite|external_not_allowed": {
         "en": "You do not have permission to add external people from the public sector in this room.",
-        "fr": "Vous n'avez pas la permission d'inviter des personnes externes aux secteur publique dans ce salon."
+        "fr": "Vous n'avez pas la permission d'inviter des personnes externes au secteur public dans ce salon."
     },
     "invite|irreversible": {
         "en": "This modification is final and not reversible.",

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -988,10 +988,18 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
         // :TCHAP: check if it is an external user
         this.doesTargetsContainsExternal(toAdd).then(containAnExternal => {
-            this.setState({
-                ...this.state, shouldDisplayExternalWarning: containAnExternal,
-                shouldDisableInviteButton: this.checkDisableInviteButton(containAnExternal)
-            })
+            if (unableToAddMore) {
+                this.setState({
+                    filterText: unableToAddMore.join(" "),
+                    targets: uniqBy([...this.state.targets, ...toAdd], (t) => t.userId),
+                    shouldDisableInviteButton: this.checkDisableInviteButton(containAnExternal)
+                });
+            } else {
+                this.setState({
+                    targets: uniqBy([...this.state.targets, ...toAdd], (t) => t.userId),
+                    shouldDisableInviteButton: this.checkDisableInviteButton(containAnExternal)
+                });
+            }
         });
         // end :TCHAP:
 

--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -68,8 +68,8 @@ import InviteProgressBody from "./InviteProgressBody.tsx";
 
 import TchapRoomUtils from "~tchap-web/src/tchap/util/TchapRoomUtils.ts";
 import { type TchapIAccessRuleEventContent, TchapRoomAccessRule, TchapRoomAccessRulesEventId, TchapRoomType } from "~tchap-web/src/tchap/@types/tchap.ts";
-import { useTchapRoom } from "~tchap-web/src/tchap/util/TchapRoomHook.ts";
 import { TchapStore } from "~tchap-web/src/tchap/util/TchapStore.ts";
+import TchapUtils from "~tchap-web/src/tchap/util/TchapUtils.ts";
 
 // we have a number of types defined from the Matrix spec which can't reasonably be altered here.
 /* eslint-disable camelcase */
@@ -265,6 +265,7 @@ interface IInviteDialogState {
 
     // :TCHAP:
     shouldDisplayExternalWarning?: boolean;
+    shouldDisableInviteButton?: boolean;
     tchapRoomType?: TchapRoomType;
     // end :TCHAP
 }
@@ -334,6 +335,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
             // :TCHAP:
             shouldDisplayExternalWarning: false,
+            shouldDisableInviteButton: false,
             tchapRoomType: undefined
             // end :TCHAP
         };
@@ -483,40 +485,19 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
         const newTargets = [...(this.state.targets || []), newMember];
         // :TCHAP: check if it is an external user
-        const containAnExternal = this.doesTargetsContainsExternal(newTargets);
+        this.doesTargetsContainsExternal(newTargets).then(containAnExternal => {
+            console.log("doesTargetsContainsExternal", containAnExternal);
+            this.setState({
+                targets: newTargets,
+                filterText: "",
+                shouldDisplayExternalWarning: containAnExternal,
+                shouldDisableInviteButton: this.checkDisableInviteButton(containAnExternal)
+            })
+        });
         // end :TCHAP:
 
-        this.setState({ targets: newTargets, filterText: "", shouldDisplayExternalWarning: containAnExternal && this.canInviteExternalMembers()});
+        this.setState({ targets: newTargets, filterText: ""});
         return newTargets;
-    }
-
-    private doesTargetsContainsExternal(members: Member[]) : boolean {
-        // if the room is already open to external users, don't need to show warning
-        if (this.tchapAccessRule?.rule === TchapRoomAccessRule.Unrestricted) {
-            return false;
-        }
-        // If at least one of the selected member is external, we return true
-        return members.some(m => {
-            console.log("in doesTargetsContainsExternal member", m)
-            // get homeserver
-            const userIdArray = m.userId.split(":");
-            const hs = userIdArray.pop() || "";
-            return m instanceof ThreepidMember
-                || Email.looksValid(m.name)
-                || ["externe.tchap.gouv.fr", "e.tchap.gouv.fr", "ext01.tchap.incubateur.net"].includes(hs);
-
-        });
-    }
-
-    private canInviteExternalMembers(): boolean {
-        if (this.props.kind === InviteKind.Invite) {
-            const cli = MatrixClientPeg.safeGet();
-            const room = cli.getRoom(this.props.roomId);
-            // user has the right or no to update the external access_rule state event
-            const canUpdateExternalStateEvent = room?.getLiveTimeline()?.getState(EventTimeline.FORWARDS)?.mayClientSendStateEvent(TchapRoomAccessRulesEventId, cli);
-            return this.state.tchapRoomType !== TchapRoomType.Forum && !!canUpdateExternalStateEvent;
-        }
-        return false
     }
 
     /**
@@ -581,7 +562,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
         const targets = this.convertFilter();
         // :TCHAP: check again, not sure state already propagated properly at this time
-        const containAnExternal = this.doesTargetsContainsExternal(targets);
+        const containAnExternal = await this.doesTargetsContainsExternal(targets);
         // end :TCHAP:
         const targetIds = targets.map((t) => t.userId);
 
@@ -598,7 +579,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
 
         // :TCHAP:
 
-        if (this.state.shouldDisplayExternalWarning || (containAnExternal && this.canInviteExternalMembers())) {
+        if (this.state.shouldDisplayExternalWarning || (containAnExternal)) {
             // Before continuing we should alert the user that this is irreversible action
             const { finished } = Modal.createDialog(QuestionDialog, {
                 title: _t("badge|external_guests"),
@@ -616,16 +597,39 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 });
                 return;
             };
-            cli.sendStateEvent(
-                room.roomId,
-                TchapRoomAccessRulesEventId,
-                { 
-                rule: TchapRoomAccessRule.Unrestricted, 
-                visibility: this.tchapAccessRule?.visibility,
-                force_unencrypted_at_creation: this.tchapAccessRule?.force_unencrypted_at_creation
-                },
-                ""
-            );
+            try {
+                await cli.sendStateEvent(
+                    room.roomId,
+                    TchapRoomAccessRulesEventId,
+                    {
+                    rule: TchapRoomAccessRule.Unrestricted,
+                    visibility: this.tchapAccessRule?.visibility,
+                    force_unencrypted_at_creation: this.tchapAccessRule?.force_unencrypted_at_creation
+                    },
+                    ""
+                );
+                const result = await inviteMultipleToRoom(cli, this.props.roomId, targetIds, {
+                    // We show our own progress body, so don't pop up a separate dialog.
+                    inhibitProgressDialog: true,
+                });
+                if (!this.shouldAbortAfterInviteError(result, room)) {
+                    // handles setting error message too
+                    this.props.onFinished(true);
+                }
+            } catch (err) {
+                logger.error(err);
+                // an error occured, we need to go back to original state
+                this.setState({
+                    busy: false,
+                    errorText: _t("invite|error_invite"),
+                });
+                cli.sendStateEvent(
+                    room.roomId,
+                    TchapRoomAccessRulesEventId,
+                    { rule: TchapRoomAccessRule.Restricted, encrypted: this.tchapAccessRule?.force_unencrypted_at_creation, visibility: this.tchapAccessRule?.visibility },
+                    "")
+            }
+            return;
         }
         // end :TCHAP:
         try {
@@ -643,15 +647,6 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 busy: false,
                 errorText: _t("invite|error_invite"),
             });
-            // an error occured, we need to go back to original state
-            if (this.state.shouldDisplayExternalWarning) {
-                cli.sendStateEvent(
-                room.roomId,
-                TchapRoomAccessRulesEventId,
-                { rule: TchapRoomAccessRule.Restricted, encrypted: this.tchapAccessRule?.encrypted, visibility: this.tchapAccessRule?.visibility },
-                ""
-            );
-            }
         }
     };
 
@@ -858,10 +853,18 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
                 targets.push(member);
                 filterText = ""; // clear the filter when the user accepts a suggestion
             }
-            //
+
             // :TCHAP: this.setState({ targets, filterText });
-            const shouldDisplayExternalWarning = this.doesTargetsContainsExternal(targets) && this.canInviteExternalMembers();
-            this.setState({ targets, filterText, shouldDisplayExternalWarning });
+            // Using promise to not modify original function
+            this.doesTargetsContainsExternal(targets).then(containsExternal => {
+                this.setState({
+                    targets,
+                    filterText,
+                    shouldDisplayExternalWarning: containsExternal,
+                    shouldDisableInviteButton: this.checkDisableInviteButton(containsExternal)
+                });
+            })
+            this.setState({ targets, filterText });
             // end :TCHAP:
 
             if (this.editorRef && this.editorRef.current) {
@@ -876,8 +879,13 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         if (idx >= 0) {
             targets.splice(idx, 1);
             // :TCHAP: this.setState({ targets });
-            const shouldDisplayExternalWarning = this.doesTargetsContainsExternal(targets) && this.canInviteExternalMembers();
-            this.setState({ targets, shouldDisplayExternalWarning });
+            this.doesTargetsContainsExternal(targets).then(containsExternal => {
+                this.setState({
+                    targets, shouldDisplayExternalWarning: containsExternal,
+                    shouldDisableInviteButton: this.checkDisableInviteButton(containsExternal)
+                })
+            })
+            this.setState({ targets });
             // end :TCHAP:
         }
 
@@ -979,23 +987,22 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         }
 
         // :TCHAP: check if it is an external user
-        const containAnExternal = this.doesTargetsContainsExternal(toAdd);
+        this.doesTargetsContainsExternal(toAdd).then(containAnExternal => {
+            this.setState({
+                ...this.state, shouldDisplayExternalWarning: containAnExternal,
+                shouldDisableInviteButton: this.checkDisableInviteButton(containAnExternal)
+            })
+        });
         // end :TCHAP:
 
         if (unableToAddMore) {
             this.setState({
                 filterText: unableToAddMore.join(" "),
-                targets: uniqBy([...this.state.targets, ...toAdd], (t) => t.userId),
-                // :TCHAP:
-                shouldDisplayExternalWarning: containAnExternal && this.canInviteExternalMembers()
-                // end :TCHAP:
+                targets: uniqBy([...this.state.targets, ...toAdd], (t) => t.userId)
             });
         } else {
             this.setState({
-                targets: uniqBy([...this.state.targets, ...toAdd], (t) => t.userId),
-                // :TCHAP:
-                shouldDisplayExternalWarning: containAnExternal && this.canInviteExternalMembers()
-                // end :TCHAP:
+                targets: uniqBy([...this.state.targets, ...toAdd], (t) => t.userId)
             });
         }
     };
@@ -1020,6 +1027,7 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         if (this.state.tchapRoomType !== TchapRoomType.External
             && this.state.tchapRoomType !== TchapRoomType.PrivateNonEncryptedExternal
             && this.state.shouldDisplayExternalWarning
+            && this.canInviteExternalMembers()
             // if it is a DM we don't show the warning
             && this.props.kind !== InviteKind.Dm) {
             return (
@@ -1031,9 +1039,11 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         return null;
     }
 
+    // This warning should be displayed when  user cant invite in the room
+    // And that the list of invitees contain at least an external
     private renderWarningCantInviteExternal(): ReactNode {
         if (!this.canInviteExternalMembers()
-            && this.doesTargetsContainsExternal(this.state.targets)
+            && this.state.shouldDisplayExternalWarning
             // if it is a DM we don't show the warning
             && this.props.kind !== InviteKind.Dm
         )
@@ -1044,6 +1054,39 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
         )
         return null
     }
+
+
+    private checkDisableInviteButton(containsExternal: boolean): boolean {
+        return this.props.kind == InviteKind.Invite && !this.canInviteExternalMembers() && containsExternal;
+    }
+
+    private async doesTargetsContainsExternal(members: Member[]) : Promise<boolean> {
+        // if the room is already open to external users, don't need to show warning
+        if (this.tchapAccessRule?.rule === TchapRoomAccessRule.Unrestricted) {
+            return false;
+        }
+        // If at least one of the selected member is external, we return true
+        for (const m of members) {
+            // For email targets, validate against identity server
+            if (Email.looksValid(m.name)) {
+                const isExternal = await TchapUtils.checkIfEmailIsExternal(m.name);
+                return isExternal;
+            }
+        }
+        return false;
+    }
+
+    private canInviteExternalMembers(): boolean {
+        if (this.props.kind === InviteKind.Invite) {
+            const cli = MatrixClientPeg.safeGet();
+            const room = cli.getRoom(this.props.roomId);
+            // user has the right or no to update the external access_rule state event
+            const canUpdateExternalStateEvent = room?.getLiveTimeline()?.getState(EventTimeline.FORWARDS)?.mayClientSendStateEvent(TchapRoomAccessRulesEventId, cli);
+            return this.state.tchapRoomType !== TchapRoomType.Forum && !!canUpdateExternalStateEvent;
+        }
+        return false
+    }
+
     // end :TCHAP:
 
     private renderSection(kind: "recents" | "suggestions"): ReactNode {
@@ -1477,16 +1520,13 @@ export default class InviteDialog extends React.PureComponent<Props, IInviteDial
             goButtonFn = this.inviteUsers;
         }
 
-        // :TCHAP: dont disable invite button if its external and DM
-        const externalDisableInvite = this.props.kind == InviteKind.Invite && !this.canInviteExternalMembers() && this.doesTargetsContainsExternal(this.state.targets)
-
         const goButton =
             this.props.kind == InviteKind.CallTransfer ? null : (
                 <AccessibleButton
                     kind="primary"
                     onClick={goButtonFn}
                     className="mx_InviteDialog_goButton"
-                    disabled={this.state.busy || !this.hasSelection() || externalDisableInvite}
+                    disabled={this.state.busy || !this.hasSelection() || this.state.shouldDisableInviteButton}
                 >
                     {buttonText}
                 </AccessibleButton>

--- a/src/tchap/util/TchapRoomHook.ts
+++ b/src/tchap/util/TchapRoomHook.ts
@@ -27,13 +27,12 @@ export const useTchapRoom = (room: Room | undefined ) => {
             if (!room) {
                 return currentRoomType;
             }
-            console.log("*** in event emitter tchap room hook updating room", room.roomId);
             const result = await TchapStore.instance.getRoomType(room);
             // if nothing change, dont need to update
             if (result != currentRoomType) {
                 setCurrentType(result);
             }
-            
+
             return result;
         } catch (err) {
             console.error("TCHAP: Error getting tchap type", err);

--- a/src/tchap/util/TchapRoomUtils.ts
+++ b/src/tchap/util/TchapRoomUtils.ts
@@ -14,8 +14,6 @@ export default class TchapRoomUtils {
     //direct type is not handled yet
     static getTchapRoomType(room: Room): Promise<TchapRoomType> {
         const tchapAccessRule = this.getTchapRoomAccessRule(room);
-        console.log("*** tchapAccessRule", tchapAccessRule);
-        console.log("*** tchapAccessRule room", room.roomId);
         return this.getTchapRoomTypeInternal(tchapAccessRule, room);
     }
 
@@ -63,8 +61,8 @@ export default class TchapRoomUtils {
 
     /**
      * Get if current is admin of the room
-     * @param room 
-     * @returns 
+     * @param room
+     * @returns
      */
     static isUserAdmin(room: Room) : boolean {
         const userId = room.client.getSafeUserId();

--- a/src/tchap/util/TchapUtils.ts
+++ b/src/tchap/util/TchapUtils.ts
@@ -103,6 +103,30 @@ export default class TchapUtils {
     };
 
     /**
+     * Check if a server name is the external server.
+     * @param serverName The server name to check (e.g., "externes" or "Externes")
+     * @returns true if the server is the external server, false otherwise
+     */
+    static isExternalHomeserver(serverName: string): boolean {
+        return /\bexternes\b/i.test(serverName);
+    }
+
+    /**
+     * Check if an email belongs to an external homeserver by fetching its homeserver information.
+     * This is an async operation that queries the identity server.
+     * @param email The email address to check
+     * @returns true if the email belongs to an external homeserver, false otherwise
+     */
+    static async checkIfEmailIsExternal(email: string): Promise<boolean> {
+        const homeserver = await this.fetchHomeserverForEmail(email);
+        console.log("*** checkIfEmailIsExternal", homeserver);
+        if (!homeserver || !homeserver.server_name) {
+            return false;
+        }
+        return this.isExternalHomeserver(homeserver.server_name);
+    }
+
+    /**
      * Make a ValidatedServerConfig from the server urls.
      * Todo : merge this function with fetchHomeserverForEmail, they are always used together anyway.
      * @param

--- a/test/unit-tests/tchap/components/views/dialogs/InviteDialog-test.tsx
+++ b/test/unit-tests/tchap/components/views/dialogs/InviteDialog-test.tsx
@@ -16,6 +16,10 @@ import Modal from "~tchap-web/src/Modal";
 import { filterConsole, flushPromises, getMockClientWithEventEmitter } from "~tchap-web/test/test-utils";
 import { TchapStore } from "~tchap-web/src/tchap/util/TchapStore";
 import { TchapRoomType } from "~tchap-web/src/tchap/@types/tchap";
+import TchapUtils from "~tchap-web/src/tchap/util/TchapUtils";
+
+// Mock TchapUtils to control checkIfEmailIsExternal in tests
+jest.mock("~tchap-web/src/tchap/util/TchapUtils");
 
 const getSearchField = () => screen.getByTestId("invite-dialog-input");
 
@@ -111,6 +115,9 @@ describe("InviteDialog", () => {
         mockClient.getIdentityServerUrl.mockReturnValue("https://identity-server");
         mockClient.lookupThreePid.mockResolvedValue({});
         SdkContextClass.instance.client = mockClient;
+
+        // Default: emails are not external
+        (TchapUtils.checkIfEmailIsExternal as jest.Mock).mockResolvedValue(false);
     });
 
     afterEach(() => {
@@ -205,6 +212,9 @@ describe("InviteDialog", () => {
     });
 
     it("should display external warning when a user email is selected in private room", async () => {
+        // Mock checkIfEmailIsExternal to return true for external emails
+        (TchapUtils.checkIfEmailIsExternal as jest.Mock).mockResolvedValue(true);
+
         jest.spyOn(TchapStore.instance, "getRoomType").mockImplementation(async (room) => {
             return TchapRoomType.Private;
         });
@@ -215,12 +225,17 @@ describe("InviteDialog", () => {
 
         // Paste an external email
         await pasteIntoSearchField(externalEmail);
+        await flushPromises();
+
         await waitFor(() => {
             expect(screen.getByTestId("tc_warning")).toMatchSnapshot();
         });
     });
 
     it("should not display external warning when room is already open to external users", async () => {
+        // Mock checkIfEmailIsExternal to return true for external emails
+        (TchapUtils.checkIfEmailIsExternal as jest.Mock).mockResolvedValue(true);
+
         jest.spyOn(TchapStore.instance, "getRoomType").mockImplementation(async (room) => {
             return TchapRoomType.External;
         });
@@ -231,13 +246,17 @@ describe("InviteDialog", () => {
 
         // Juste paste some values without enter
         await pasteIntoSearchField(externalEmail);
+        await flushPromises();
 
-        waitFor(() => {
-            expect(screen.getByTestId("tc_warning")).toBeUndefined();
+        await waitFor(() => {
+            expect(screen.queryByTestId("tc_warning")).not.toBeInTheDocument();
         });
     });
 
     it("should warn when room is public so not possible to add external", async () => {
+        // Mock checkIfEmailIsExternal to return true for external emails
+        (TchapUtils.checkIfEmailIsExternal as jest.Mock).mockResolvedValue(true);
+
         jest.spyOn(TchapStore.instance, "getRoomType").mockImplementation(async (room) => {
             return TchapRoomType.Forum;
         });
@@ -249,13 +268,17 @@ describe("InviteDialog", () => {
 
         // Juste paste some values without enter
         await pasteIntoSearchField(externalEmail);
+        await flushPromises();
 
-        waitFor(() => {
+        await waitFor(() => {
             expect(screen.getByTestId("tc_warning")).toMatchSnapshot();
         });
     });
 
     it("should invite button be disable when user doesnt have permission to change to external room", async () => {
+        // Mock checkIfEmailIsExternal to return true for external emails
+        (TchapUtils.checkIfEmailIsExternal as jest.Mock).mockResolvedValue(true);
+
         jest.spyOn(TchapStore.instance, "getRoomType").mockImplementation(async (room) => {
             return TchapRoomType.Private;
         });
@@ -269,13 +292,17 @@ describe("InviteDialog", () => {
 
         // Juste paste some values without enter
         await pasteIntoSearchField(externalEmail);
+        await flushPromises();
 
-        waitFor(() => {
-            expect(screen.getByRole("button", { name: "Invite" })).toBeDisabled();
+        await waitFor(() => {
+            expect(screen.getByRole("button", { name: "Invite" })).toHaveAttribute("aria-disabled", "true");
         });
     });
 
     it("should not show any warning if the invitedialog type is DM", async () => {
+        // Mock checkIfEmailIsExternal to return true for external emails
+        (TchapUtils.checkIfEmailIsExternal as jest.Mock).mockResolvedValue(true);
+
         jest.spyOn(TchapStore.instance, "getRoomType").mockImplementation(async (room) => {
             return TchapRoomType.Private;
         });
@@ -287,9 +314,10 @@ describe("InviteDialog", () => {
 
         // Juste paste some values without enter
         await pasteIntoSearchField(externalEmail);
+        await flushPromises();
 
-        waitFor(() => {
-            expect(screen.getByTestId("tc_warning")).toBeUndefined();
+        await waitFor(() => {
+            expect(screen.queryByTestId("tc_warning")).not.toBeInTheDocument();
         });
     });
 });


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-web-v4/issues/1607

## Changes
first version of this new flow was not robuste. It is not relying on email fetch from correct homeserver, and flaky error when room change state occured before invite

## Testing cases 
- Private room with admin privilege, should disaplay warning when adding external user from :
      - suggestion (existing external user)
      - copy paste email
      - writing the full email in the text box 
- Private room already open to external should not display any warning
- Entering e full email of internal agents should not trigger warning
- Public room should disable button 
- With non admin privilege button should be disabled when trying to add an external