### PR TITLE
TCHAP(content-scanner): fix preview sourceurl and thumburl initialization

### DIFF
--- a/apps/web/src/components/views/messages/MBodyFactory.tsx
+++ b/apps/web/src/components/views/messages/MBodyFactory.tsx
@@ -111,12 +111,13 @@ export function VideoBodyFactory({
 
     const content = mxEvent.getContent<MediaEventContent>();
     scanningMediaHelper.onScanStateChange(() => {
-        if (scanState !== scanningMediaHelper.getScanState()) {
-            setScanState(scanningMediaHelper.getScanState())
+        const newScanState = scanningMediaHelper.getScanState();
+        if (scanState !== newScanState) {
+            setScanState(newScanState)
         }
     });
     //  end :TCHAP:
-    //
+
     const vm = useCreateAutoDisposedViewModel(
         () =>
             new VideoBodyViewModel({

--- a/apps/web/src/tchap/content-scanner/ContentScannerMediaHelper.ts
+++ b/apps/web/src/tchap/content-scanner/ContentScannerMediaHelper.ts
@@ -28,8 +28,8 @@ export class ContentScannerMediaHelper implements IDestroyable {
         this.media = this.inner.media as unknown as Media;
 
         // Proxy URLs directly - no scan needed to display previews
-        this.sourceUrl = this.inner.sourceUrl;
-        this.thumbnailUrl = this.inner.thumbnailUrl;
+        this.sourceUrl = new LazyValue(this.prepareSourceUrl);
+        this.thumbnailUrl = new LazyValue(this.prepareThumbnailUrl);
 
         // Guard blob access behind scan gate
         this.sourceBlob = new LazyValue(async () => {
@@ -46,6 +46,27 @@ export class ContentScannerMediaHelper implements IDestroyable {
 
         void this.startScan();
     }
+
+    // Taken from initial Media Helper
+    private prepareSourceUrl = async (): Promise<string | null> => {
+        if (this.media.isEncrypted) {
+            const blob = await this.sourceBlob.value;
+            return URL.createObjectURL(blob);
+        } else {
+            return this.media.srcHttp;
+        }
+    };
+
+    // Taken from initial Media Helper
+    private prepareThumbnailUrl = async (): Promise<string | null> => {
+        if (this.media.isEncrypted) {
+            const blob = await this.thumbnailBlob.value;
+            if (blob === null) return null;
+            return URL.createObjectURL(blob);
+        } else {
+            return this.media.thumbnailHttp;
+        }
+    };
 
     public get fileName(): string {
         return this.inner.fileName;
@@ -73,10 +94,23 @@ export class ContentScannerMediaHelper implements IDestroyable {
     private waitForScan(): Promise<void> {
         if (this.scanState !== "scanning") return Promise.resolve();
         return new Promise((resolve) => {
+            let completed = false;
+
             const unsubscribe = this.onScanStateChange(() => {
+                if (completed) return;
+                completed = true;
                 unsubscribe();
                 resolve();
             });
+
+            // Double-check in case state changed while registering
+            if (this.scanState !== "scanning") {
+                if (!completed) {
+                    completed = true;
+                    unsubscribe();
+                    resolve();
+                }
+            }
         });
     }
 
@@ -87,14 +121,6 @@ export class ContentScannerMediaHelper implements IDestroyable {
                 this.media.scanThumbnail(),
             ]);
             this.scanState = sourceClean && thumbnailClean ? "done" : "unsafe";
-
-            // workaround: when users click on image, image preview is not available because,
-            // sourceBlob has no value yet
-            // pre-fetch sourceBlob and thumbnailBlob if scanning is sucessful
-            if (this.scanState === "done") {
-                await this.sourceBlob.value;
-                await this.thumbnailBlob.value;
-            }
         } catch (error) {
             logger.warn("ContentScannerMediaHelper: scan error:", error);
             this.scanState = "error";

--- a/apps/web/src/tchap/customisations/components/views/messages/ContentScanningImageBody.tsx
+++ b/apps/web/src/tchap/customisations/components/views/messages/ContentScanningImageBody.tsx
@@ -27,7 +27,7 @@ import OriginalImageBody from "../../../../components/views/messages/OriginalIma
 import { Media } from "../../../ContentScanningMedia";
 import { BlockedIcon } from "../../../../components/views/elements/BlockedIcon";
 import { ContentScanningStatus } from "../../../../components/views/elements/ContentScanningStatus";
-import { ScanState } from "~tchap-web/src/tchap/content-scanner/ContentScannerMediaHelper";
+import { ContentScannerMediaHelper, ScanState } from "~tchap-web/src/tchap/content-scanner/ContentScannerMediaHelper";
 
 interface State {
     scanState: ScanState;

--- a/apps/web/src/viewmodels/room/EventTileActionBarViewModel.ts
+++ b/apps/web/src/viewmodels/room/EventTileActionBarViewModel.ts
@@ -246,7 +246,7 @@ export class EventTileActionBarViewModel
         // const mediaHelper = MediaEventHelper.isEligible(mxEvent) ? new MediaEventHelper(mxEvent) : undefined;
 
         // :TCHAP: content-scanner
-        const mediaHelper = scannerMediaHelper ?? (MediaEventHelper.isEligible(mxEvent) ? new MediaEventHelper(mxEvent) : undefined);
+        const mediaHelper = scannerMediaHelper ?? (MediaEventHelper.isEligible(mxEvent) ? new ContentScannerMediaHelper(mxEvent) : undefined);
         // end :TCHAP:
         return {
             showDownload: contentActionable && Boolean(mediaHelper) && localState.canDownload,

--- a/packages/shared-components/src/room/timeline/event-tile/actions/ActionBarView/ActionBarView.tsx
+++ b/packages/shared-components/src/room/timeline/event-tile/actions/ActionBarView/ActionBarView.tsx
@@ -145,7 +145,9 @@ export function ActionBarView({ vm, className }: Readonly<ActionBarViewProps>): 
         isDownloadLoading,
         isPinned,
         isQuoteExpanded,
+        // :TCHAP:
         downloadScanState
+        // end :TCHAP:
     } = useViewModel(vm);
 
     // Track the live button element for each action and keep the callback refs stable

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24459,7 +24459,7 @@ snapshots:
 
   vitest-sonar-reporter@3.0.0(vitest@4.1.2):
     dependencies:
-      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(jsdom@26.1.0(patch_hash=040623e87b1c8b676c2a705513c0276c0704dd1b23fc3a1bb77cde8128b64b5f))(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.12))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(jsdom@26.1.0(patch_hash=040623e87b1c8b676c2a705513c0276c0704dd1b23fc3a1bb77cde8128b64b5f))(vite@8.0.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@22.19.19)(esbuild@0.27.4)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.12))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3))
 
   vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(@vitest/browser-playwright@4.1.2)(jsdom@26.1.0(patch_hash=040623e87b1c8b676c2a705513c0276c0704dd1b23fc3a1bb77cde8128b64b5f))(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.12))(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:


### PR DESCRIPTION
Fix issue https://github.com/tchapgouv/tchap-web-v4/issues/1637, which as a temporary workariund from this PR https://github.com/tchapgouv/tchap-web-v4/pull/1644

The problem of the first fix was that it was loading everytime the mouse pass by a file. (`Eventtileactionbarview` was called and underlyng mediahelper reloading the file). Consequently, there was a glitch where the loading button would appear and disappear