### PR TITLE
TCHAP(search): improve search info box

### DIFF
--- a/apps/web/modules/tchap-translations/tchap_translations.json
+++ b/apps/web/modules/tchap-translations/tchap_translations.json
@@ -1168,5 +1168,9 @@
     "room|intro|private_unencrypted_warning": {
         "en": "This room is unencrypted and only accessible by invitation. Avoid sharing sensitive data.",
         "fr": "Ce salon non chiffré est accessible uniquement sur invitation. Évitez d’y partager des informations sensibles."
+    },
+    "search|summary|warning": {
+        "en": "It is possible that your messages were not cached yet hence not accessible for search. <a> Learn more </a>",
+        "fr": "Il est possible que vos messages n'aient pas encore été mis en cache et soient donc inaccessibles par la recherche. <a> En savoir plus </a>"
     }
 }

--- a/apps/web/res/css/_components.pcss
+++ b/apps/web/res/css/_components.pcss
@@ -113,6 +113,7 @@
 @import "./tchap/views/rooms/_ContentScanningFileBody.pcss";
 @import "./tchap/views/rooms/_ContentScanningImageBody.pcss";
 @import "./tchap/views/rooms/_ContentScanningVideoBody.pcss";
+@import "./tchap/views/rooms/_RoomSearchAuxPanel.pcss";
 @import "./tchap/views/rooms/_TchapExportMembersButton.pcss";
 @import "./tchap/views/sso/_TchapSSO.pcss";
 @import "./views/audio_messages/_PlayPauseButton.pcss";

--- a/apps/web/res/css/tchap/views/rooms/_RoomSearchAuxPanel.pcss
+++ b/apps/web/res/css/tchap/views/rooms/_RoomSearchAuxPanel.pcss
@@ -1,0 +1,20 @@
+.tc_search_warning {
+    background-color: var(--badge-external-color);
+    padding: var(--cpd-space-3x);
+    border-radius: 8px;
+    margin-left: 9px;
+    margin-right: 9px;
+    display: flex;
+    align-items: center;
+    gap: var(--cpd-space-2x);
+    color: var(--badge-external-text-color);
+
+    svg {
+        color: var(--external-color);
+    }
+
+    a {
+        color: var(--badge-external-text-color);
+        font-weight: bold;
+    }
+}

--- a/apps/web/src/components/views/elements/SearchWarning.tsx
+++ b/apps/web/src/components/views/elements/SearchWarning.tsx
@@ -17,6 +17,8 @@ import { Action } from "../../../dispatcher/actions";
 import { UserTab } from "../dialogs/UserTab";
 import AccessibleButton, { type ButtonEvent } from "./AccessibleButton";
 
