### PR TITLE
Fix tchap version in preview app

### DIFF
--- a/.github/workflows/tchap_build.yml
+++ b/.github/workflows/tchap_build.yml
@@ -35,7 +35,9 @@ jobs:
 
             - name: Build
               working-directory: apps/web
-              run: "pnpm build"
+              env:
+                  CI_PACKAGE: true
+              run: "VERSION=$(scripts/get-version-from-git.sh) pnpm run build"
 
             - name: Upload build in artifact
               uses: actions/upload-artifact@v4


### PR DESCRIPTION
Before

<img width="657" height="283" alt="image" src="https://github.com/user-attachments/assets/673601e9-c697-47a6-a92e-2c9cadd135e4" />

After

<img width="660" height="223" alt="image" src="https://github.com/user-attachments/assets/36dcd1bd-636a-491a-b1af-1d777458244a" />


<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
