### PR TITLE
fix: prefetch blob after scanning

### DIFF
--- a/apps/web/src/tchap/content-scanner/ContentScannerMediaHelper.ts
+++ b/apps/web/src/tchap/content-scanner/ContentScannerMediaHelper.ts
@@ -87,6 +87,14 @@ export class ContentScannerMediaHelper implements IDestroyable {
                 this.media.scanThumbnail(),
             ]);
             this.scanState = sourceClean && thumbnailClean ? "done" : "unsafe";
+
+            // workaround: when users click on image, image preview is not available because, 
+            // sourceBlob has no value yet
+            // pre-fetch sourceBlob and thumbnailBlob if scanning is sucessful            
+            if (this.scanState === "done") {
+                await this.sourceBlob.value;
+                await this.thumbnailBlob.value;
+            }
         } catch (error) {
             logger.warn("ContentScannerMediaHelper: scan error:", error);
             this.scanState = "error";

--- a/apps/web/src/tchap/content-scanner/ContentScannerMediaHelper.ts
+++ b/apps/web/src/tchap/content-scanner/ContentScannerMediaHelper.ts
@@ -88,9 +88,9 @@ export class ContentScannerMediaHelper implements IDestroyable {
             ]);
             this.scanState = sourceClean && thumbnailClean ? "done" : "unsafe";
 
-            // workaround: when users click on image, image preview is not available because, 
+            // workaround: when users click on image, image preview is not available because,
             // sourceBlob has no value yet
-            // pre-fetch sourceBlob and thumbnailBlob if scanning is sucessful            
+            // pre-fetch sourceBlob and thumbnailBlob if scanning is sucessful
             if (this.scanState === "done") {
                 await this.sourceBlob.value;
                 await this.thumbnailBlob.value;


### PR DESCRIPTION
issue #1637 

Issue : when users click on image, `this.props.mediaEventHelper.sourceBlob.cachedValue`  returns no value, then the condition is true
 https://github.com/tchapgouv/tchap-web-v4/blob/eec33c6511b78d5e5bd96ee165773a36a98042c6/apps/web/src/components/views/messages/MImageBody.tsx#L111
Therefore a thumbnail is used whereas some image event have no thumbnail. It results in no opening any image preview open for users.

This PR fix this issue by fetching the blob after scanning to get the mimetype.

## Checklist

- [ ] I have read through [review guidelines](https://github.com/element-hq/element-web/blob/develop/docs/review.md) and [CONTRIBUTING.md](https://github.com/element-hq/element-web/blob/develop/CONTRIBUTING.md).
- [ ] Tests written for new code (and old code if feasible).
- [ ] New or updated `public`/`exported` symbols have accurate [TSDoc](https://tsdoc.org/) documentation.
- [ ] Linter and other CI checks pass.
- [ ] I have licensed the changes to Element by completing the [Contributor License Agreement (CLA)](https://cla-assistant.io/element-hq/element-web)