+import TchapUrls from "~tchap-web/src/tchap/util/TchapUrls";
+
 export enum WarningKind {
     Files,
     Search,
@@ -30,7 +32,7 @@ interface IProps {
 
 export default function SearchWarning({ isRoomEncrypted, kind, showLogo = true }: IProps): JSX.Element {
     if (!isRoomEncrypted) return <></>;
-    if (EventIndexPeg.get()) return <></>;
+    // :TCHAP: search-no-results-warning- if (EventIndexPeg.get()) return <></>;
 
     if (EventIndexPeg.error) {
         return (
@@ -46,7 +48,8 @@ export default function SearchWarning({ isRoomEncrypted, kind, showLogo = true }
                                     evt.preventDefault();
                                     dis.dispatch({
                                         action: Action.ViewUserSettings,
-                                        initialTabId: UserTab.Security,
+                                        // :TCHAP: initialTabId: UserTab.Security,
+                                        initialTabId: UserTab.Encryption,
                                     });
                                 }}
                             >
@@ -58,6 +61,24 @@ export default function SearchWarning({ isRoomEncrypted, kind, showLogo = true }
             </div>
         );
     }
+
+    // :TCHAP: search-no-results-warning we don't display usage warning if it is web build
+    if (EventIndexPeg.get()) {
+        console.log("*** in search warning")
+        return _t("search|summary|warning", null, {
+            a: (sub: string) => (
+                <a
+                    href={TchapUrls.helpSearchMessage}
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    aria-label={`${sub} (opens in new tab)`}
+                >
+                    {sub}
+                </a>
+            ),
+        })
+    }
+    // end :TCHAP:
 
     const brand = SdkConfig.get("brand");
     const desktopBuilds = SdkConfig.getObject("desktop_builds");

--- a/apps/web/src/components/views/rooms/RoomSearchAuxPanel.tsx
+++ b/apps/web/src/components/views/rooms/RoomSearchAuxPanel.tsx
@@ -10,6 +10,7 @@ import React from "react";
 import SearchIcon from "@vector-im/compound-design-tokens/assets/web/icons/search";
 import CloseIcon from "@vector-im/compound-design-tokens/assets/web/icons/close";
 import { IconButton, Link } from "@vector-im/compound-web";
+import { WarningIcon } from "@vector-im/compound-design-tokens/assets/web/icons";
 
 import { _t } from "../../../languageHandler";
 import { PosthogScreenTracker } from "../../../PosthogTrackers";
@@ -23,6 +24,25 @@ interface Props {
     onSearchScopeChange(this: void, scope: SearchScope): void;
     onCancelClick(this: void): void;
 }
+
+// :TCHAP: search-no-results-warning
+const displayTchapWarning = (
+    searchInfo: SearchInfo | undefined,
+    isRoomEncrypted: boolean,
+): React.ReactElement | undefined => {
+
+    if ((searchInfo?.count === undefined || searchInfo?.count === 0) && isRoomEncrypted) {
+        console.log("*** should display tchap warning search")
+        return (
+            <div className="tc_search_warning" data-testid="tchap-search-warning-box">
+                <WarningIcon width="24px" height="24px" />
+                <SearchWarning kind={WarningKind.Search} isRoomEncrypted={isRoomEncrypted} showLogo={false} />
+            </div>
+        );
+    }
+    return;
+};
+// end :TCHAP:
 
 const RoomSearchAuxPanel: React.FC<Props> = ({ searchInfo, isRoomEncrypted, onSearchScopeChange, onCancelClick }) => {
     const scope = searchInfo?.scope ?? SearchScope.Room;
@@ -45,7 +65,9 @@ const RoomSearchAuxPanel: React.FC<Props> = ({ searchInfo, isRoomEncrypted, onSe
                         ) : (
                             <InlineSpinner />
                         )}
-                        <SearchWarning kind={WarningKind.Search} isRoomEncrypted={isRoomEncrypted} showLogo={false} />
+                        {/* :TCHAP */}
+                        {/* <SearchWarning kind={WarningKind.Search} isRoomEncrypted={isRoomEncrypted} showLogo={false} />*/}
+                        {/* end :TCHAP */}
                     </div>
                 </div>
                 <div className="mx_RoomSearchAuxPanel_buttons">
@@ -69,6 +91,9 @@ const RoomSearchAuxPanel: React.FC<Props> = ({ searchInfo, isRoomEncrypted, onSe
                     </IconButton>
                 </div>
             </div>
+            {/*:TCHAP search-no-results-warning */}
+            {displayTchapWarning(searchInfo, isRoomEncrypted)}
+            {/* end :TCHAP: */}
         </>
     );
 };

--- a/apps/web/src/tchap/util/TchapUrls.ts
+++ b/apps/web/src/tchap/util/TchapUrls.ts
@@ -47,6 +47,8 @@ export default class TchapUrls {
 
     public static helpCreateRoom = `${TchapUrls.helpBaseUrl}/fr/article/comment-creer-un-salon-web-11abmcr/`;
 
+    public static helpSearchMessage = `${TchapUrls.helpBaseUrl}/fr/article/tchap-windows-recherche-dans-un-salon-prive-6s153i/`;
+
     public static openHelper = (uri: string) => {
         const platform = PlatformPeg.get();
         if (platform) {

--- a/apps/web/test/unit-tests/tchap/components/views/elements/SearchWarning-test.tsx
+++ b/apps/web/test/unit-tests/tchap/components/views/elements/SearchWarning-test.tsx
@@ -1,0 +1,37 @@
+import { render } from "jest-matrix-react";
+import React from "react";
+
+import SdkConfig from "~tchap-web/src/SdkConfig";
+import SearchWarning, { WarningKind } from "~tchap-web/src/components/views/elements/SearchWarning";
+
+describe("<SearchWarning />", () => {
+    describe("with desktop builds available", () => {
+        beforeEach(() => {
+            SdkConfig.put({
+                brand: "Element",
+                desktop_builds: {
+                    available: true,
+                    logo: "https://logo",
+                    url: "https://url",
+                },
+            });
+        });
+
+        it("renders with a logo by default", () => {
+            const { asFragment, getByRole } = render(
+                <SearchWarning isRoomEncrypted={true} kind={WarningKind.Search} />,
+            );
+            expect(getByRole("presentation")).toHaveAttribute("src", "https://logo");
+            expect(asFragment()).toMatchSnapshot();
+        });
+
+        it("renders without a logo when showLogo=false", () => {
+            const { asFragment, queryByRole } = render(
+                <SearchWarning isRoomEncrypted={true} kind={WarningKind.Search} showLogo={false} />,
+            );
+
+            expect(queryByRole("img")).not.toBeInTheDocument();
+            expect(asFragment()).toMatchSnapshot();
+        });
+    });
+});

--- a/apps/web/test/unit-tests/tchap/components/views/elements/__snapshots__/SearchWarning-test.tsx.snap
+++ b/apps/web/test/unit-tests/tchap/components/views/elements/__snapshots__/SearchWarning-test.tsx.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`<SearchWarning /> with desktop builds available renders with a logo by default 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_SearchWarning"
+  >
+    <img
+      alt=""
+      src="https://logo"
+      width="32px"
+    />
+    <span>
+      <span>
+        Use the 
+        <a
+          href="https://url"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          Desktop app
+        </a>
+         to search encrypted messages
+      </span>
+    </span>
+  </div>
+</DocumentFragment>
+`;
+
+exports[`<SearchWarning /> with desktop builds available renders without a logo when showLogo=false 1`] = `
+<DocumentFragment>
+  <div
+    class="mx_SearchWarning"
+  >
+    <span>
+      <span>
+        Use the 
+        <a
+          href="https://url"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          Desktop app
+        </a>
+         to search encrypted messages
+      </span>
+    </span>
+  </div>
+</DocumentFragment>
+`;

--- a/apps/web/test/unit-tests/tchap/components/views/rooms/RoomSearchAuxPanel-test.tsx
+++ b/apps/web/test/unit-tests/tchap/components/views/rooms/RoomSearchAuxPanel-test.tsx
@@ -1,0 +1,116 @@
+import React from "react";
+import { render, screen } from "jest-matrix-react";
+
+import RoomSearchAuxPanel from "~tchap-web/src/components/views/rooms/RoomSearchAuxPanel";
+import { SearchScope } from "~tchap-web/src/Searching";
+
+describe("RoomSearchAuxPanel", () => {
+    it("should render the count of results", () => {
+        render(
+            <RoomSearchAuxPanel
+                searchInfo={{
+                    searchId: 1234,
+                    count: 5,
+                    term: "abcd",
+                    scope: SearchScope.Room,
+                    promise: new Promise(() => {}),
+                }}
+                isRoomEncrypted={false}
+                onSearchScopeChange={jest.fn()}
+                onCancelClick={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText("5 results found for", { exact: false })).toHaveTextContent(
+            "5 results found for “abcd”",
+        );
+    });
+
+    it("should allow the user to toggle to all rooms search", async () => {
+        const onSearchScopeChange = jest.fn();
+
+        render(
+            <RoomSearchAuxPanel
+                isRoomEncrypted={false}
+                onSearchScopeChange={onSearchScopeChange}
+                onCancelClick={jest.fn()}
+            />,
+        );
+
+        screen.getByText("Search all rooms").click();
+        expect(onSearchScopeChange).toHaveBeenCalledWith(SearchScope.All);
+    });
+
+    it("should allow the user to toggle back to room-specific search", async () => {
+        const onSearchScopeChange = jest.fn();
+
+        render(
+            <RoomSearchAuxPanel
+                searchInfo={{
+                    searchId: 1234,
+                    term: "abcd",
+                    scope: SearchScope.All,
+                    promise: new Promise(() => {}),
+                }}
+                isRoomEncrypted={false}
+                onSearchScopeChange={onSearchScopeChange}
+                onCancelClick={jest.fn()}
+            />,
+        );
+
+        screen.getByText("Search this room").click();
+        expect(onSearchScopeChange).toHaveBeenCalledWith(SearchScope.Room);
+    });
+
+    it("should allow the user to cancel a search", async () => {
+        const onCancelClick = jest.fn();
+
+        render(
+            <RoomSearchAuxPanel
+                isRoomEncrypted={false}
+                onSearchScopeChange={jest.fn()}
+                onCancelClick={onCancelClick}
+            />,
+        );
+
+        screen.getByRole("button", { name: "Cancel" }).click();
+        expect(onCancelClick).toHaveBeenCalled();
+    });
+
+    it("should display warning when search returns no results in encrypted room", () => {
+        render(
+            <RoomSearchAuxPanel
+                searchInfo={{
+                    searchId: 1234,
+                    count: 0,
+                    term: "abcd",
+                    scope: SearchScope.Room,
+                    promise: new Promise(() => {}),
+                }}
+                isRoomEncrypted={true}
+                onSearchScopeChange={jest.fn()}
+                onCancelClick={jest.fn()}
+            />,
+        );
+        expect(screen.getByTestId("tchap-search-warning-box")).toBeInTheDocument();
+    });
+
+    it("should not display warning when search returns results in non encrypted room", async () => {
+        render(
+            <RoomSearchAuxPanel
+                searchInfo={{
+                    searchId: 1234,
+                    count: 5,
+                    term: "abcd",
+                    scope: SearchScope.Room,
+                    promise: new Promise(() => {}),
+                }}
+                isRoomEncrypted={false}
+                onSearchScopeChange={jest.fn()}
+                onCancelClick={jest.fn()}
+            />,
+        );
+
+        await expect(screen.findAllByTestId("tchap-search-warning-box")).rejects.toThrow();
+    });
+});

--- a/patches_tchap/tchap-modifications.json
+++ b/patches_tchap/tchap-modifications.json
@@ -256,5 +256,12 @@
     "remove-mxid-onpill": {
         "issue": "https://github.com/tchapgouv/tchap-web-v4/issues/1560",
         "files": ["src/autocomplete/UserProvider.tsx"]
+    },
+    "search-no-results-warning": {
+        "issue": "https://github.com/tchapgouv/tchap-desktop/issues/226",
+        "files": [
+            "src/components/views/rooms/RoomSearchAuxPanel.tsx",
+            "src/components/views/elements/SearchWarning.tsx"
+        ]
     }
 }


### PR DESCRIPTION
closes https://github.com/tchapgouv/tchap-desktop/issues/226
closes https://github.com/tchapgouv/tchap-design/issues/76

## Changes 
Web search on encrypted room
<img width="1137" height="231" alt="image" src="https://github.com/user-attachments/assets/8983f04f-7a58-403d-b7fd-bde51a171290" />

Desktop search with indexor error 
<img width="1102" height="185" alt="image" src="https://github.com/user-attachments/assets/835057bd-e81d-4c2c-95b1-caa42a34ed00" />

Desktop search with no result
<img width="1134" height="239" alt="image" src="https://github.com/user-attachments/assets/998a5e26-e349-4656-9234-a23f461d0e87" />

- The translation missing space "0Résultat" was correcting on Element localazy translations
